### PR TITLE
Fix the pick_email test failure when all tests are run.

### DIFF
--- a/resources/static/test/cases/pages/add_email_address_test.js
+++ b/resources/static/test/cases/pages/add_email_address_test.js
@@ -25,7 +25,6 @@
     },
     teardown: function() {
       testHelpers.teardown();
-      $("#page_head").empty();
     }
   });
 

--- a/resources/static/test/cases/shared/helpers.js
+++ b/resources/static/test/cases/shared/helpers.js
@@ -7,15 +7,17 @@
   "use strict";
 
   var bid = BrowserID,
-      helpers = bid.Helpers;
+      helpers = bid.Helpers,
+      testHelpers = bid.TestHelpers;
 
   module("shared/helpers", {
     setup: function() {
+      testHelpers.setup();
       bid.Renderer.render("#page_head", "site/add_email_address", {});
     },
 
     teardown: function() {
-      $("#page_head").empty();
+      testHelpers.teardown();
     }
   });
 

--- a/resources/static/test/cases/shared/renderer.js
+++ b/resources/static/test/cases/shared/renderer.js
@@ -7,40 +7,32 @@
   "use strict";
 
   var bid = BrowserID,
-      renderer = bid.Renderer;
+      renderer = bid.Renderer,
+      testHelpers = bid.TestHelpers;
 
   module("shared/renderer", {
     setup: function() {
-
+      testHelpers.setup();
     },
 
     teardown: function() {
-
+      testHelpers.teardown();
     }
   });
 
   test("render template loaded using XHR", function() {
-    $("#formWrap .contents").empty();
-    $("#templateInput").remove();
-
     renderer.render("#formWrap .contents", "test_template_with_input");
 
     ok($("#templateInput").length, "template written when loaded using XHR");
   });
 
   test("render template from memory", function() {
-    $("#formWrap .contents").empty();
-    $("#templateInput").remove();
-
     renderer.render("#formWrap .contents", "inMemoryTemplate");
 
     ok($("#templateInput").length, "template written when loaded from memory");
   });
 
   test("append template to element", function() {
-    $("#formWrap .contents").empty();
-    $("#templateInput").remove();
-
     renderer.append("#formWrap", "inMemoryTemplate");
 
     ok($("#formWrap > #templateInput").length && $("#formWrap > .contents"), "template appended to element instead of overwriting it");

--- a/resources/static/test/cases/shared/screens.js
+++ b/resources/static/test/cases/shared/screens.js
@@ -8,23 +8,21 @@
 
   var bid = BrowserID,
       screens = bid.Screens,
+      testHelpers = bid.TestHelpers,
       el;
 
   module("shared/screens", {
     setup: function() {
-
+      testHelpers.setup();
     },
 
     teardown: function() {
-      if (el) {
-        el.empty();
-      }
+      testHelpers.teardown();
     }
   });
 
   test("form", function() {
     el = $("#formWrap .contents");
-    el.empty();
     screens.form.show("test_template_with_input");
 
     ok($("#templateInput").length, "the template has been written");
@@ -38,7 +36,6 @@
 
   test("wait", function() {
     var el = $("#wait .contents");
-    el.empty();
     screens.wait.show("test_template_with_input");
 
     ok($("#templateInput").length, "the template has been written");
@@ -52,7 +49,6 @@
 
   test("error", function() {
     var el = $("#error .contents");
-    el.empty();
     screens.error.show("test_template_with_input");
 
     ok($("#templateInput").length, "the template has been written");
@@ -66,7 +62,6 @@
 
   test("XHR 503 (server unavailable) error", function() {
     var el = $("#error .contents");
-    el.empty();
 
     screens.error.show("error", {
       network: {
@@ -79,7 +74,6 @@
 
   test("XHR 403 (Forbidden) error - show the 403, cookies required error", function() {
     var el = $("#error .contents");
-    el.empty();
 
     screens.error.show("error", {
       network: {

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -68,15 +68,13 @@ BrowserID.TestHelpers = (function() {
       $("body").stop().show();
       $("body")[0].className = "";
 
-      var el = $("#controller_head");
-      el.find("#formWrap .contents").html("");
-      el.find("#wait .contents").html("");
       $(".error").removeClass("error");
-      $("#error").stop().html("<div class='contents'></div>").hide();
+      $("#error").hide();
       $(".notification").stop().hide();
       $("form").show();
       screens.wait.hide();
       screens.error.hide();
+      screens.delay.hide();
       tooltip.reset();
       provisioning.setStatus(provisioning.NOT_AUTHENTICATED);
       user.reset();
@@ -96,12 +94,9 @@ BrowserID.TestHelpers = (function() {
       });
       network.init();
       storage.clear();
-      $(".error").removeClass("error");
-      $("#error").stop().html("<div class='contents'></div>").hide();
-      $(".notification").stop().hide();
-      $("form").show();
       screens.wait.hide();
       screens.error.hide();
+      screens.delay.hide();
       tooltip.reset();
       provisioning.setStatus(provisioning.NOT_AUTHENTICATED);
       user.reset();

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -21,7 +21,7 @@
 		<ol id="qunit-tests"></ol>
 		<div id="qunit-test-area"></div>
 
-    <div style="position: absolute; top: -1000px; left: 100px; right: 100px; height: 300px;">
+    <div id="qunit-fixture" style="position: absolute; top: -1000px; left: 100px; right: 100px; height: 300px;">
         <a href="#" onclick="$('#contents').hide(); return false;">Close</a>
         <h3>Test Contents, this will be updated and can be safely ignored</h3>
 


### PR DESCRIPTION
The problem stemmed from the DOM was not completely reset between every test.  When the manage page inserted email addresses into its portion of the DOM, it added email addresses with elements with the same ID as the pick email controller.  Instead of ensuring we clean wipe these elements between every test, rely on QUnit's ability to reset a portion of the DOM to its initial state.
- Add the `qunit-fixture` id to the bit of DOM that should be reset between every test run.
- Add the testHelpers.setup/testHelpers.teardown functions to several suites that manually called emtpy() on DOM elements.

issue #1156
