### PR TITLE
Hotfix 1170 graduating banner

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,7 @@ train-2012.02.02:
   * (hotfix 2012.02.07) Modify build process to pick up locales from a .json file
   * (hotfix 2012.02.07) fix production-locales.sh script to defer to the environment for configuration
   * (hotfix 2012.02.13) fix for IE users not seeing error screens sometimes: #1087
+  * (hotfix 2012.02.22) add banner announcing brand change
 
 train-2012.01.18:
   * support for 3rd party primary identity providers: #761, #904, #865

--- a/resources/static/css/m.css
+++ b/resources/static/css/m.css
@@ -99,7 +99,7 @@
     padding: 0 10px;
     font-size: 16px;
     line-height: 21px;
-    margin: 122px 0 122px;
+    margin: 0 0 90px;  /* Add a bottom margin so the footer is never overlapped. */
   }
 
   #signUp p {
@@ -231,4 +231,8 @@
     float: right;
   }
 
+  #newsbanner {
+    margin: 115px 0 28px 0; /* put a margin-top on so that it does not go under the header */
+
+  }
 }

--- a/resources/static/css/style.css
+++ b/resources/static/css/style.css
@@ -808,3 +808,18 @@ footer {
   bottom: 0;
 }
 
+#newsbanner {
+  background-color: #faca33;
+  line-height: 32px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+  text-align: center;
+  color: #626160;
+  text-shadow: 1px 1px 0 rgba(255,255,255,0.5);
+  height: 32px;
+  -webkit-transition: all 500ms;
+  -moz-transition: all 500ms;
+  -ms-transition: all 500ms;
+  -o-transition: all 500ms;
+  transition: all 500ms;
+}

--- a/resources/static/css/style.css
+++ b/resources/static/css/style.css
@@ -809,6 +809,7 @@ footer {
 }
 
 #newsbanner {
+  margin-top: 60px; /* put a margin-top on so that it does not go under the header */
   background-color: #faca33;
   line-height: 32px;
   border-radius: 4px;
@@ -816,7 +817,6 @@ footer {
   text-align: center;
   color: #626160;
   text-shadow: 1px 1px 0 rgba(255,255,255,0.5);
-  height: 32px;
   -webkit-transition: all 500ms;
   -moz-transition: all 500ms;
   -ms-transition: all 500ms;

--- a/resources/views/index.ejs
+++ b/resources/views/index.ejs
@@ -52,6 +52,10 @@
   </div>
 
   <div id="vAlign" class="display_nonauth">
+      <div id="newsbanner">
+        BrowserID is graduating: we're launching <b>Mozilla Persona</b>. Find out more on <a href="http://identity.mozilla.com/">the identity blog</a>.
+      </div>
+
       <div id="signUp">
           <div id="card"><img src="/i/slit.png"></div>
           <div id="hint"></div>

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2012.02.16
-Release:       1%{?dist}_%{svnrev}
+Release:       2%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Pete Fritchman <petef@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
@lloyd - can you review this?

I have taken the original train-2012.02.16 from browserid_private and made CSS changes to ensure that the banner is both the correct size and does not get pushed under the header.

It shows up as 3 commits because this includes the original hotfix commits to the other repo.

The relevant changes are in style.css and m.css, 3 sections were added/modified.  The relevant changes can be seen in: b40442b5fd2de8f58c343c271514ef4ca1fd8381

Things to test:
1) Banner looks right in both mobile and desktop.
2) Banner never goes under the header.
3) When window is narrow, banner expands to 2 or 3 lines as needed.
4) Sign in/sign up/manage/verify email/user are not affected.

When complete, can you cherry-pick b40442b into dev?
