### PR TITLE
Hotfix 1087 empty unsupported dialog

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -90,7 +90,7 @@ section > .contents {
     opacity: 1;
 }
 
-.error #error {
+.error #error, #error.unsupported {
     z-index: 3;
     opacity: 1;
 }

--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -92,6 +92,7 @@ section > .contents {
 
 .error #error, #error.unsupported {
     z-index: 3;
+    -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     opacity: 1;
 }
 


### PR DESCRIPTION
This includes two commits to handle both IE8 and IE9 being in IE7 mode.  

Issue1) IE8 in IE7 mode would display an empty unsupported_dialog
Issue2) IE9 in IE7 mode would display an empty unsupported_dialog

Link to issue #1087.
