### PR TITLE
Fix zoom/scrolling issues across platforms.

### DIFF
--- a/resources/static/css/common.css
+++ b/resources/static/css/common.css
@@ -21,7 +21,7 @@ body {
   font-size: 13px;
   line-height: 21px;
   background-image: url('/i/bg.png');
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 /* for floats */

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -354,7 +354,7 @@
             }
           }, timeout);
         }
-        
+
         var onMessage = function(origin, method, m) {
           // if an observer was specified at allocation time, invoke it
           if (typeof cfg.gotMessageObserver === 'function') {
@@ -914,7 +914,7 @@
     var isFennec = navigator.userAgent.indexOf('Fennec/') != -1;
     var windowOpenOpts =
       (isFennec ? undefined :
-       "menubar=0,location=1,resizable=0,scrollbars=0,status=0,dialog=1,width=700,height=375");
+       "menubar=0,location=1,resizable=1,scrollbars=1,status=0,dialog=1,width=700,height=375");
 
     var w;
 


### PR DESCRIPTION
- Set both resizable and scrollbars to 1 for users who have their browsers zoomed.
- Set the body's overflow-y to auto so no scrollbars are shown unless they are needed.

issue #423
