### PR TITLE
repair internal.get API - it should return a bare assertion represented ...

### DIFF
--- a/resources/static/dialog/resources/internal_api.js
+++ b/resources/static/dialog/resources/internal_api.js
@@ -14,6 +14,17 @@
       storage = bid.Storage,
       moduleManager = bid.module;
 
+  // given an object containing an assertion, extract the assertion string,
+  // as the internal API is supposed to return a string assertion, not an
+  // object.  issue #1395
+
+  function assertionObjectToString(assertion) {
+    if (assertion !== null && typeof assertion === 'object' && assertion.assertion) {
+      assertion = assertion.assertion;
+    }
+    return assertion;
+  }
+
   /**
    * Set the persistent flag to true for an origin.
    * @method setPersistent
@@ -53,12 +64,7 @@
    */
   internal.get = function(origin, callback, options) {
     function complete(assertion) {
-      // The API is supposed to return a string assertion, not an
-      // object.  issue #1395
-      if (typeof assertion === 'object' && assertion.assertion) {
-        assertion = assertion.assertion;
-      }
-
+      assertion = assertionObjectToString(assertion);
       // If no assertion, give no reason why there was a failure.
       callback && callback(assertion || null);
     }
@@ -96,12 +102,7 @@
    */
   function getSilent(origin, email, callback) {
     function complete(assertion) {
-      // The API is supposed to return a string assertion, not an
-      // object.  issue #1395
-      if (typeof assertion === 'object' && assertion.assertion) {
-        assertion = assertion.assertion;
-      }
-
+      assertion = assertionObjectToString(assertion);
       callback && callback(assertion || null);
     }
 

--- a/resources/static/dialog/resources/internal_api.js
+++ b/resources/static/dialog/resources/internal_api.js
@@ -53,6 +53,12 @@
    */
   internal.get = function(origin, callback, options) {
     function complete(assertion) {
+      // The API is supposed to return a string assertion, not an
+      // object.  issue #1395
+      if (typeof assertion === 'object' && assertion.assertion) {
+        assertion = assertion.assertion;
+      }
+
       // If no assertion, give no reason why there was a failure.
       callback && callback(assertion || null);
     }
@@ -90,7 +96,13 @@
    */
   function getSilent(origin, email, callback) {
     function complete(assertion) {
-      callback && callback(assertion);
+      // The API is supposed to return a string assertion, not an
+      // object.  issue #1395
+      if (typeof assertion === 'object' && assertion.assertion) {
+        assertion = assertion.assertion;
+      }
+
+      callback && callback(assertion || null);
     }
 
     user.checkAuthenticationAndSync(function(authenticated) {


### PR DESCRIPTION
...as a string, not an object - issue #1395
