### PR TITLE
Hotfix 1087 empty unsupported dialog

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -90,7 +90,7 @@ section > .contents {
     opacity: 1;
 }
 
-.error #error {
+.error #error, #error.unsupported {
     z-index: 3;
     opacity: 1;
 }


### PR DESCRIPTION
1 line CSS fix to ensure that the unsupported browser dialog message is always shown.

issue #1087
