### PR TITLE
auto-fix PATH for uglifyjs, and exit on errors

### DIFF
--- a/scripts/compress.sh
+++ b/scripts/compress.sh
@@ -2,6 +2,8 @@
 
 cd $(dirname "$0")/..
 
+export PATH=$PWD/node_modules/.bin:$PATH
+
 UGLIFY=`which uglifyjs 2> /dev/null`
 if [ ! -x "$UGLIFY" ]; then
     echo "uglifyjs not found in your path.  can't create production resources.  disaster."
@@ -15,6 +17,8 @@ if [ ! -x "$JAVA" ]; then
 fi
 
 YUI_LOCATION=`pwd`'/resources/static/steal/build/scripts/yui.jar'
+
+set -e  # exit on errors
 
 echo ''
 echo '****Compressing include.js****'


### PR DESCRIPTION
this gets us proper exit codes for scripts/compress.sh when we encounter an error -- with the side effect of exiting the script as soon as we see an error.
