### PR TITLE
No need to JSON.stringify the emails list.

### DIFF
--- a/browserid/static/dialog/resources/browserid-network.js
+++ b/browserid/static/dialog/resources/browserid-network.js
@@ -168,7 +168,7 @@ var BrowserIDNetwork = (function() {
         type: "POST",
         url: '/wsapi/sync_emails',
         data: {
-          emails: JSON.stringify(issued_identities),
+          emails: issued_identities,
           csrf: BrowserIDNetwork.csrf_token
         },
         success: function(resp, textStatus, jqXHR) {


### PR DESCRIPTION
This fixes #175 and #176.  All we had to do was remove the extra JSON.stringify.
