### PR TITLE
adding support for travis ci. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+ 
+before_install:
+ - sudo apt-get install libgmp3-dev
+
+node_js:
+ - 0.6
+
+notifications:
+  irc: "irc.mozilla.org#identity"


### PR DESCRIPTION
This will run on every commit and then a message to IRC to say if was successful or not. http://travis-ci.org/#!/AutomatedTester/browserid is an example. 

By having this here, even if we have our own CI environmnent in the future, is that contributors can just switch on Travis-CI for the project and when they commit they will get details of failures or passes and gives us an indication if the patch is good before we even merge it.

This can run as an interim until other CI tasks are setup. Currently this only tests the backend items of code. 

This will need a manual step of getting it running by following http://about.travis-ci.org/docs/user/how-to-setup-and-trigger-the-hook-manually/. I am happy to do this since I am a Mozilla admin on github if you want.
