### PR TITLE
BrowserID instead of Browser ID

### DIFF
--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -20,7 +20,7 @@
       <link href="/dialog/css/m.css" rel="stylesheet" type="text/css">
   <% } %>
   <link href="https://fonts.googleapis.com/css?family=Droid+Serif:400,400italic,700,700italic" rel="stylesheet" type="text/css">
-  <title><%= gettext('Browser ID') %></title>
+  <title><%= gettext('BrowserID') %></title>
 </head>
   <body class="waiting">
       <div id="wrapper">


### PR DESCRIPTION
We use BrowserID (without space) everywhere else.
