### PR TITLE
Changing the "pick email" string to "sign in"

### DIFF
--- a/resources/static/dialog/views/authenticate.ejs
+++ b/resources/static/dialog/views/authenticate.ejs
@@ -58,6 +58,6 @@
           <button class="start" tabindex="3"><%= gettext('next') %></button>
           <button class="newuser" tabindex="3"><%= gettext('verify email') %></button>
 
-          <button class="returning" tabindex="3"><%= gettext('select email') %></button>
+          <button class="returning" tabindex="3"><%= gettext('sign in') %></button>
       </div>
   </div>


### PR DESCRIPTION
Since we merged #198, when the user enters their authentication credentials we no longer show the email picker.  Instead of showing "pick email", show "sign in"

issue #1185
