### PR TITLE
Hotfix 1058 forgot password

### DIFF
--- a/resources/static/dialog/controllers/actions.js
+++ b/resources/static/dialog/controllers/actions.js
@@ -100,7 +100,7 @@ BrowserID.Modules.Actions = (function() {
     },
 
     doResetPassword: function(info) {
-      this.doConfirmUser(info.email);
+      this.doConfirmUser(info);
     },
 
     doConfirmEmail: function(info) {


### PR DESCRIPTION
Fix the missing email address in the "check your email" screen for the forgot password flow.

issue #1058
