### PR TITLE
Removing the href/target attributes from translated anchor tags.

### DIFF
--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -11,7 +11,7 @@
     <h2 id="error_403">
       <%= gettext("BrowserID required cookies") %>
     </h2>
-    <%= format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ['http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked']) %>
+    <%= format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'"]) %>
   <% } else { %>
     <h2 id="defaultError">
       <%= gettext("We are very sorry, there has been an error!") %>

--- a/resources/static/shared/error-messages.js
+++ b/resources/static/shared/error-messages.js
@@ -47,7 +47,7 @@ BrowserID.Errors = (function(){
 
     cookiesDisabled: {
       title: gettext("BrowserID requires cookies"),
-      message: format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ["http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked"])
+      message: format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'"])
     },
 
     cookiesEnabled: {

--- a/resources/views/cookies_disabled.ejs
+++ b/resources/views/cookies_disabled.ejs
@@ -10,7 +10,7 @@
           </h2>
 
           <p>
-            <%- format(gettext("Please close this window, <a target='_blank' href='%s'>enable cookies</a> and try again"), ['http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked']) %>
+            <%- format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'"]) %>
           </p>
         </div>
       </div>

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -38,7 +38,7 @@
                 </ul-->
 
                 <div class="learn">
-<%- gettext('BrowserID is the fast and secure way to sign in &mdash; <a target="_blank" href="/about">learn more</a>') %>
+<%- format(gettext('BrowserID is the fast and secure way to sign in &mdash; <a %s>learn more</a>'), [" href='/about' target='_blank'"]) %>
                 </div>
 
           </footer>

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -43,8 +43,8 @@
 
     <footer id="footer">
         <ul class="cf">
-            <li><%- format(gettext('By the <a href="%s" target="_blank">Identity Team</a> @ <a href="%s" target="_blank">Mozilla Labs</a>'),
-                           ['http://identity.mozilla.com', 'http://mozillalabs.com']) %></li>
+            <li><%- format(gettext('By the <a %s>Identity Team</a> @ <a %s>Mozilla Labs</a>'),
+                           [" href='http://identity.mozilla.com' target='_blank'", " href='http://mozillalabs.com' target='_blank'"]) %></li>
             <li>&mdash;</li>
             <li><a href="/privacy"><%= gettext('Privacy') %></a></li>
             <li><a href="/tos"><%= gettext('TOS') %></a></li>


### PR DESCRIPTION
@ozten, @mathjazz - can you guys review this?

Instead, translators will see a %s and the href and target attributes will be added dynamically.

issue #1160
