### PR TITLE
Adding more tests to make sure when the user sets a password, the min/max password lengths are checked.

### DIFF
--- a/resources/static/test/cases/pages/add_email_address_test.js
+++ b/resources/static/test/cases/pages/add_email_address_test.js
@@ -133,10 +133,7 @@
   });
 
   asyncTest("password: too long of a password", function() {
-    var tooLong = "";
-    for(var i = 0; i < 81; i++) {
-      tooLong += (i % 10);
-    }
+    var tooLong = testHelpers.generateString(81);
     $("#password").val(tooLong);
     $("#vpassword").val(tooLong);
 

--- a/resources/static/test/cases/pages/manage_account.js
+++ b/resources/static/test/cases/pages/manage_account.js
@@ -201,14 +201,10 @@
   asyncTest("changePassword with too long of a password - tooltip", function() {
     bid.manageAccount(mocks, function() {
       $("#old_password").val("oldpassword");
-      var tooLong = "";
-      for(var i = 0; i < 81; i++) {
-        tooLong += (i % 10);
-      }
-      $("#new_password").val(tooLong);
+      $("#new_password").val(testHelpers.generateString(81));
 
       bid.manageAccount.changePassword(function(status) {
-        equal(status, false, "on too short of a password, status is false");
+        equal(status, false, "on too long of a password, status is false");
         testHelpers.testTooltipVisible();
         start();
       });

--- a/resources/static/test/cases/pages/verify_email_address_test.js
+++ b/resources/static/test/cases/pages/verify_email_address_test.js
@@ -11,6 +11,7 @@
       storage = bid.Storage,
       xhr = bid.Mocks.xhr,
       testHelpers = bid.TestHelpers,
+      testTooltipVisible = testHelpers.testTooltipVisible,
       validToken = true;
 
   module("pages/verify_email_address", {
@@ -82,6 +83,35 @@
 
       bid.verifyEmailAddress.submit(function() {
         equal($("#congrats").is(":visible"), false, "congrats is not visible, missing password");
+        testTooltipVisible();
+        start();
+      });
+    });
+  });
+
+  asyncTest("submit with good token, too short of a password", function() {
+    bid.verifyEmailAddress("token", function() {
+      var pass = testHelpers.generateString(6);
+      $("#password").val(pass);
+      $("#vpassword").val(pass);
+
+      bid.verifyEmailAddress.submit(function() {
+        equal($("#congrats").is(":visible"), false, "congrats is not visible, too short of a password");
+        testTooltipVisible();
+        start();
+      });
+    });
+  });
+
+  asyncTest("submit with good token, too long of a password", function() {
+    bid.verifyEmailAddress("token", function() {
+      var pass = testHelpers.generateString(81);
+      $("#password").val(pass);
+      $("#vpassword").val(pass);
+
+      bid.verifyEmailAddress.submit(function() {
+        equal($("#congrats").is(":visible"), false, "congrats is not visible, too long of a password");
+        testTooltipVisible();
         start();
       });
     });
@@ -96,6 +126,7 @@
 
     bid.verifyEmailAddress.submit(function() {
       equal($("#congrats").is(":visible"), false, "congrats is not visible, missing verification password");
+      testTooltipVisible();
       start();
     });
 
@@ -109,6 +140,7 @@
 
     bid.verifyEmailAddress.submit(function() {
       equal($("#congrats").is(":visible"), false, "congrats is not visible, different passwords");
+      testTooltipVisible();
       start();
     });
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -180,6 +180,17 @@ BrowserID.TestHelpers = (function() {
       }
 
       cb && cb.apply(null, args);
+    },
+
+    /**
+     * Generate a long string
+     */
+    generateString: function(length) {
+      var str = "";
+      for(var i = 0; i < length; i++) {
+        str += (i % 10);
+      }
+      return str;
     }
   };
 


### PR DESCRIPTION
This is a test only change to add some new tests to ensure password lengths are within bounds when setting passwords as well as clean up generation of long strings.
- to testHelpers, add a generateString function which generates a string of the specified length.
- Replace the manual creation of strings for long passwords with generateString.
- To verify_email_address_test, adding checks for min and max length when setting the password.

issue #1173
