### PR TITLE
Fix broken URL for the reference validator

### DIFF
--- a/browserid/views/developers.ejs
+++ b/browserid/views/developers.ejs
@@ -82,7 +82,7 @@
           server.  While a bit more complicated you can reduce your
           dependencies on others.  Refer
           to <a href="https://wiki.mozilla.org/Identity/Verified_Email_Protocol">the
-          specification</a> and the <a href="https://github.com/mozilla/browserid/tree/master/verifier">source for the reference
+          specification</a> and the <a href="https://github.com/mozilla/browserid/tree/dev/verifier">source for the reference
           validator</a>.
         </p>
       </li>


### PR DESCRIPTION
Looks like the master branch got renamed to dev at some point.
