### PR TITLE
Add the groundwork for browser specific "Enable Cookies" URLs.

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -38,6 +38,7 @@ var common_js = [
   '/shared/helpers.js',
   '/shared/screens.js',
   '/shared/browser-support.js',
+  '/shared/enable_cookies_url.js',
   '/shared/wait-messages.js',
   '/shared/error-messages.js',
   '/shared/error-display.js',

--- a/resources/static/shared/browser-support.js
+++ b/resources/static/shared/browser-support.js
@@ -62,6 +62,11 @@ BrowserID.BrowserSupport = (function() {
     return reason;
   }
 
+  function isIOS() {
+    var ua = nav.userAgent;
+    return ua.indexOf("like Mac OS X") > -1;
+  }
+
   return {
     /**
      * Set the test environment.
@@ -84,7 +89,12 @@ BrowserID.BrowserSupport = (function() {
     /**
      * IE version surfaced for crypto optimizations
      */
-    getInternetExplorerVersion: getInternetExplorerVersion
+    getInternetExplorerVersion: getInternetExplorerVersion,
+    /**
+     * Check to see whether user is using iOS
+     * @method isIOS
+     */
+    isIOS: isIOS
   };
 
 }());

--- a/resources/static/shared/enable_cookies_url.js
+++ b/resources/static/shared/enable_cookies_url.js
@@ -1,0 +1,20 @@
+/*global BrowserID: true, gettext: true*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+BrowserID.EnableCookiesURL = (function(){
+  "use strict";
+
+  var bid = BrowserID,
+      bs = bid.BrowserSupport;
+
+  function getURL() {
+    return bs.isIOS() ?
+      "https://support.mozilla.org/kb/how-enable-cookies-iphone" :
+      "http://support.mozilla.org/kb/Websites%20say%20cookies%20are%20blocked";
+  }
+
+  return {
+    getURL: getURL
+  };
+}());

--- a/resources/static/shared/error-messages.js
+++ b/resources/static/shared/error-messages.js
@@ -5,6 +5,8 @@
 BrowserID.Errors = (function(){
   "use strict";
 
+  var enableCookiesURL = BrowserID.EnableCookiesURL.getURL();
+
   // NOTE: The majority of these strings do not have gettext because they are
   // not immediately user facing.  These strings are used in the error dialog
   // and are only shown after the user clicks on "show more info"
@@ -47,7 +49,8 @@ BrowserID.Errors = (function(){
 
     cookiesDisabled: {
       title: gettext("BrowserID requires cookies"),
-      message: format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='http://support.mozilla.org/en-US/kb/Websites%20say%20cookies%20are%20blocked'"])
+      message: format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='" + enableCookiesURL + "'"])
+
     },
 
     cookiesEnabled: {

--- a/resources/static/test/cases/shared/browser-support.js
+++ b/resources/static/test/cases/shared/browser-support.js
@@ -66,6 +66,20 @@
     equal(support.isSupported(), true, "Firefox 7.01 is supported");
     equal(typeof support.getNoSupportReason(), "undefined", "no reason, we are all good");
   });
+
+  test("isIOS with userAgent that is not iOS - return false", function() {
+    stubNavigator.appName = "Netscape";
+    stubNavigator.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:14.0) Gecko/20120326 Firefox/14.0a1";
+
+    strictEqual(support.isIOS(), false, "false returned for Firefox userAgent");
+  });
+
+  test("isIOS with userAgent that is iOS - return true", function() {
+    stubNavigator.userAgent = "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
+
+    strictEqual(support.isIOS(), true, "true returned for iOS userAgent");
+  });
+
 }());
 
 

--- a/resources/static/test/cases/shared/enable_cookies_url.js
+++ b/resources/static/test/cases/shared/enable_cookies_url.js
@@ -1,0 +1,26 @@
+/*jshint browsers:true, forin: true, laxbreak: true */
+/*global test: true, start: true, module: true, ok: true, equal: true, BrowserID: true */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  "use strict";
+
+  var bid = BrowserID,
+      testHelpers = bid.TestHelpers;
+
+  module("/shared/enable_cookies_url", {
+    setup: function() {
+      testHelpers.setup();
+    },
+
+    teardown: function() {
+      testHelpers.teardown();
+    }
+  });
+
+  test("returns a URL", function() {
+    ok(bid.EnableCookiesURL.getURL(), "a URL is returned");
+  });
+}());
+

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -91,6 +91,7 @@
     <script src="/shared/helpers.js"></script>
     <script src="/shared/screens.js"></script>
     <script src="/shared/browser-support.js"></script>
+    <script src="/shared/enable_cookies_url.js"></script>
     <script src="/shared/wait-messages.js"></script>
     <script src="/shared/error-messages.js"></script>
     <script src="/shared/error-display.js"></script>
@@ -143,6 +144,7 @@
     <script src="cases/shared/tooltip.js"></script>
     <script src="cases/shared/error-display.js"></script>
     <script src="cases/shared/browser-support.js"></script>
+    <script src="cases/shared/enable_cookies_url.js"></script>
     <script src="cases/shared/validation.js"></script>
     <script src="cases/shared/storage.js"></script>
     <script src="cases/shared/xhr.js"></script>


### PR DESCRIPTION
@ozten or @lloyd - Could you guys do a review/give some feedback here?

I have started with browser specific enable cookie URLs, at the moment only differentiating between iOS and the rest of the world.  I would like to make a list of specialized URLs for popular desktop and mobile browsers.

issue #1167
issue #1302
