### PR TITLE
Fixing the complete registration flow when the browser the user completes registration is different from the one they started at.                               

### DIFF
--- a/resources/static/dialog/controllers/check_registration.js
+++ b/resources/static/dialog/controllers/check_registration.js
@@ -36,7 +36,7 @@ BrowserID.Modules.CheckRegistration = (function() {
           });
         }
         else if (status === "mustAuth") {
-          self.close("auth", { email: self.email });
+          self.close("authenticate", { email: self.email });
           oncomplete && oncomplete();
         }
       }, self.getErrorDialog(errors.registration, oncomplete));

--- a/resources/static/shared/user.js
+++ b/resources/static/shared/user.js
@@ -112,6 +112,19 @@ BrowserID.User = (function() {
           // ensure that the stagedOnBehalfOf is cleared so there is no stale
           // data.
           storage.setStagedOnBehalfOf("");
+
+          // To avoid too many address_info requests, returns from each
+          // address_info request are cached.  If the user is doing
+          // a registrationPoll, it means the user was registering the address
+          // and the registration has completed.  Because the status is
+          // "complete" or "known", we know that the address is known, so we
+          // toggle the field to be up to date.  If the known field remains
+          // false, then the user is redirected back to the authentication
+          // page and the system thinks the address must be verified again.
+          if(addressCache[email]) {
+            addressCache[email].known = true;
+          }
+
           if (onSuccess) {
             onSuccess(status);
           }

--- a/resources/static/test/qunit/controllers/check_registration_unit_test.js
+++ b/resources/static/test/qunit/controllers/check_registration_unit_test.js
@@ -50,7 +50,7 @@
   asyncTest("user validation with mustAuth result", function() {
     xhr.useResult("mustAuth");
 
-    testVerifiedUserEvent("auth", "User Must Auth");
+    testVerifiedUserEvent("authenticate", "User Must Auth");
   });
 
   asyncTest("user validation with pending->complete result ~3 seconds", function() {


### PR DESCRIPTION
- in check_registration.js, the "auth" message has been changed to "authenticate    "
- in user.js, when the registration poll completes, set the "known" field of the     address in the addressInfo cache to "true"

issue #1026
