### PR TITLE
Fix cookiesEnabled being possible to call it's onComplete callback twice if onComplete throws an exception the first time.

### DIFF
--- a/resources/static/shared/network.js
+++ b/resources/static/shared/network.js
@@ -577,10 +577,11 @@ BrowserID.Network = (function() {
           // http://stackoverflow.com/questions/8509387/android-browser-not-respecting-cookies-disabled/9264996#9264996
           document.cookie = "test=true; max-age=1";
           var enabled = document.cookie.indexOf("test") > -1;
-          complete(onComplete, enabled);
         } catch(e) {
-          complete(onComplete, false);
+          enabled = false;
         }
+
+        complete(onComplete, enabled);
       }, onFailure);
     }
   };

--- a/resources/static/test/cases/shared/network.js
+++ b/resources/static/test/cases/shared/network.js
@@ -548,4 +548,21 @@
     }, testHelpers.unexpectedXHRFailure);
   });
 
+  asyncTest("cookiesEnabled with onComplete exception thrown - should not call onComplete a second time", function() {
+    // Since we are manually throwing an exception, it must be caught
+    // below.
+    try {
+      network.cookiesEnabled(function(status) {
+        // if there is a problem, this callback will be called a second time
+        // with a false status.
+        equal(status, true, "cookies are enabled, correct status");
+        start();
+
+        throw "callback exception";
+      }, testHelpers.unexpectedXHRFailure);
+    } catch(e) {
+      equal(e.toString(), "callback exception", "correct exception caught");
+    }
+  });
+
 }());


### PR DESCRIPTION
If the onComplete callback excepted, the catch block would re-call onComplete with a false status, indicating the cookies were disabled.

issue #1339
