### PR TITLE
Adding a 20px left and right margin to the delay, wait, and error screens

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -132,6 +132,9 @@ section > .contents {
     color: #777;
 }
 
+#wait .vertical, #error .vertical, #delay .vertical {
+    padding: 0 20px;
+}
 
 #formWrap {
     background-color: #fff;


### PR DESCRIPTION
This prevents long text from butting directly up to the edges in these screens. 

close #1117
