### PR TITLE
Fix Fx throwing an exception when accessing localStorage if cookies are disabled.

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -105,6 +105,15 @@ pre {
 <script src="https://browserid.org/include.js"></script>
 <script>
 
+try {
+  var storage = localStorage;
+}
+catch(e) {
+  // Fx with cookies disabled with blow up when trying to access localStorage.
+  storage = {};
+}
+
+
 function loggit() {
   try {
     console.log.apply(console, arguments);
@@ -135,7 +144,7 @@ function checkAssertion(assertion) {
 };
 
 navigator.id.experimental.watch({
-  email: (localStorage.loggedInUser === 'null') ? null : localStorage.loggedInUser,
+  email: (storage.loggedInUser === 'null') ? null : storage.loggedInUser,
   onready: function () {
     loggit("onready");
     var txt = serial++ + ' navigator.id ready at ' + (new Date).toString();
@@ -179,10 +188,10 @@ $(document).ready(function() {
   $(".specify button.logout").click(navigator.id.logout);
 
   $(".session button.update_session").click(function() {
-    localStorage.loggedInUser = $.trim($('#loggedInUser').val());
+    storage.loggedInUser = $.trim($('#loggedInUser').val());
     $(".session input").fadeOut(100).fadeIn(350);
   });
-  $('#loggedInUser').val(localStorage.loggedInUser ? localStorage.loggedInUser : "");
+  $('#loggedInUser').val(storage.loggedInUser ? storage.loggedInUser : "");
 });
 
 </script>

--- a/resources/static/pages/page_helpers.js
+++ b/resources/static/pages/page_helpers.js
@@ -8,8 +8,8 @@ BrowserID.PageHelpers = (function() {
 
   var win = window,
       doc = win.document,
-      locStorage = win.localStorage,
       bid = BrowserID,
+      storage = bid.Storage,
       user = bid.User,
       helpers = bid.Helpers,
       dom = bid.DOM,
@@ -18,7 +18,15 @@ BrowserID.PageHelpers = (function() {
       origStoredEmail;
 
   function setStoredEmail(email) {
-    locStorage.signInEmail = email;
+    storage.signInEmail.set(email);
+  }
+
+  function clearStoredEmail() {
+    storage.signInEmail.remove();
+  }
+
+  function getStoredEmail() {
+    return storage.signInEmail.get() || "";
   }
 
   function onEmailChange(event) {
@@ -30,7 +38,7 @@ BrowserID.PageHelpers = (function() {
     // If the user tried to sign in on the sign up page with an existing email,
     // place that email in the email field, then focus the password.
     var el = $("#email"),
-        email = locStorage.signInEmail;
+        email = getStoredEmail();
 
     if (email) {
       el.val(email);
@@ -39,14 +47,6 @@ BrowserID.PageHelpers = (function() {
 
     dom.bindEvent("#email", "change", onEmailChange);
     dom.bindEvent("#email", "keyup", onEmailChange);
-  }
-
-  function clearStoredEmail() {
-    locStorage.removeItem("signInEmail");
-  }
-
-  function getStoredEmail() {
-    return locStorage.signInEmail || "";
   }
 
   function getParameterByName( name ) {

--- a/resources/static/test/cases/shared/storage.js
+++ b/resources/static/test/cases/shared/storage.js
@@ -157,5 +157,12 @@
   test("getStagedOnBehalfOf", function() {
     // XXX needs a test
   });
+
+  test("signInEmail.set/.get/.remove - set, get, and remove the signInEmail", function() {
+    storage.signInEmail.set("testuser@testuser.com");
+    equal(storage.signInEmail.get(), "testuser@testuser.com", "correct email gotten");
+    storage.signInEmail.remove();
+    equal(typeof storage.signInEmail.get(), "undefined", "after remove, signInEmail is empty");
+  });
 }());
 


### PR DESCRIPTION
- In the example RP, instead of accessing localStorage directly, access it through a variable that is guaranteed to exist.
- In page_helpers.js, do all localStorage access through new functions in storage.js
- In storage.js, if localStorage is inaccessible, create a standin.

issue #1414
