### PR TITLE
Prod hotfix internal api

### DIFF
--- a/resources/static/dialog/resources/internal_api.js
+++ b/resources/static/dialog/resources/internal_api.js
@@ -49,7 +49,6 @@
    * Set the persistent flag to true for an origin.
    * @method setPersistent
    * @param {string} origin
-   * @param {string} email
    * @param {callback} [callback] - callback to call when complete.  Called
    * with true if successful, null if user is not authenticated or failure.
    */
@@ -76,14 +75,14 @@
    * email without showing the dialog.
    * @method get
    * @param {string} origin
-   * @param {object} options.  See options block for navigator.id.get.
-   * options.silent defaults to false.
    * @param {function} callback - called when complete.  Called with assertion
    * if success, null if the user cancels.  Other conditions causing null
    * return value: silent is true and user is not authenticated.  silent is
    * true, requiredEmail is specified but user does not control email.
+   * @param {object} options.  See options block for navigator.id.get.
+   * options.silent defaults to false.
    */
-  internal.get = function(origin, options, callback) {
+  internal.get = function(origin, callback, options) {
     function complete(assertion) {
       // If no assertion, give no reason why there was a failure.
       callback && callback(assertion || null);
@@ -107,7 +106,7 @@
     else {
       // Use the standard dialog facilities to get the assertion, pass the
       // options block directly to the dialog.
-      var controller = moduleManager.getModule("dialog");
+      var controller = moduleManager.getRunningModule("dialog");
       if(controller) {
         controller.get(origin, options, complete, complete);
       }

--- a/resources/static/lib/module.js
+++ b/resources/static/lib/module.js
@@ -30,6 +30,16 @@ BrowserID.module = (function() {
     return registration[service].constructor;
   }
 
+  function getRunningModule(service) {
+    var module = running[service];
+
+    if(!module) {
+      throw "no module running for " + service;
+    }
+
+    return module;
+  }
+
   function reset() {
     registration = {};
     running = {};
@@ -88,6 +98,7 @@ BrowserID.module = (function() {
   return {
     register: register,
     getModule: getModule,
+    getRunningModule: getRunningModule,
     reset: reset,
     start: start,
     stop: stop,

--- a/resources/static/test/qunit/resources/internal_api_unit_test.js
+++ b/resources/static/test/qunit/resources/internal_api_unit_test.js
@@ -46,12 +46,22 @@
       storage = bid.Storage,
       moduleManager = bid.module;
 
+  function ModuleMock() {}
+
+  ModuleMock.prototype = {
+    init: function() {},
+    start: function() {}
+  };
+
   module("resources/internal_api", {
     setup: function() {
       network.setXHR(xhr);
       xhr.useResult("valid");
       xhr.setContextInfo("authenticated", false);
       storage.clear();
+      moduleManager.reset();
+      moduleManager.register("dialog", ModuleMock);
+      moduleManager.start("dialog");
     },
 
     teardown: function() {
@@ -85,22 +95,22 @@
   });
 
   asyncTest("BrowserID.internal.get with silent: true, non-authenticated user - returns null assertion", function() {
-    internal.get(origin, {
-        requiredEmail: "testuser@testuser.com",
-        silent: true
-    }, function(assertion) {
+    internal.get(origin, function(assertion) {
       strictEqual(assertion, null, "user not logged in, assertion impossible to get");
       start();
+    }, {
+        requiredEmail: "testuser@testuser.com",
+        silent: true
     });
   });
 
   asyncTest("BrowserID.internal.get with silent: true, authenticated user, no requiredEmail, and no email address associated with site - not enough info to generate an assertion", function() {
     user.authenticate("testuser@testuser.com", "password", function() {
-      internal.get(origin, {
-          silent: true
-        }, function(assertion) {
+      internal.get(origin, function(assertion) {
         strictEqual(assertion, null, "not enough info to generate an assertion, assertion should not be generated");
         start();
+      }, {
+        silent: true
       });
     });
   });
@@ -112,11 +122,11 @@
 
         xhr.useResult("invalid");
 
-        internal.get(origin, {
-            silent: true
-          }, function(assertion) {
+        internal.get(origin, function(assertion) {
           strictEqual(assertion, null, "XHR failure while getting assertion");
           start();
+        }, {
+          silent: true
         });
       });
     });
@@ -127,11 +137,11 @@
       user.syncEmails(function() {
         storage.site.set(origin, "email", "testuser@testuser.com");
 
-        internal.get(origin, {
-            silent: true
-          }, function(assertion) {
+        internal.get(origin, function(assertion) {
           ok(assertion, "assertion generated using stored email address for site.");
           start();
+        }, {
+          silent: true
         });
       });
     });
@@ -141,12 +151,12 @@
     user.authenticate("testuser@testuser.com", "password", function() {
       // email addresses will not be synced just because we authenticated.
       // Depending on get to do the sync.
-      internal.get(origin, {
-        silent: true,
-        requiredEmail: "invalid@testuser.com"
-      }, function(assertion) {
+      internal.get(origin, function(assertion) {
         strictEqual(assertion, null, "uncontrolled email address returns null assertion");
         start();
+      }, {
+        silent: true,
+        requiredEmail: "invalid@testuser.com"
       });
     });
   });
@@ -154,75 +164,63 @@
   asyncTest("BrowserID.internal.get with silent: true, authenticated user, requiredEmail and XHR error - return null assertion", function() {
     user.authenticate("testuser@testuser.com", "password", function() {
       xhr.useResult("invalid");
-      internal.get(origin, {
-        silent: true,
-        requiredEmail: "invalid@testuser.com"
-      }, function(assertion) {
+      internal.get(origin, function(assertion) {
         strictEqual(assertion, null, "unregistered email address returns null assertion");
         start();
+      }, {
+        silent: true,
+        requiredEmail: "invalid@testuser.com"
       });
     });
   });
 
   asyncTest("BrowserID.internal.get with silent: true, authenticated user, requiredEmail, and registered email address - return an assertion", function() {
     user.authenticate("testuser@testuser.com", "password", function() {
-      internal.get(origin, {
-        silent: true,
-        requiredEmail: "testuser@testuser.com"
-      }, function(assertion) {
+      internal.get(origin, function(assertion) {
         ok(assertion, "assertion has been returned");
         start();
+      }, {
+        silent: true,
+        requiredEmail: "testuser@testuser.com"
       });
     });
   });
 
   asyncTest("BrowserID.internal.get with dialog - simulate the user return of an assertion", function() {
-    moduleManager.reset();
-
     var controllerOrigin;
 
-    moduleManager.register("dialog", {
-      get: function(getOrigin, options, onsuccess, onerror) {
-        controllerOrigin = getOrigin;
-        // simulate the full dialog flow.
-        onsuccess("simulated_assertion");
-      }
-    });
+    ModuleMock.prototype.get = function(getOrigin, options, onsuccess, onerror) {
+      controllerOrigin = getOrigin;
+      // simulate the full dialog flow.
+      onsuccess("simulated_assertion");
+    };
 
-    internal.get(origin, {}, function onComplete(assertion) {
+    internal.get(origin, function onComplete(assertion) {
         equal(controllerOrigin, origin, "correct origin passed");
         equal(assertion, "simulated_assertion", "Kosher assertion");
         start();
-    });
+    }, {});
   });
 
   asyncTest("BrowserID.internal.get with dialog with failure - simulate the return of a null assertion", function() {
-    moduleManager.reset();
+    ModuleMock.prototype.get = function(getOrigin, options, onsuccess, onerror) {
+      onerror();
+    };
 
-    moduleManager.register("dialog", {
-      get: function(getOrigin, options, onsuccess, onerror) {
-        onerror();
-      }
-    });
-
-    internal.get(origin, {}, function onComplete(assertion) {
+    internal.get(origin, function onComplete(assertion) {
         equal(assertion, null, "on failure, assertion is null");
         start();
-    });
+    }, {});
   });
 
   asyncTest("BrowserID.internal.get with dialog with user cancellation - return null assertion", function() {
-    moduleManager.reset();
+    ModuleMock.prototype.get = function(getOrigin, options, onsuccess, onerror) {
+      onsuccess(null);
+    };
 
-    moduleManager.register("dialog", {
-      get: function(getOrigin, options, onsuccess, onerror) {
-        onsuccess(null);
-      }
-    });
-
-    internal.get(origin, {}, function onComplete(assertion) {
+    internal.get(origin, function onComplete(assertion) {
         equal(assertion, null, "on cancel, assertion is null");
         start();
-    });
+    }, {});
   });
 }());

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -48,7 +48,7 @@
       <% if (useJavascript !== false) { %>
         <% if (production) { %>
           <script type="text/javascript" src="/dialog/production.js"></script>
-          
+
         <% } else { %>
           <script type="text/javascript" src="/dialog/resources/channel.js"></script>
           <script type="text/javascript" src="/lib/jquery-1.6.2.min.js"></script>
@@ -76,6 +76,7 @@
           <script type="text/javascript" src="/shared/browser-support.js"></script>
           <script type="text/javascript" src="/shared/wait-messages.js"></script>
           <script type="text/javascript" src="/shared/helpers.js"></script>
+          <script type="text/javascript" src="/dialog/resources/internal_api.js"></script>
           <script type="text/javascript" src="/dialog/resources/helpers.js"></script>
           <script type="text/javascript" src="/dialog/resources/state_machine.js"></script>
           <script type="text/javascript" src="/dialog/controllers/page.js"></script>


### PR DESCRIPTION
- Options block comes last to be consistent with navigator.id.get.
- fix a problem where if silent:false is specified, controller could not be found.

issue #601
