### PR TITLE
Cherry picking the cookies enabled check and test from the feature_835_cookies_disabled branch.

### DIFF
--- a/resources/static/shared/network.js
+++ b/resources/static/shared/network.js
@@ -13,7 +13,6 @@ BrowserID.Network = (function() {
       domain_key_creation_time,
       auth_status,
       code_version,
-      cookies_enabled,
       time_until_delay,
       mediator = bid.Mediator,
       xhr = bid.XHR,
@@ -29,7 +28,6 @@ BrowserID.Network = (function() {
     domain_key_creation_time = result.domain_key_creation_time;
     auth_status = result.auth_level;
     code_version = result.code_version;
-    cookies_enabled = result.cookies_enabled || true;
 
     // seed the PRNG
     // FIXME: properly abstract this out, probably by exposing a jwcrypto
@@ -570,8 +568,19 @@ BrowserID.Network = (function() {
      * @method cookiesEnabled
      */
     cookiesEnabled: function(onComplete, onFailure) {
+      // Make sure we get context first or else we will needlessly send
+      // a cookie to the server.
       withContext(function() {
-        complete(onComplete, cookies_enabled);
+        try {
+          // set a test cookie with a duration of 1 second.
+          // NOTE - The Android 3.3 default browser will still pass this.
+          // http://stackoverflow.com/questions/8509387/android-browser-not-respecting-cookies-disabled/9264996#9264996
+          document.cookie = "test=true; max-age=1";
+          var enabled = document.cookie.indexOf("test") > -1;
+          complete(onComplete, enabled);
+        } catch(e) {
+          complete(onComplete, false);
+        }
       }, onFailure);
     }
   };

--- a/resources/static/test/cases/shared/network.js
+++ b/resources/static/test/cases/shared/network.js
@@ -541,18 +541,11 @@
     failureCheck(network.changePassword, "oldpassword", "newpassword");
   });
 
-  asyncTest("cookiesEnabled with cookies enabled", function() {
-    transport.setContextInfo("cookies_enabled", true);
-
+  asyncTest("cookiesEnabled with cookies enabled - return true status", function() {
     network.cookiesEnabled(function(status) {
       equal(status, true, "cookies are enabled, correct status");
       start();
     }, testHelpers.unexpectedXHRFailure);
-  });
-
-  asyncTest("cookiesEnabled with XHR failure", function() {
-    transport.useResult("contextAjaxError");
-    failureCheck(network.cookiesEnabled);
   });
 
 }());


### PR DESCRIPTION
This is to inform iOS users whose cookies have been disabled during a sync that they need to turn their cookies on.

close #1056
