### PR TITLE
Issue 1133 email with plus

### DIFF
--- a/resources/static/dialog/views/pick_email.ejs
+++ b/resources/static/dialog/views/pick_email.ejs
@@ -7,10 +7,10 @@
 
   <div id="selectEmail" class="form_section">
       <ul class="inputs">
-          <% _.each(identities, function(item) { var emailAddress = item.address; var cleanedEmail = emailAddress.replace("@","_").replace(".", "_"); %>
+          <% _.each(identities, function(item, index) { var emailAddress = item.address, id = "email_" + index; %>
               <li>
-                  <label for="<%= cleanedEmail %>" class="serif<% if (emailAddress === siteemail) { %> preselected<% } %> selectable" title="<%= emailAddress %>">
-                    <input type="radio" name="email" id="<%= cleanedEmail %>" value="<%= emailAddress %>"
+                  <label for="<%= id %>" class="serif<% if (emailAddress === siteemail) { %> preselected<% } %> selectable" title="<%= emailAddress %>" >
+                    <input type="radio" name="email" id="<%= id %>" value="<%= emailAddress %>"
                         <% if (emailAddress === siteemail) { %> checked="checked" <% } %>
                       />
                     <%= emailAddress %>

--- a/resources/static/test/cases/controllers/pick_email.js
+++ b/resources/static/test/cases/controllers/pick_email.js
@@ -46,12 +46,10 @@
 
     createController();
 
-    var firstLI = $("#first_testuser_com").closest("li");
-    var secondLI = $("#second_testuser_com").closest("li");
-    var thirdLI = $("#third_testuser_com").closest("li");
-
-    equal(firstLI.next().is(secondLI), true, "first is before second");
-    equal(secondLI.next().is(thirdLI), true, "second is before third");
+    var inputs = $(".inputs input[type=radio]");
+    equal(inputs.eq(0).val(), "first@testuser.com", "correct email for the first element");
+    equal(inputs.eq(1).val(), "second@testuser.com", "correct email for the second element");
+    equal(inputs.eq(2).val(), "third@testuser.com", "correct email for the third element");
   });
 
   test("pickemail controller with email associated with site - check correct email", function() {
@@ -156,20 +154,37 @@
   });
 
   test("click on an email label and radio button - select corresponding radio button", function() {
-    storage.addEmail("testuser@testuser.com", {});
     storage.addEmail("testuser2@testuser.com", {});
+    storage.addEmail("testuser@testuser.com", {});
 
     createController(false);
 
-    equal($("#testuser_testuser_com").is(":checked"), false, "radio button is not selected before click.");
+    equal($("#email_1").is(":checked"), false, "radio button is not selected before click.");
 
     // selects testuser@testuser.com
-    $("label[for=testuser_testuser_com]").trigger("click");
-    equal($("#testuser_testuser_com").is(":checked"), true, "radio button is correctly selected");
+    $(".inputs label:eq(1)").trigger("click");
+    equal($("#email_1").is(":checked"), true, "radio button is correctly selected");
 
     // selects testuser2@testuser.com
-    $("#testuser2_testuser_com").trigger("click");
-    equal($("#testuser2_testuser_com").is(":checked"), true, "radio button is correctly selected");
+    $(".inputs label:eq(0)").trigger("click");
+    equal($("#email_0").is(":checked"), true, "radio button is correctly selected");
+  });
+
+  test("click on an email label that contains a + - select corresponding radio button", function() {
+    storage.addEmail("testuser+test0@testuser.com", {});
+    storage.addEmail("testuser+test1@testuser.com", {});
+
+    createController(false);
+
+    equal($("#email_1").is(":checked"), false, "radio button is not selected before click.");
+
+    // selects testuser+test1@testuser.com
+    $(".inputs label:eq(1)").trigger("click");
+    equal($("#email_1").is(":checked"), true, "radio button is correctly selected");
+
+    // selects testuser+test0@testuser.com
+    $(".inputs label:eq(0)").trigger("click");
+    equal($("#email_0").is(":checked"), true, "radio button is correctly selected");
   });
 
   test("click on the 'Always sign in...' label and checkbox - correct toggling", function() {


### PR DESCRIPTION
@lloyd or @ozten - can you check this?

The original problem stems from DOM id's not being allowed to contain certain characters such as a "+" and jQuery not being able to search for an element with an ID that contains a ".".  Instead of basing the radio button's id on the email address, using a generic "email_" + <number>.  <number> is the index of the address in the list, so each id is unique.  @tonychung's update in issue #1133 is incomplete, an email address containing a `+` was not able to be selected by clicking on the text in any browser/OS - this is not an iOS specific problem.

Things to check:
- email addresses that contain `+` and `.` in the local portion work.
- email addresses can be selected by clicking on the text on iPhones/iPods

Post Merge:
Please cherry-pick or merge into dev and re-close issue #1133.

issue #1133
