### PR TITLE
Beefing up the cookies disabled check so that it handles almost all cases without user interaction.

### DIFF
--- a/lib/browserid/views.js
+++ b/lib/browserid/views.js
@@ -90,6 +90,10 @@ exports.setup = function(app) {
     renderCachableView(req, res, 'unsupported_dialog.ejs', {layout: 'dialog_layout.ejs', useJavascript: false});
   });
 
+  app.get("/cookies_disabled", function(req,res) {
+    renderCachableView(req, res, 'cookies_disabled.ejs', {layout: 'dialog_layout.ejs', useJavascript: false});
+  });
+
   // Used for a relay page for communication.
   app.get("/relay", function(req, res, next) {
     // Allow the relay to be run within a frame

--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -91,7 +91,7 @@ section > .contents {
     opacity: 1;
 }
 
-.error #error, #error.unsupported {
+.error #error, #error.unsupported, #error.cookies_disabled {
     z-index: 3;
     -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
     opacity: 1;

--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -11,7 +11,7 @@
     <h2 id="error_403">
       <%= gettext("BrowserID required cookies") %>
     </h2>
-    <%= gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again") %>
+    <%= format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ['http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked']) %>
   <% } else { %>
     <h2 id="defaultError">
       <%= gettext("We are very sorry, there has been an error!") %>

--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -9,27 +9,31 @@
     </h2>
   <% } else if (typeof network !== "undefined" && network.status == 403) { %>
     <h2 id="error_403">
-      <%= gettext("We are sorry, BrowserID required cookies") %>
+      <%= gettext("BrowserID required cookies") %>
     </h2>
-    <%= gettext("BrowserID requires your browser's cookies to be enabled to operate. Please enable your browser's cookies.") %>
+    <%= gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again") %>
   <% } else { %>
     <h2 id="defaultError">
       <%= gettext("We are very sorry, there has been an error!") %>
     </h2>
   <% } %>
 
-  <p>
-  <% if (typeof dialog !== "undefined" && dialog !== false) { %>
-    <%= gettext("To retry, you will have to reload the page and try again.") %>
-  <% } else { %>
-    <%= gettext("To retry, you will have to close this window and try again.") %>
+  <% if (!(typeof network !== "undefined" && network.status == 403)) { %>
+    <p>
+      <% if (typeof dialog !== "undefined" && dialog !== false) { %>
+        <%= gettext("To retry, you will have to reload the page and try again.") %>
+      <% } else { %>
+        <%= gettext("To retry, you will have to close this window and try again.") %>
+      <% } %>
+    </p>
   <% } %>
-  </p>
 
   <% if(typeof action !== "undefined" || typeof network !== "undefined") { %>
-    <a href="#" id="openMoreInfo">
-      <%= gettext("See more info") %>
-    </a>
+    <p>
+      <a href="#" id="openMoreInfo">
+        <%= gettext("See more info") %>
+      </a>
+    </p>
 
     <ul id="moreInfo">
       <% if (typeof action !== "undefined") { %>

--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -7,6 +7,11 @@
     <h2 id="error_503">
       <%= gettext("We are very sorry, the server is under extreme load!") %>
     </h2>
+  <% } else if (typeof network !== "undefined" && network.status == 403) { %>
+    <h2 id="error_403">
+      <%= gettext("We are sorry, BrowserID required cookies") %>
+    </h2>
+    <%= gettext("BrowserID requires your browser's cookies to be enabled to operate. Please enable your browser's cookies.") %>
   <% } else { %>
     <h2 id="defaultError">
       <%= gettext("We are very sorry, there has been an error!") %>
@@ -45,7 +50,7 @@
           <strong id="network">Network Info:</strong> <%= network.type %>: <%= network.url %>
 
           <p>
-            <strong>Response Code - </strong> <%= network.textStatus %>
+            <strong>Response Code - </strong> <%= network.status %>
           </p>
 
           <% if (network.responseText) { %>

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -863,7 +863,7 @@
         }
         else {
           // Browser does not have local storage.
-          return "LOCALSTORAGE_MISSING";
+          return "LOCALSTORAGE_NOT_SUPPORTED";
         }
       } catch(e) {
           return "LOCALSTORAGE_DISABLED";
@@ -872,13 +872,13 @@
 
     function checkPostMessage() {
       if(!win.postMessage) {
-        return "POSTMESSAGE_MISSING";
+        return "POSTMESSAGE_NOT_SUPPORTED";
       }
     }
 
     function checkJSON() {
       if(!(window.JSON && window.JSON.stringify && window.JSON.parse)) {
-        return "JSON_MISSING";
+        return "JSON_NOT_SUPPORTED";
       }
     }
 

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -831,7 +831,7 @@
           ieNosupport = ieVersion > -1 && ieVersion < 8;
 
       if(ieNosupport) {
-        return "IE_VERSION";
+        return "BAD_IE_VERSION";
       }
     }
 
@@ -863,7 +863,7 @@
         }
         else {
           // Browser does not have local storage.
-          return "LOCALSTORAGE";
+          return "LOCALSTORAGE_MISSING";
         }
       } catch(e) {
           return "LOCALSTORAGE_DISABLED";
@@ -872,13 +872,13 @@
 
     function checkPostMessage() {
       if(!win.postMessage) {
-        return "POSTMESSAGE";
+        return "POSTMESSAGE_MISSING";
       }
     }
 
     function checkJSON() {
       if(!(window.JSON && window.JSON.stringify && window.JSON.parse)) {
-        return "JSON";
+        return "JSON_MISSING";
       }
     }
 

--- a/resources/static/shared/error-messages.js
+++ b/resources/static/shared/error-messages.js
@@ -47,7 +47,7 @@ BrowserID.Errors = (function(){
 
     cookiesDisabled: {
       title: gettext("BrowserID requires cookies"),
-      message: gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again")
+      message: format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ["http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked"])
     },
 
     cookiesEnabled: {

--- a/resources/static/shared/error-messages.js
+++ b/resources/static/shared/error-messages.js
@@ -46,8 +46,8 @@ BrowserID.Errors = (function(){
     },
 
     cookiesDisabled: {
-      title: gettext("We are sorry, BrowserID requires cookies"),
-      message: gettext("BrowserID requires your browser's cookies to be enabled to operate. Please enable your browser's cookies and try again")
+      title: gettext("BrowserID requires cookies"),
+      message: gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again")
     },
 
     cookiesEnabled: {

--- a/resources/static/shared/network.js
+++ b/resources/static/shared/network.js
@@ -13,7 +13,6 @@ BrowserID.Network = (function() {
       domain_key_creation_time,
       auth_status,
       code_version,
-      cookies_enabled,
       time_until_delay,
       mediator = bid.Mediator,
       xhr = bid.XHR,
@@ -29,7 +28,6 @@ BrowserID.Network = (function() {
     domain_key_creation_time = result.domain_key_creation_time;
     auth_status = result.auth_level;
     code_version = result.code_version;
-    cookies_enabled = result.cookies_enabled || true;
 
     // seed the PRNG
     // FIXME: properly abstract this out, probably by exposing a jwcrypto
@@ -570,8 +568,19 @@ BrowserID.Network = (function() {
      * @method cookiesEnabled
      */
     cookiesEnabled: function(onComplete, onFailure) {
+      // Make sure we get context first or else we will needlessly send
+      // a cookie to the server.
       withContext(function() {
-        complete(onComplete, cookies_enabled);
+        try {
+          // set a test cookie with a duration of 1 second.
+          // NOTE - The Android 3.3 default browser will still pass this.
+          // http://stackoverflow.com/questions/8509387/android-browser-not-respecting-cookies-disabled/9264996#9264996
+          document.cookie = "test=true; max-age=1";
+          var enabled = document.cookie.indexOf("test") > -1;
+          complete(onComplete, enabled);
+        } catch(e) {
+          complete(onComplete, false);
+        }
       }, onFailure);
     }
   };

--- a/resources/static/test/cases/shared/modules/cookie_check.js
+++ b/resources/static/test/cases/shared/modules/cookie_check.js
@@ -50,19 +50,5 @@
     });
   });
 
-  /*
-  // XXX - disabling this test until we have the full solution for how we are going
-  // to interact with the backend.
-  asyncTest("createController with cookies disabled - ready returns with false status, error shown", function() {
-    transport.setContextInfo("cookies_enabled", false);
-    createController({
-      ready: function(status) {
-        testHelpers.testErrorVisible();
-        equal(status, false, "cookies are disabled, false status");
-        start();
-      }
-    });
-  });
-  */
 }());
 

--- a/resources/static/test/cases/shared/network.js
+++ b/resources/static/test/cases/shared/network.js
@@ -541,18 +541,11 @@
     failureCheck(network.changePassword, "oldpassword", "newpassword");
   });
 
-  asyncTest("cookiesEnabled with cookies enabled", function() {
-    transport.setContextInfo("cookies_enabled", true);
-
+  asyncTest("cookiesEnabled with cookies enabled - return true status", function() {
     network.cookiesEnabled(function(status) {
       equal(status, true, "cookies are enabled, correct status");
       start();
     }, testHelpers.unexpectedXHRFailure);
-  });
-
-  asyncTest("cookiesEnabled with XHR failure", function() {
-    transport.useResult("contextAjaxError");
-    failureCheck(network.cookiesEnabled);
   });
 
 }());

--- a/resources/static/test/cases/shared/screens.js
+++ b/resources/static/test/cases/shared/screens.js
@@ -76,4 +76,17 @@
 
     ok($("#error_503").length, "503 header is shown");
   });
+
+  test("XHR 403 (Forbidden) error - show the 403, cookies required error", function() {
+    var el = $("#error .contents");
+    el.empty();
+
+    screens.error.show("error", {
+      network: {
+        status: 403
+      }
+    });
+
+    ok($("#error_403").length, "403 header is shown");
+  });
 }());

--- a/resources/static/test/mocks/xhr.js
+++ b/resources/static/test/mocks/xhr.js
@@ -13,8 +13,7 @@ BrowserID.Mocks.xhr = (function() {
       authenticated: false,
       auth_level: undefined,
       code_version: "ABC123",
-      random_seed: "H+ZgKuhjVckv/H4i0Qvj/JGJEGDVOXSIS5RCOjY9/Bo=",
-      cookies_enabled: true
+      random_seed: "H+ZgKuhjVckv/H4i0Qvj/JGJEGDVOXSIS5RCOjY9/Bo="
     };
 
   // this cert is meaningless, but it has the right format

--- a/resources/views/cookies_disabled.ejs
+++ b/resources/views/cookies_disabled.ejs
@@ -1,0 +1,20 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+  <section id="error" class="cookies_disabled">
+      <div class="table">
+        <div class="vertical contents">
+          <h2 id="reason">
+            <%= gettext("We are sorry, BrowserID requires cookies") %>
+          </h2>
+
+          <p>
+            <%= gettext("BrowserID requires your browser's cookies to be enabled to operate. Please enable your browser's cookies and try again") %>
+          </p>
+          <p>
+            <%= gettext("To retry, you will have to close this window and try again.") %>
+          </p>
+        </div>
+      </div>
+  </section>

--- a/resources/views/cookies_disabled.ejs
+++ b/resources/views/cookies_disabled.ejs
@@ -6,14 +6,11 @@
       <div class="table">
         <div class="vertical contents">
           <h2 id="reason">
-            <%= gettext("We are sorry, BrowserID requires cookies") %>
+            <%= gettext("BrowserID requires cookies") %>
           </h2>
 
           <p>
-            <%= gettext("BrowserID requires your browser's cookies to be enabled to operate. Please enable your browser's cookies and try again") %>
-          </p>
-          <p>
-            <%= gettext("To retry, you will have to close this window and try again.") %>
+            <%- gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again") %>
           </p>
         </div>
       </div>

--- a/resources/views/cookies_disabled.ejs
+++ b/resources/views/cookies_disabled.ejs
@@ -10,7 +10,7 @@
           </h2>
 
           <p>
-            <%- gettext("Please close this window, <a target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'>enable cookies</a> and try again") %>
+            <%- format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ['http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked']) %>
           </p>
         </div>
       </div>

--- a/tests/cache-header-tests.js
+++ b/tests/cache-header-tests.js
@@ -93,6 +93,7 @@ suite.addBatch({
   '/sign_in': hasProperCacheHeaders('/sign_in'),
   '/communication_iframe': hasProperCacheHeaders('/communication_iframe'),
   '/unsupported_dialog': hasProperCacheHeaders('/unsupported_dialog'),
+  '/cookies_disabled': hasProperCacheHeaders('/cookies_disabled'),
   '/relay': hasProperCacheHeaders('/relay'),
   '/authenticate_with_primary': hasProperCacheHeaders('/authenticate_with_primary'),
   '/signup': hasProperCacheHeaders('/signup'),

--- a/tests/page-requests-test.js
+++ b/tests/page-requests-test.js
@@ -67,6 +67,7 @@ suite.addBatch({
   'GET /.well-known/browserid':  respondsWith(200),
   'GET /signin':                 respondsWith(200),
   'GET /unsupported_dialog':     respondsWith(200),
+  'GET /cookies_disabled':       respondsWith(200),
   'GET /developers':             respondsWith(200),
   'GET /manage':                 respondsWith(302),
   'GET /users':                  respondsWith(302),


### PR DESCRIPTION
- Add a new view, cookies_disabled - this is displayed to browsers that do not allow access to localStorage when cookies are disabled (Firefox, Chrome, Fennec)
- Add localStorage check in include.js to check for browsers that do not allow write access to localStorage.
- Add a Javascript cookie check in network.js->cookiesEnabled using a test cookie with duration of 1 second so it is never sent to the server.
- Remove the old cookies_enabled check that was theorized to come from session_context - remove this from the XHR mock as well.

issue #835
