### PR TITLE
Adding script to check if all locales have committed to SVN

### DIFF
--- a/scripts/check_po.sh
+++ b/scripts/check_po.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# syntax:
+# check-po.sh
+
+for lang in `find locale -type f -name "*.po"`; do
+    dir=`dirname $lang`
+    stem=`basename $lang .po`
+    printf "${lang}: "
+    msgfmt --statistics ${dir}/${stem}.po
+done
+rm messages.mo


### PR DESCRIPTION
Most of the localiers work with our web-based tool Verbatim:
https://localize.mozilla.org/projects/browserid/

Some of them keep forgetting to commit their translations to SVN when they're done.

I need this script to quickly check if all of the locales that are ready for shipping also committed their work to the repo from which we're taking translations.
