### PR TITLE
Ensure req.body exists before trying to use it.

### DIFF
--- a/verifier/app.js
+++ b/verifier/app.js
@@ -39,13 +39,14 @@ const   path = require('path'),
    httputils = require('./lib/httputils.js'),
  idassertion = require('./lib/idassertion.js'),
          jwt = require('./lib/jwt.js'),
-     express = require('express');
+     express = require('express'),
      metrics = require('../libs/metrics.js'),
      logger = require('../libs/logging.js').logger;
 
 logger.info("verifier server starting up");
 
 function doVerify(req, resp, next) {
+  req.body = req.body || {}
   var assertion = (req.query && req.query.assertion) ? req.query.assertion : req.body.assertion;
   var audience = (req.query && req.query.audience) ? req.query.audience : req.body.audience;
 


### PR DESCRIPTION
I spent the latter half of yesterday learning a painful lesson: express.bodyParser() will not parse a request body unless the content-type is 'application/x-www-form-urlencoded'. It won't even set req.body to an empty dict, it leaves it undefined.

I suppose it's my own fault for neglecting to set this header when making my requests, but this was causing browserid.org/verify to consistently give me 500s.

This, at the very least, will make it so the verifier doesn't 500 on malformed requests.
