### PR TITLE
Don't break when a client machine has a system clocks that is off by more than 2 minutes

### DIFF
--- a/browserid/lib/wsapi.js
+++ b/browserid/lib/wsapi.js
@@ -115,7 +115,7 @@ function checkAuthed(req, resp, next) {
 }
 
 function setup(app) {
-  // return the CSRF token and current server time (for assertion signing)
+  // return the CSRF token, authentication status, and current server time (for assertion signing)
   // IMPORTANT: this is safe because it's only readable by same-origin code
   app.get('/wsapi/session_context', function(req, res) {
     if (typeof req.session == 'undefined') {
@@ -129,12 +129,34 @@ function setup(app) {
       logger.debug("NEW csrf token created: " + req.session.csrf);
     }
 
-    res.write(JSON.stringify({
-      csrf_token: req.session.csrf,
-      server_time: (new Date()).getTime()
-    }));
+    var auth_status = false;
 
-    res.end();
+    function sendResponse() {
+      res.write(JSON.stringify({
+        csrf_token: req.session.csrf,
+        server_time: (new Date()).getTime(),
+        authenticated: auth_status
+      }));
+      res.end();
+    };
+
+    // if they're authenticated for an email address that we don't know about,
+    // then we should purge the stored cookie
+    if (!isAuthed(req)) {
+      logger.debug("user is not authenticated");
+      sendResponse();
+    } else {
+      db.emailKnown(req.session.authenticatedUser, function (known) {
+        if (!known) {
+          logger.debug("user is authenticated with an email that doesn't exist in the database");
+          clearAuthenticatedUser(req.session);
+        } else {
+          logger.debug("user is authenticated");
+          auth_status = true;
+        }
+        sendResponse();
+      });
+    }
   });
 
   /* checks to see if an email address is known to the server
@@ -272,7 +294,6 @@ function setup(app) {
           setAuthenticatedUser(req.session, req.body.email);
 
           // if the work factor has changed, update the hash here
-          
         }
         resp.json(success);
       });
@@ -333,30 +354,11 @@ function setup(app) {
       var expiration = new Date();
       expiration.setTime(new Date().valueOf() + configuration.get('certificate_validity_ms'));
       var cert = ca.certify(req.body.email, pk, expiration);
-      
+
       resp.writeHead(200, {'Content-Type': 'text/plain'});
       resp.write(cert);
       resp.end();
     });
-  });
-
-  app.get('/wsapi/am_authed', function(req,resp) {
-    // if they're authenticated for an email address that we don't know about,
-    // then we should purge the stored cookie
-    if (!isAuthed(req)) {
-      logger.debug("user is not authenticated");
-      resp.json(false);
-    } else {
-      db.emailKnown(req.session.authenticatedUser, function (known) {
-        if (!known) {
-          logger.debug("user is authenticated with an email that doesn't exist in the database");
-          clearAuthenticatedUser(req.session);
-        } else {
-          logger.debug("user is authenticated");
-        }
-        resp.json(known);
-      });
-    }
   });
 
   app.post('/wsapi/logout', function(req, resp) {

--- a/browserid/lib/wsapi.js
+++ b/browserid/lib/wsapi.js
@@ -115,11 +115,9 @@ function checkAuthed(req, resp, next) {
 }
 
 function setup(app) {
-  // return the CSRF token
-  // IMPORTANT: this should be safe because it's only readable by same-origin code
-  // but we must be careful that this is never a JSON structure that could be hijacked
-  // by a third party
-  app.get('/wsapi/csrf', function(req, res) {
+  // return the CSRF token and current server time (for assertion signing)
+  // IMPORTANT: this is safe because it's only readable by same-origin code
+  app.get('/wsapi/session_context', function(req, res) {
     if (typeof req.session == 'undefined') {
       req.session = {};
     }
@@ -131,10 +129,13 @@ function setup(app) {
       logger.debug("NEW csrf token created: " + req.session.csrf);
     }
 
-    res.write(req.session.csrf);
+    res.write(JSON.stringify({
+      csrf_token: req.session.csrf,
+      server_time: (new Date()).getTime()
+    }));
+
     res.end();
   });
-
 
   /* checks to see if an email address is known to the server
    * takes 'email' as a GET argument */

--- a/browserid/static/dialog/resources/browserid-identities.js
+++ b/browserid/static/dialog/resources/browserid-identities.js
@@ -383,7 +383,6 @@ var BrowserIDIdentities = (function() {
       // we use the current time from the browserid servers
       // to avoid issues with clock drift on user's machine.
       network.serverTime(function(serverTime) {
-        alert("server time: " + serverTime.toString() + " local time: " + (new Date()).toString());
         var storedID = Identities.getStoredIdentities()[email],
         assertion;
 

--- a/browserid/static/dialog/resources/browserid-identities.js
+++ b/browserid/static/dialog/resources/browserid-identities.js
@@ -380,21 +380,25 @@ var BrowserIDIdentities = (function() {
      * @param {function} [onFailure] - Called on failure.
      */
     getIdentityAssertion: function(email, onSuccess, onFailure) {
-      var storedID = Identities.getStoredIdentities()[email],
-          assertion;
+      // we use the current time from the browserid servers
+      // to avoid issues with clock drift on user's machine.
+      network.serverTime(function(serverTime) {
+        alert("server time: " + serverTime.toString() + " local time: " + (new Date()).toString());
+        var storedID = Identities.getStoredIdentities()[email],
+        assertion;
 
-      if (storedID) {
-        // parse the secret key
-        prepareDeps();
-        var sk = jwk.SecretKey.fromSimpleObject(storedID.priv);
-        var tok = new jwt.JWT(null, new Date(), network.origin);
-        assertion = vep.bundleCertsAndAssertion([storedID.cert], tok.sign(sk));
-      }
+        if (storedID) {
+          // parse the secret key
+          prepareDeps();
+          var sk = jwk.SecretKey.fromSimpleObject(storedID.priv);
+          var tok = new jwt.JWT(null, serverTime, network.origin);
+          assertion = vep.bundleCertsAndAssertion([storedID.cert], tok.sign(sk));
+        }
 
-      if (onSuccess) {
-        onSuccess(assertion);
-      }
-
+        if (onSuccess) {
+          onSuccess(assertion);
+        }
+      }, onFailure);
     },
 
     /**

--- a/browserid/static/dialog/resources/browserid-network.js
+++ b/browserid/static/dialog/resources/browserid-network.js
@@ -42,7 +42,7 @@ var BrowserIDNetwork = (function() {
   var auth_status;
 
   function withContext(cb) {
-    if (typeof auth_status !== 'boolean' && csrf_token !== undefined) setTimeout(cb, 0);
+    if (typeof auth_status === 'boolean' && csrf_token !== undefined) setTimeout(cb, 0);
     else {
       $.get('/wsapi/session_context', {}, function(result) {
         csrf_token = result.csrf_token;
@@ -139,9 +139,13 @@ var BrowserIDNetwork = (function() {
       withContext(function() {
         $.post("/wsapi/logout", {
           csrf: csrf_token
-        }, function() {
-          csrf_token = undefined;
-          auth_status = undefined;
+        }, function(result) {
+          // assume the logout request is successful and
+          // log the user out.  There is no need to reset the
+          // CSRF token.
+          // FIXME: we should return a confirmation that the
+          // user was successfully logged out.
+          auth_status = false;
           withContext(function() {
             if (onSuccess) {
               onSuccess();

--- a/browserid/static/dialog/test/qunit/browserid-identities_unit_test.js
+++ b/browserid/static/dialog/test/qunit/browserid-identities_unit_test.js
@@ -112,6 +112,10 @@ steal.plugins("jquery", "funcunit/qunit").then("/dialog/resources/browserid-iden
       onSuccess();
     },
 
+    serverTime: function(onSuccess) {
+      onSuccess(new Date());
+    },
+
     logout: function(onSuccess) {
       credentialsValid = false;
       onSuccess();

--- a/browserid/static/dialog/test/qunit/browserid-network_test.js
+++ b/browserid/static/dialog/test/qunit/browserid-network_test.js
@@ -91,13 +91,13 @@ steal.plugins("jquery", "funcunit/qunit").then("/dialog/resources/browserid-netw
 
   test("logout->checkAuth: are we really logged out?", function() {
     BrowserIDNetwork.authenticate("testuser@testuser.com", "testuser", function onSuccess(authenticated) {
-      BrowserIDNetwork.logout(function onSuccess(authenticated) {
+      BrowserIDNetwork.logout(function onSuccess() {
         BrowserIDNetwork.checkAuth(function onSuccess(authenticated) {
           start();
           equal(false, authenticated, "after logout, we are not authenticated");
-        }, function onFailure() {
+        }, function onFailure(err) {
           start();
-          ok(false, "checkAuth failure");
+          ok(false, "checkAuth failure", err);
         });
       });
     });
@@ -151,4 +151,17 @@ steal.plugins("jquery", "funcunit/qunit").then("/dialog/resources/browserid-netw
   test("cancelUser", function() {
     equal(typeof BrowserIDNetwork.cancelUser, "function", "what a ridiculously stupid test");
   });
+
+  test("serverTime", function() {
+    BrowserIDNetwork.serverTime(function onSuccess(time) {
+      var diff = (new Date()) - time;
+      equal(Math.abs(diff) < 100, true, "server time and local time should be less than 100ms different (is " + diff + "ms different)");
+      start();
+    }, function onfailure() {
+      start();
+    });
+
+    stop();
+  });
+
 });

--- a/browserid/tests/password-length-test.js
+++ b/browserid/tests/password-length-test.js
@@ -56,9 +56,13 @@ email.setInterceptor(function(email, site, secret) { });
 
 suite.addBatch({
   "get csrf token": {
-    topic: wsapi.get('/wsapi/csrf'),
+    topic: wsapi.get('/wsapi/session_context'),
     "works": function (r, err) {
       assert.equal(typeof r.body, 'string');
+      var v = JSON.parse(r.body);
+      assert.equal(typeof v, 'object');
+      assert.equal(typeof v.csrf_token, 'string');
+      assert.equal(typeof v.server_time, 'number');
     }
   }
 });

--- a/browserid/tests/registration-status-wsapi-test.js
+++ b/browserid/tests/registration-status-wsapi-test.js
@@ -136,10 +136,10 @@ suite.addBatch({
 
 suite.addBatch({
   "after successful registration": {
-    topic: wsapi.get("/wsapi/am_authed"),
+    topic: wsapi.get("/wsapi/session_context"),
     "we're authenticated": function (r, err) {
       assert.strictEqual(r.code, 200);
-      assert.strictEqual(JSON.parse(r.body), true);
+      assert.strictEqual(JSON.parse(r.body).authenticated, true);
     },
     "but we can easily clear cookies on the client to change that!": function(r, err) {
       wsapi.clearCookies();
@@ -149,10 +149,10 @@ suite.addBatch({
 
 suite.addBatch({
   "after clearing cookies": {
-    topic: wsapi.get("/wsapi/am_authed"),
+    topic: wsapi.get("/wsapi/session_context"),
     "we're NOT authenticated": function (r, err) {
       assert.strictEqual(r.code, 200);
-      assert.strictEqual(JSON.parse(r.body), false);
+      assert.strictEqual(JSON.parse(r.body).authenticated, false);
     }
   }
 });

--- a/libs/wsapi_client.js
+++ b/libs/wsapi_client.js
@@ -112,10 +112,15 @@ exports.get = function(cfg, path, context, getArgs, cb) {
 function withCSRF(cfg, context, cb) {
   if (context.csrf) cb(context.csrf);
   else {
-    exports.get(cfg, '/wsapi/csrf', context, undefined, function(r) {
-      if (r.code === 200 && typeof r.body === 'string')
-        context.csrf = r.body;
-      cb(context.csrf);
+    exports.get(cfg, '/wsapi/session_context', context, undefined, function(r) {
+      try {
+        if (r.code !== 200) throw 'http error';
+        context.csrf = JSON.parse(r.body).csrf_token;
+        cb(context.csrf);
+      } catch(e) {
+        console.log('error getting csrf token: ', e);
+        cb();
+      }
     });
   }
 }


### PR DESCRIPTION
@shane-tomlinson and @benadida - I'd like careful review of these commits.  Basically I create a new `session_context` API which serves three pieces of information:
1. authentication status of the connection
2. current server time
3. csrf token

Client code is reworked so session status is only hit when needed to save on traffic, and usually in a normal usage it will only need to be hit once per dialog interaction.

Also, now the assertion generation code uses server time instead of local time to sign assertions.

If this code looks ok we'll merge into the rolling train and get QA on it.
