### PR TITLE
Fixing long email addresses (and some other general layout fixes) in pick_email.

### DIFF
--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -51,13 +51,11 @@
   }
 
   #signIn {
-      max-width: none;
       padding: 10px;
   }
 
-  #signIn .table {
+  #signIn .container {
       width: 100%;
-      margin: 0;
   }
 
   #signIn form {
@@ -101,11 +99,16 @@
   }
 
   #signIn .vertical {
-    padding-bottom: 0;
+    padding: 10px;
   }
 
   #signIn .vertical ul li {
     margin-top: 20px;
+  }
+
+  #selectEmail > .inputs > li > label {
+    margin: 0;
+    padding: 15px 1px;
   }
 
   #signIn .submit {

--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -18,16 +18,18 @@ h2 {
 }
 
 
+.vertical {
+    height: 250px;
+}
+
 .table {
     display: table;
     width: 100%;
 }
 
-.vertical {
-    height: 250px;
+.table .vertical {
     display: table-cell;
     vertical-align: middle;
-    width: 100%;
 }
 
 #content {
@@ -84,6 +86,7 @@ section > .contents {
 #wait, #delay {
   background-image: url("/i/bg.png");
 }
+
 
 .waiting #wait {
     z-index: 1;
@@ -146,9 +149,12 @@ section > .contents {
     top: 0;
 }
 
-#signIn .table {
+#signIn .container {
+    /**
+     * Set the width of the container for when the arrow animation happens
+     * otherwise the buttons slide right with the arrow
+     */
     width: 325px;
-    margin-right: 40px;
 }
 
 .arrow {
@@ -196,12 +202,12 @@ div#required_email {
 }
 
 #signIn .vertical {
-    padding: 0 20px;
+    padding: 20px 52px 20px 20px;
+    position: relative;
 }
 
 #signIn .vertical ul {
   list-style-type: none;
-  position: relative;
 }
 
 #signIn .vertical ul li {
@@ -215,9 +221,9 @@ div#required_email {
 #signIn .submit {
     line-height: 28px;
     position: absolute;
-    bottom: 0;
+    bottom: 20px;
     left: 0;
-    right: 0;
+    right: 52px;
 }
 
 #signIn .submit > p {
@@ -258,6 +264,17 @@ label.selectable {
 
 .inputs > li > label {
     color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#signIn #selectEmail > .inputs > li {
+    margin: 0;
+}
+
+#selectEmail > .inputs > li > label {
+    padding: 5px 1px;
+    white-space: nowrap;
 }
 
 .inputs > li > label.preselected {
@@ -322,19 +339,9 @@ footer {
 
 .inputs {
     margin: 1em 0 .5em;
-    padding: 0 1em;
     line-height: 18px;
     max-height: 130px;
     overflow-y: auto;
-}
-
-.pickemail .inputs {
-    position: relative;
-}
-
-.form_section {
-    height: 176px;
-    position: relative;
 }
 
 .add {
@@ -351,12 +358,7 @@ label[for=remember] {
 }
 
 #thisIsNotMe {
-  margin-right: 10px;
   float: right;
-}
-
-#useNewEmail {
-  margin-left: 0.8em;
 }
 
 a.emphasize {
@@ -369,7 +371,7 @@ a.emphasize {
 }
 
 .submit > button {
-    margin: 0 5px 0 0;
+    margin: 0 0 0 5px;
 }
 
 #newEmail {

--- a/resources/static/dialog/views/pick_email.ejs
+++ b/resources/static/dialog/views/pick_email.ejs
@@ -9,11 +9,10 @@
       <ul class="inputs">
           <% _.each(identities, function(item) { var emailAddress = item.address; var cleanedEmail = emailAddress.replace("@","_").replace(".", "_"); %>
               <li>
-
-                  <label for="<%= cleanedEmail %>" class="serif<% if (emailAddress === siteemail) { %> preselected<% } %> selectable">
+                  <label for="<%= cleanedEmail %>" class="serif<% if (emailAddress === siteemail) { %> preselected<% } %> selectable" title="<%= emailAddress %>">
                     <input type="radio" name="email" id="<%= cleanedEmail %>" value="<%= emailAddress %>"
-                      <% if (emailAddress === siteemail) { %> checked="checked" <% } %>
-                    />
+                        <% if (emailAddress === siteemail) { %> checked="checked" <% } %>
+                      />
                     <%= emailAddress %>
                   </label>
               </li>

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -11,9 +11,8 @@
 
         <div id="signIn">
             <div class="arrow"></div>
-            <div class="table">
-                <div class="vertical contents">
-                </div>
+            <div class="container">
+              <div class="vertical contents"></div>
             </div>
         </div>
       </form>
@@ -21,6 +20,7 @@
 
 
     <section id="wait">
+        <!-- because each section is an absolutely positioned element, we have to use the inner table container element to be able to vertically/horizontally center correctly.  Without the table element, the layout gets all messed up. -->
         <div class="table">
             <div class="vertical contents">
                 <h2><%= gettext('Communicating with server') %></h2>


### PR DESCRIPTION
- Long email addresses stay on one line and show an ellipsis when too long.
- Cleaning up some of the button placement so that things are more lined up.

close #1100
