### PR TITLE
Fixing withCSRF to correctly get the CSRF token.

### DIFF
--- a/browserid/static/js/browserid.js
+++ b/browserid/static/js/browserid.js
@@ -43,11 +43,10 @@ var csrf = undefined;
 // execute a function with a csrf token, fetching it if required
 function withCSRF(cb) {
   if (csrf === undefined) {
-    $.get("/wsapi/csrf", function(result) {
-      alert(result);
-      csrf = result.body;
+    $.get("/wsapi/csrf", {}, function(result) {
+      csrf = result;
       cb();
-    });
+    }, 'html');
   } else {
     setTimeout(cb, 0);
   }


### PR DESCRIPTION
The request was assuming XML, which caused jQuery to blow its top since the response was not valid XML.  If we set the response to HTML, we can set the CSRF token directly from the response, without using response.body.

issue #177
