### PR TITLE
Setting up Vagrant for BrowserID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ This repository contains several distinct things related to BrowserID:
   * **the browserid.org website** - the templates, css, and javascript that make up the visible part of browserid.org
   * **the javascript/HTML dialog & include library** - this is include.js and the code that it includes, the bit that someone using browserid will include.
 
+## Quick Start Virtual Machine
+
+We've prepared a VM so you can test/hack/have fun with BrowserID without modifying your local computer (too much). Skip to the next section "Dependencies", for detailed instructions to install this codebase locally, instead of using Vagrant.
+
+1. Install [Vagrant](http://vagrantup.com/docs/getting-started/index.html).
+
+This does add ruby, ruby-gems, and VirtualBox to your local desktop computer. No other software 
+or changes will be made.
+
+2. Boot up the VM:
+
+    $ cd browserid
+    $ vagrant up
+    $ vagrant ssh
+    vagrant@lucid32:browserid$ node ./run.js
+
+`vagrant up` will take a while. Go get a cup of coffee. This is because it downloads the 500MB VM.
+
+You can now browse to http://localhost:10001 and http://localhost:10002.
+
+Any changes to the source code on your local computer are immediately mirrored in the VM.
+
+Handy for dev and QA tasks, but if you want to install from scratch...
+
 ## Dependencies
 
 Here's the software you'll need installed:
@@ -20,6 +44,7 @@ Here's the software you'll need installed:
 * npm: http://npmjs.org/
 * Several node.js 3rd party libraries - see `package.json` for details
 * browserify which will be installed globally.
+* git, g++
 
 ## Getting started:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+Vagrant::Config.run do |config|
+
+    config.vm.box = "lucid32_2.box"
+    config.vm.box_url = "http://people.mozilla.org/~aking/browserid/lucid32_2.box"
+
+    #                      name      vagrant  desktop
+    config.vm.forward_port("readme",   10000, 10000)
+    config.vm.forward_port("verifier", 10001, 10001)
+    config.vm.forward_port("server",   10002, 10002)
+
+
+
+    # Increase vagrant's patience during hang-y CentOS bootup
+    # see: https://github.com/jedi4ever/veewee/issues/14
+    config.ssh.max_tries = 50
+    config.ssh.timeout   = 300
+
+    # nfs needs to be explicitly enabled to run.
+
+    config.vm.share_folder("v-root", "/home/vagrant/browserid", ".")
+
+    # Add to /etc/hosts: 33.33.33.27 dev.browserid.org
+    config.vm.network "33.33.33.27"
+
+end


### PR DESCRIPTION
TLDR; This PR adds a Vagrant VM for quick dev setup. Please try it out.

Details:
Vagrant provides cheap and easy ways to run a repo in a VM that has all dependencies pre-installed.

The VM runs locally. Vagrant sets up ssh and other port forwarding.

You can work against your local filesystem with the tools you already use. Changes are mirrored in the VM.

The first time you load a VM, it takes a long time. Subsequent restarts are fast, until someone cuts a new VM.

This is a boon for developers, QA, and community who do not have to install dependencies, nor clutter their local desktop.

Vagrant crash course:
vagrant up -- boots the VM
vagrant ssh -- drops you into shell
vagrant halt -- opposite of vagrant up
vagrant destroy -- vagrant halt and then remove locally cached VM

BrowserID specific - In our .bashrc we set IP_ADDRESS=0.0.0.0 so that node will listen for external traffic (instead of localhost).
