### PR TITLE
When the user successfully authenticates, log them in automatically with out going to the email picker.

### DIFF
--- a/resources/static/dialog/resources/state.js
+++ b/resources/static/dialog/resources/state.js
@@ -162,6 +162,8 @@ BrowserID.State = (function() {
     });
 
     subscribe("email_chosen", function(msg, info) {
+      info = info || {};
+
       var email = info.email,
           idInfo = storage.getEmail(email);
 
@@ -214,7 +216,7 @@ BrowserID.State = (function() {
     });
 
     subscribe("authenticated", function(msg, info) {
-      publish("pick_email");
+      publish("email_chosen", info);
     });
 
     subscribe("forgot_password", function(msg, info) {

--- a/resources/static/test/cases/resources/state.js
+++ b/resources/static/test/cases/resources/state.js
@@ -170,10 +170,11 @@
     ok(actions.called.doEmailChosen, "doEmailChosen called");
   });
 
-  test("authenticated", function() {
-    mediator.publish("authenticated");
+  test("authenticated - call doEmailChosen", function() {
+    storage.addEmail("testuser@testuser.com", {});
+    mediator.publish("authenticated", { email: "testuser@testuser.com" });
 
-    ok(actions.called.doPickEmail, "doPickEmail has been called");
+    ok(actions.called.doEmailChosen, "doEmailChosen has been called");
   });
 
   test("forgot_password", function() {


### PR DESCRIPTION
This only affects when users must fill out their username and password, it does not affect if the user is already authenticated with BrowserID or for required email.

issue #198
