### PR TITLE
Fixing a problem where the expiration date for the assertions was being c

### DIFF
--- a/browserid/static/dialog/resources/user.js
+++ b/browserid/static/dialog/resources/user.js
@@ -536,8 +536,9 @@ BrowserID.User = (function() {
           network.serverTime(function(serverTime) {
             var sk = jwk.SecretKey.fromSimpleObject(idInfo.priv);
             // assertions are valid for 2 minutes
-            var expiration = serverTime + (2 * 60 * 1000);
-            var tok = new jwt.JWT(null, expiration, origin);
+            var expirationMS = serverTime.getTime() + (2 * 60 * 1000);
+            var expirationDate = (new Date()).setTime(expirationMS);
+            var tok = new jwt.JWT(null, expirationDate, origin);
             assertion = vep.bundleCertsAndAssertion([idInfo.cert], tok.sign(sk));
             if (onSuccess) {
               onSuccess(assertion);

--- a/browserid/static/dialog/resources/user.js
+++ b/browserid/static/dialog/resources/user.js
@@ -537,7 +537,7 @@ BrowserID.User = (function() {
             var sk = jwk.SecretKey.fromSimpleObject(idInfo.priv);
             // assertions are valid for 2 minutes
             var expirationMS = serverTime.getTime() + (2 * 60 * 1000);
-            var expirationDate = (new Date()).setTime(expirationMS);
+            var expirationDate = new Date(expirationMS);
             var tok = new jwt.JWT(null, expirationDate, origin);
             assertion = vep.bundleCertsAndAssertion([idInfo.cert], tok.sign(sk));
             if (onSuccess) {

--- a/browserid/static/dialog/test/qunit/resources/user_unit_test.js
+++ b/browserid/static/dialog/test/qunit/resources/user_unit_test.js
@@ -178,7 +178,14 @@ steal.plugins("jquery", "funcunit/qunit").then("/dialog/resources/user", functio
 
     // Check for parts of the assertion
     equal(tok.audience, testOrigin, "correct audience");
-    equal(isNaN(tok.expires.valueOf()), false, "expiration date is valid");
+    var expires = tok.expires.getTime();
+    ok(typeof expires === "number" && !isNaN(expires), "expiration date is valid");
+  
+    var nowPlus2Mins = new Date().getTime() + (2 * 60 * 1000);
+    // expiration date must be within 5 seconds of 2 minutes from now - see 
+    // issue 433 (https://github.com/mozilla/browserid/issues/433)
+    ok(((nowPlus2Mins - 5000) < expires) && (expires < (nowPlus2Mins + 5000)), "expiration date must be within 5 seconds of 2 minutes from now");
+
     equal(typeof tok.cryptoSegment, "string", "cryptoSegment exists");
     equal(typeof tok.headerSegment, "string", "headerSegment exists");
     equal(typeof tok.payloadSegment, "string", "payloadSegment exists");


### PR DESCRIPTION
Fixing a problem where the expiration date for the assertions was being calculated incorrectly.

Adding basic assertion tests to make sure all of the necessary parts are there and that the expiration date is actually a date.

I was unsure of what to include in the assertion tests.  Since it is a unit test, I did not want to call the backend, which would make it more of a functional test.  Ideas, suggestions, fixes are all appreciated.

issue #457
