### PR TITLE
Wait to get the initial csrf request until dom load.

### DIFF
--- a/browserid/static/dialog/resources/browserid-network.js
+++ b/browserid/static/dialog/resources/browserid-network.js
@@ -209,7 +209,9 @@ var BrowserIDNetwork = (function() {
     }
   };
 
-  Network.csrf();
+  $(function() {
+    Network.csrf();
+  });
   return Network;
 
   function filterOrigin(origin) {


### PR DESCRIPTION
This keeps steal.build from trying to include 'csrf' as a file that needs compressed.
