### PR TITLE
Setting up views for include.js and include.orig.js

### DIFF
--- a/lib/browserid/views.js
+++ b/lib/browserid/views.js
@@ -17,8 +17,6 @@ path = require('path');
 
 
 const VIEW_PATH = path.join(__dirname, "..", "..", "resources", "views");
-const DEV_INCLUDE = path.join(__dirname, "..", "..", "resources", "static", "include_js", "include.js");
-const PROD_INCLUDE = path.join(__dirname, "..", "..", "resources", "static", "production", "include.js");
 
 // none of our views include dynamic data.  all of them should be served
 // with reasonable cache headers.  This wrapper around rendering handles
@@ -53,18 +51,19 @@ exports.setup = function(app) {
   });
 
   app.get('/include.js', function(req, res, next) {
-    var include = DEV_INCLUDE,
-        env = config.get('env');
+    var env = config.get('env');
 
+    req.url = "/include_js/include.js";
     if (env === 'production') {
-      include = PROD_INCLUDE;
+      req.url = "/production/include.js"
     }
 
-    res.sendfile(include);
+    next();
   });
 
   app.get('/include.orig.js', function(req, res, next) {
-    res.sendfile(DEV_INCLUDE);
+    req.url = "/include_js/include.js";
+    next();
   });
 
   // this should probably be an internal redirect

--- a/lib/browserid/views.js
+++ b/lib/browserid/views.js
@@ -17,6 +17,8 @@ path = require('path');
 
 
 const VIEW_PATH = path.join(__dirname, "..", "..", "resources", "views");
+const DEV_INCLUDE = path.join(__dirname, "..", "..", "resources", "static", "include_js", "include.js");
+const PROD_INCLUDE = path.join(__dirname, "..", "..", "resources", "static", "production", "include.js");
 
 // none of our views include dynamic data.  all of them should be served
 // with reasonable cache headers.  This wrapper around rendering handles
@@ -48,6 +50,21 @@ exports.setup = function(app) {
 
   app.set('view options', {
     production: config.get('use_minified_resources')
+  });
+
+  app.get('/include.js', function(req, res, next) {
+    var include = DEV_INCLUDE,
+        env = config.get('env');
+
+    if (env === 'production') {
+      include = PROD_INCLUDE;
+    }
+
+    res.sendfile(include);
+  });
+
+  app.get('/include.orig.js', function(req, res, next) {
+    res.sendfile(DEV_INCLUDE);
   });
 
   // this should probably be an internal redirect
@@ -134,7 +151,7 @@ exports.setup = function(app) {
   });
 
   /**
-   * 
+   *
    * XXX benadida or lloyd, I tried to use straight up regexp to do this, but.
    * is there a better way to do this?
    */

--- a/resources/static/include.js
+++ b/resources/static/include.js
@@ -1,1 +1,0 @@
-production/include.js

--- a/scripts/compress.sh
+++ b/scripts/compress.sh
@@ -107,7 +107,3 @@ $UGLIFY < $BUILD_PATH/communication_iframe.uncompressed.js > communication_ifram
 $UGLIFYCSS $BUILD_PATH/browserid.uncompressed.css > browserid.css
 $UGLIFYCSS $BUILD_PATH/dialog.uncompressed.css > dialog.css
 
-# set up new simlink for include.js.  How can this part be better?
-cd ..
-rm include.js
-ln -s production/include.js

--- a/tests/page-requests-test.js
+++ b/tests/page-requests-test.js
@@ -73,7 +73,12 @@ suite.addBatch({
   'GET /users/':                 respondsWith(302),
   'GET /primaries':              respondsWith(302),
   'GET /primaries/':             respondsWith(302),
-  'GET /developers':             respondsWith(302)
+  'GET /developers':             respondsWith(302),
+  'GET /developers/':            respondsWith(302),
+  'GET /test':                   respondsWith(200),
+  'GET /test/':                  respondsWith(200),
+  'GET /include.js':             respondsWith(200),
+  'GET /include.orig.js':        respondsWith(200)
 });
 
 // shut the server down and cleanup


### PR DESCRIPTION
@lloyd, @ozten - could this be reviewed?  I have set up routes for include.js and include.orig.js as follows:
- include.js points to include_js/include.js or production/include.js depending on environment.
- Added tests checking for correct responses to 'include.js' and 'include.orig.js'.
- Added missing tests for correct response for '/test' and '/test/'
- Remove the symlink to include.js
- Remove symlink update in compress.sh

issue #921

Areas of concern - what was our previous caching policy on these files?  What should our caching policy be?

Any suggestions or updates are welcome!
