### PR TITLE
Set the default text color to #000.  Used in the addon so text is not whi

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -18,7 +18,7 @@ body {
     font-size: 13px;
     line-height: 21px;
     background-image: url('/i/bg.png');
-    color: #333;
+    color: #000;
 }
 
 

--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -18,6 +18,7 @@ body {
     font-size: 13px;
     line-height: 21px;
     background-image: url('/i/bg.png');
+    color: #333;
 }
 
 


### PR DESCRIPTION
Set the default text color to #000.  Used in the addon so text is not white on white.

close #522
