### PR TITLE
Fix the extended error info not opening.

### DIFF
--- a/resources/static/pages/page_helpers.js
+++ b/resources/static/pages/page_helpers.js
@@ -63,6 +63,7 @@ BrowserID.PageHelpers = (function() {
   function showFailure(error, info, callback) {
     info = $.extend(info || {}, { action: error, dialog: false });
     bid.Screens.error.show("error", info);
+    errorDisplay.start();
     callback && callback(false);
   }
 

--- a/resources/static/test/cases/pages/page_helpers.js
+++ b/resources/static/test/cases/pages/page_helpers.js
@@ -147,10 +147,22 @@
     });
   });
 
-  asyncTest("showFailure shows a failure screen", function() {
-    pageHelpers.showFailure({}, errors.offline, function() {
+  asyncTest("showFailure - show a failure screen, extended info can be opened", function() {
+    pageHelpers.showFailure("error", { network: 400, status: "error"}, function() {
       testHelpers.testErrorVisible();
-      start();
+
+      // We have to make sure the error screen itself is visible and that the
+      // extra info is hidden so when we click on the extra info it opens.
+      $("#error").show();
+      $("#moreInfo").hide();
+      $("#openMoreInfo").trigger("click");
+
+      // Add a bit of delay to wait for the animation
+      setTimeout(function() {
+        equal($("#moreInfo").is(":visible"), true, "extra info is visible after click");
+        start();
+      }, 100);
+
     });
   });
 


### PR DESCRIPTION
- Add BrowserID.ErrorDisplay.start() to showFailure - this handles opening the extended info.
- Add a test to make sure clicking on the openMoreInfo button shows the extended info.

close #1139
