### PR TITLE
Fix the "sign in" and "use a different email" buttons overlapping in some languages.

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -347,6 +347,15 @@ footer {
     overflow-y: auto;
 }
 
+/* Some languages have long text for the "sign in" and "use a different email"
+ * buttons.  If the user >= 6 emails in these languages, the buttons overlap.
+ * This shrinks the email address box by one address to prevent this overlap.
+ */
+#selectEmail .inputs {
+    max-height: 115px;
+}
+
+
 .add {
     font-size: 80%;
 }

--- a/resources/static/dialog/views/pick_email.ejs
+++ b/resources/static/dialog/views/pick_email.ejs
@@ -30,9 +30,6 @@
           <% } %>
 
           <button id="signInButton"><%= gettext('sign in') %></button>
-
-          <p>
-          </p>
       </div>
   </div>
 


### PR DESCRIPTION
@ozten - Can you review this one?

Some languages have long text for the "sign in" and "use a different email" buttons.  If the user >= 6 emails in these languages, the buttons overlap. This shrinks the email address box by one address to prevent this overlap.

close #1105
