### PR TITLE
some rpm build fixes

### DIFF
--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -1,7 +1,7 @@
 %define _rootdir /opt/browserid
 
 Name:          browserid-server
-Version:       0.2011.11.03
+Version:       0.2011.11.17
 Release:       1%{?dist}
 Summary:       BrowserID server
 Packager:      Pete Fritchman <petef@mozilla.com>

--- a/scripts/rpmbuild.sh
+++ b/scripts/rpmbuild.sh
@@ -6,17 +6,14 @@ progname=$(basename $0)
 
 cd $(dirname $0)/..    # top level of the checkout
 
-curdir=$(basename $PWD)
-if [ "$curdir" != "browserid" ]; then
-    echo "$progname: git checkout must be in a dir named 'browserid'" >&2
-    exit 1
-fi
+mkdir -p rpmbuild/SOURCES rpmbuild/SPECS rpmbuild/SOURCES
+rm -rf rpmbuild/RPMS rpmbuild/SOURCES/browserid
 
-mkdir -p rpmbuild/SOURCES rpmbuild/SPECS
-rm -rf rpmbuild/RPMS
-
-tar -C .. --exclude rpmbuild -czf \
-    $PWD/rpmbuild/SOURCES/browserid-server.tar.gz browserid
+# work around the checkout name not being "browserid"
+ln -sf $PWD rpmbuild/SOURCES/browserid
+tar -C rpmbuild/SOURCES --exclude rpmbuild --exclude .git \
+    --exclude var -czhf \
+    $PWD/rpmbuild/SOURCES/browserid-server.tar.gz browserid/
 
 set +e
 


### PR DESCRIPTION
Support rpm building from a checkout directory that is not named "browserid" (for hudson builds).
