### PR TITLE
Easier setup for configuring email in development

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -113,7 +113,6 @@ g_configs.production = {
 // local development configuration
 g_configs.local =  {
   URL: 'http://127.0.0.1:10002',
-  email_to_console: true, // don't send email, just dump verification URLs to console.
   use_minified_resources: false,
   var_path: path.join(__dirname, "..", "var"),
   database: {
@@ -189,6 +188,10 @@ if (!g_config.smtp) {
     user: process.env['SMTP_USER'],
     pass: process.env['SMTP_PASS']
   };
+
+  if (process.env['SMTP_PORT']) {
+    g_config.smtp.port = process.env['SMTP_PORT'];
+  }
 }
 
 // now handle ephemeral database configuration.  Used in testing.

--- a/lib/email.js
+++ b/lib/email.js
@@ -82,10 +82,7 @@ function doSend(landing_page, email, site, secret) {
 
   if (interceptor) {
     interceptor(email, site, secret);
-  } else if (!smtp_params.user) {
-    // log verification email to console separated by whitespace.
-    console.log("\nVERIFICATION URL:\n" + url + "\n");
-  } else {
+  } else if (smtp_params && smtp_params.host) {
     emailer.send_mail({
       sender: "noreply@browserid.org",
       to: email,
@@ -97,7 +94,10 @@ function doSend(landing_page, email, site, secret) {
         logger.error("verification URL: " + url);
       }
     });
-  };
+  } else {
+    // log verification email to console separated by whitespace.
+    console.log("\nVERIFICATION URL:\n" + url + "\n");
+  }
 };
 
 exports.sendNewUserEmail = function(email, site, secret) {

--- a/lib/email.js
+++ b/lib/email.js
@@ -50,6 +50,9 @@ if (smtp_params && smtp_params.host) {
     emailer.SMTP.use_authentication = true;
     emailer.SMTP.user = smtp_params.user;
     emailer.SMTP.pass = smtp_params.pass;
+    if (smtp_params.port) {
+      emailer.SMTP.port = smtp_params.port;
+    }
 
     logger.info("authenticating to email host as " +  emailer.SMTP.user);
   }
@@ -79,7 +82,7 @@ function doSend(landing_page, email, site, secret) {
 
   if (interceptor) {
     interceptor(email, site, secret);
-  } else if (config.get('email_to_console')) {
+  } else if (!smtp_params.user) {
     // log verification email to console separated by whitespace.
     console.log("\nVERIFICATION URL:\n" + url + "\n");
   } else {


### PR DESCRIPTION
This patch:
- adds the ability to configure the SMTP port, which allows optional TLS use.
- removes email_to_console flag set in dev/local config in favor of just checking if smtp_params have been configured.
- given the new check for smtp_params && smtp_params.host in email.js, it moves the console.log() of the verification link to the "else" so that some potentially confusing ! tests can be avoided.

These changes worked for me when I wanted to configure SMTP in dev, and I also tested the case where I did not configure the SMTP env variables, and I got the console.log call.
