### PR TITLE
Handle moz-prefixed navigator.id property for Gecko's prototype native implementation

### DIFF
--- a/resources/static/authentication_api.js
+++ b/resources/static/authentication_api.js
@@ -7,6 +7,10 @@
 (function() {
   "use strict";
 
+  if (navigator.mozid) {
+    navigator.id = navigator.mozid;
+  }
+
   if (!navigator.id) {
     navigator.id = {};
   }

--- a/resources/static/provisioning_api.js
+++ b/resources/static/provisioning_api.js
@@ -621,6 +621,10 @@
     };
   })();
 
+  if (navigator.mozid) {
+    navigator.id = navigator.mozid;
+  }
+
   if (!navigator.id) {
     navigator.id = {};
   }


### PR DESCRIPTION
We will want to vendor prefix the prototype implementation in Gecko.  The shim needs to pick up the moz-prefixed property.
