### PR TITLE
Fix the missing "verify your email" screen by disabling the "xhr delay" screen

### DIFF
--- a/resources/static/shared/modules/xhr_delay.js
+++ b/resources/static/shared/modules/xhr_delay.js
@@ -13,8 +13,8 @@ BrowserID.Modules.XHRDelay = (function() {
     start: function(options) {
       var self=this;
 
-      self.subscribe("xhr_delay", this.renderWait.curry("wait", wait.slowXHR));
-      self.subscribe("xhr_complete", this.hideWait);
+      //self.subscribe("xhr_delay", this.renderWait.curry("wait", wait.slowXHR));
+      //self.subscribe("xhr_complete", this.hideWait);
 
       sc.start.call(self, options);
     },


### PR DESCRIPTION
issue #933
issue #934
issue #935
