### PR TITLE
Use l10n-all config file when building locale data.

### DIFF
--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -26,7 +26,7 @@ export PATH=$PWD/node_modules/.bin:$PATH
 ./locale/compile-mo.sh locale/
 ./locale/compile-json.sh locale/ resources/static/i18n/
 scripts/compress.sh
-scripts/compress-locales.sh
+env CONFIG_FILES=$PWD/config/l10n-all.json scripts/compress-locales.sh
 rm -r resources/static/build resources/static/test
 echo "$GIT_REVISION" > resources/static/ver.txt
 echo "locale svn r$SVN_REVISION" >> resources/static/ver.txt


### PR DESCRIPTION
We always want to build all locales -- we selectively enable them in the prod configuration.
