### PR TITLE
Change the csrf response type to 'html'.

### DIFF
--- a/browserid/static/dialog/resources/browserid-network.js
+++ b/browserid/static/dialog/resources/browserid-network.js
@@ -45,7 +45,7 @@ var BrowserIDNetwork = (function() {
       $.get('/wsapi/csrf', {}, function(result) {
         csrf_token = result;
         cb();
-      });
+      }, 'html');
     }
   }
 


### PR DESCRIPTION
This makes sure that the non-XML response is parsed correctly and jQuery does not throw an error.
