### PR TITLE
Forcing the callback to be called after 1.75 seconds - the time the anima...

### DIFF
--- a/resources/static/dialog/resources/helpers.js
+++ b/resources/static/dialog/resources/helpers.js
@@ -48,12 +48,14 @@
         doAnimation = $("#signIn").length && body.innerWidth() > 640;
 
     if (doAnimation) {
-      $("#signIn").animate({"width" : "685px"}, "slow", function () {
-        // post animation
-         body.delay(500).animate({ "opacity" : "0.5"}, "fast", function () {
-           callback();
-         });
+      $("#signIn").animate({"width" : "95%"}, 750, function () {
+         body.delay(500).animate({ "opacity" : "0.5"}, 500);
       });
+
+      // Call setTimeout here because on Android default browser, sometimes the
+      // callback is not correctly called, it seems as if jQuery does not know
+      // the animation is complete.
+      setTimeout(callback, 1750);
     }
     else {
       callback();


### PR DESCRIPTION
...tion takes to complete.

I have seen this issue on the default Android browser in the past, and @digitarald has seen this in Soup.  Instead of relying on jQuery to know when the animation is complete, I am setting a hard timeout of 1.75 seconds (when the animation is in theory supposed to complete) and calling the callback.

@lloyd, can you review this and we can talk about getting it into beta for the developer preview?

issue #704
