### PR TITLE
Visual updates to make secondary action links be more consistent, clean up CSS.

### DIFF
--- a/resources/static/css/common.css
+++ b/resources/static/css/common.css
@@ -44,6 +44,7 @@ html[xmlns] .cf {
 
 header, section, footer {
   display: block;
+  width: 100%;
 }
 
 ul, li {
@@ -82,6 +83,19 @@ ul, li {
 a {
   color: #222;
   text-decoration: none;
+}
+
+a:hover {
+  color: #000;
+}
+
+a.action, #error a {
+  color: #549FDC;
+  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+a.action:hover, #error a:hover {
+  color: #58a7e7;
 }
 
 p:last-child {
@@ -189,10 +203,10 @@ button:hover,
 button:focus,
 .button:hover,
 .button:focus{
+    color: #fff;
     background-color: #76c2ff;
     background-image: -moz-linear-gradient(center top , #76C2FF 50%, #37A6FF 100%);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(50%, #76C2FF), color-stop(100%, #37A6FF));
-
 }
 
 button.negative:hover,
@@ -237,16 +251,6 @@ button[disabled], .submit_disabled button, .submit_disabled .button,
   opacity: .5;
 }
 
-#cancel, #back {
-  background-color: transparent;
-  color: #549FDC;
-  font-size: 1em;
-  font-weight: normal;
-  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
-  padding: 0;
-}
-
-
 .submit #cancel {
   float: right;
   margin-right: 15px;
@@ -280,23 +284,15 @@ header ul li {
   float: left;
 }
 
-header a {
-  color: #222;
-}
-
 header a.home {
   width: 80px;
   height: 21px;
   background: url("/i/icon.png") 0px 4px no-repeat;
   text-indent: -9999px;
-  display: block;
+  display: inline-block;
 }
 
 footer {
-  color: #aaa;
-}
-
-footer a {
   color: #aaa;
 }
 
@@ -308,15 +304,12 @@ footer ul li {
 
 footer .help {
     float: right;
-    color: #62615F;
     cursor: help;
 }
 
 .cancelVerify {
   font-weight: bold;
 }
-
-
 
 #wait, #delay {
   background-color: #fff;
@@ -340,8 +333,17 @@ footer .help {
 }
 
 #error a {
-    color: #549FDC;
     text-decoration: underline;
+}
+
+.forgot {
+  color: #777;
+  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
+  font-size: 11px;
+}
+
+.forgot:hover {
+  color: #333;
 }
 
 

--- a/resources/static/css/m.css
+++ b/resources/static/css/m.css
@@ -231,7 +231,7 @@
     float: right;
   }
 
-  #newsbanner {
+  .newsbanner {
     margin: 115px 0 28px 0; /* put a margin-top on so that it does not go under the header */
 
   }

--- a/resources/static/css/style.css
+++ b/resources/static/css/style.css
@@ -98,7 +98,6 @@ noscript {
 }
 
 #about {
-  font-family: 'Droid Serif', Georgia, serif;
   font-size: 14px;
   line-height: 21px;
   color: #444;
@@ -200,8 +199,8 @@ div.steps {
 }
 
 .sumo > a {
-  font-weight: bold;
   color: #444;
+  border-bottom: 1px dotted;
 }
 
 #legal {
@@ -209,13 +208,7 @@ div.steps {
 }
 
 #newuser {
-  background-color: #faca33;
-  line-height: 32px;
-  border-radius: 4px;
-  margin-bottom: 20px;
-  text-align: center;
-  color: #626160;
-  text-shadow: 1px 1px 0 rgba(255,255,255,0.5);
+  margin: 0 0 20px 0;
   height: 0;
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
   opacity: 0;
@@ -226,10 +219,10 @@ div.steps {
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
   opacity: 1;
   -webkit-transition: all 500ms;
-  -moz-transition: all 500ms;
-  -ms-transition: all 500ms;
-  -o-transition: all 500ms;
-  transition: all 500ms;
+     -moz-transition: all 500ms;
+      -ms-transition: all 500ms;
+       -o-transition: all 500ms;
+          transition: all 500ms;
 }
 
 #manage {
@@ -322,13 +315,6 @@ div.steps {
   font-size: 12px;
 }
 
-/*
-.buttonrow > button {
-  width: 48px;
-}
-*/
-.buttonrow > .edit { }
-
 .edit .buttonrow > .edit {
   display: none;
 }
@@ -390,9 +376,9 @@ div.steps {
 }
 
 .activity button {
-  width: 60px;
+  min-width: 60px;
   margin-left: 10px;
-  margin-right: -70px;
+  margin-right: -100%;
 
   -webkit-transition: margin 0.4s ease;
      -moz-transition: margin 0.4s ease;
@@ -430,9 +416,18 @@ button.delete {
        -o-border-radius: 5px;
           border-radius: 5px;
 
-  background-image: -moz-linear-gradient(#EA7676 0%, #C84343 100%);
-  background-image: -o-linear-gradient(#EA7676 0%, #C84343 100%);
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #EA7676), color-stop(100%, #C84343));
+  background-image: -moz-linear-gradient(#EA7676 0%, #C84343 100%);
+  background-image: -ms-linear-gradient(#EA7676 0%, #C84343 100%);
+  background-image: -o-linear-gradient(#EA7676 0%, #C84343 100%);
+}
+
+button.delete:hover {
+  background-color: #f07979;
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f07979), color-stop(100%, #c34141));
+  background-image: -moz-linear-gradient(#f07979 0%, #c34141 100%);
+  background-image: -ms-linear-gradient(#f07979 0%, #c34141 100%);
+  background-image: -o-linear-gradient(#f07979 0%, #c34141 100%);
 }
 
 button.delete:active {
@@ -450,6 +445,7 @@ button.delete:active {
   background-image: -o-linear-gradient(#C84343 0%, #AA3D3D 100%);
   background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #C84343), color-stop(100%, #AA3D3D));
 }
+
 
 #edit_password {
   margin-bottom: 10px;
@@ -489,10 +485,6 @@ button.delete:active {
   text-align: right;
 }
 
-#disclaimer a {
-  color: #549FDC;
-}
-
 h1 {
   margin-bottom: 20px;
 }
@@ -514,9 +506,8 @@ h1 {
   padding: 0 0 0 250px;
 }
 
-#signUp .info {
-  color: #549FDC;
-  text-decoration: underline;
+#signUp .tour {
+  border-bottom: 1px dotted #90c0db;
 }
 
 #signUp p {
@@ -618,11 +609,6 @@ h1 {
   margin: 122px 115px;
 }
 
-#signUpFormWrap a.signUpIn {
-  color: #549FDC;
-  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
-}
-
 #signUpFormWrap a.space {
   margin: 10px 20px 0;
   display: inline-block;
@@ -686,6 +672,10 @@ h1 {
   display: none;
 }
 
+.submit .remember {
+  float: left;
+}
+
 .enter_password #signUpForm > .password_entry, .known_secondary #signUpForm > .password_entry,
 .unknown_secondary #unknown_secondary, .verify_primary #verify_primary {
   display: block;
@@ -706,12 +696,6 @@ h1 {
 }
 
 
-a.forgot {
-  color: #888784;
-  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
-  font-size: 11px;
-}
-
 .notifications {
   list-style-type: none;
 }
@@ -730,7 +714,7 @@ a.forgot {
   text-align: center;
 }
 
-.notifications > .notification a, .notifications > .notification strong {
+.notifications > .notification strong {
   color: #222;
 }
 
@@ -759,6 +743,15 @@ header ul.nav li {
 }
 
 
+header ul a {
+  padding: 4px 8px;
+}
+
+header ul a:hover {
+  background-color: #f4f3f0;
+  border-radius: 3px;
+}
+
 header a.signIn, header a.signOut {
   background-color: #d1ceca;
   padding: 4px 8px;
@@ -782,11 +775,12 @@ header a.signIn:hover, header a.signOut:hover {
   display: inline;
 }
 
-#wrapper > header,
-footer {
-  display: block;
-  width: 100%;
+header, footer {
   padding: 20px 0;
+}
+
+section > header {
+  padding: 0;
 }
 
 footer {
@@ -794,7 +788,17 @@ footer {
   bottom: 0;
 }
 
-#newsbanner {
+footer a {
+  color: #aaa;
+  border-bottom: 1px dotted #ccc;
+}
+
+footer a:hover {
+  color: #777;
+}
+
+
+.newsbanner {
   margin-top: 60px; /* put a margin-top on so that it does not go under the header */
   background-color: #faca33;
   line-height: 32px;
@@ -804,8 +808,16 @@ footer {
   color: #626160;
   text-shadow: 1px 1px 0 rgba(255,255,255,0.5);
   -webkit-transition: all 500ms;
-  -moz-transition: all 500ms;
-  -ms-transition: all 500ms;
-  -o-transition: all 500ms;
-  transition: all 500ms;
+     -moz-transition: all 500ms;
+      -ms-transition: all 500ms;
+       -o-transition: all 500ms;
+          transition: all 500ms;
+}
+
+.newsbanner a {
+  border-bottom: 1px dotted;
+}
+
+.newsbanner a:hover {
+  color: #000;
 }

--- a/resources/static/dialog/controllers/authenticate.js
+++ b/resources/static/dialog/controllers/authenticate.js
@@ -18,7 +18,7 @@ BrowserID.Modules.Authenticate = (function() {
       dom = bid.DOM,
       lastEmail = "",
       addressInfo,
-      hints = ["newuser","forgot","returning","start","addressInfo"];
+      hints = ["newuser","returning","start","addressInfo"];
 
   function getEmail() {
     return helpers.getAndValidateEmail("#email");
@@ -161,7 +161,7 @@ BrowserID.Modules.Authenticate = (function() {
         tos_url: options.tosURL
       });
 
-      $(".newuser,.forgot,.returning,.start").hide();
+      $(".newuser,.returning,.start").hide();
 
       self.bind("#email", "keyup", emailKeyUp);
       self.click("#forgotPassword", forgotPassword);

--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -11,10 +11,8 @@ h2 {
     font-weight: bold;
 }
 
-header,
-footer {
+header, footer {
     position: absolute;
-    width: 100%;
     padding: 20px;
     z-index: 2;
 }
@@ -42,7 +40,12 @@ footer {
 }
 
 footer a {
-    color: #549FDC;
+    color: #62615f;
+    border-bottom: 1px dotted #999;
+}
+
+footer a:hover {
+    color: #333;
 }
 
 label {
@@ -275,12 +278,6 @@ div#required_email {
     font-weight: bold;
 }
 
-    /*
-#signIn .vertical {
-    position: relative;
-}
-*/
-
 #selectEmail {
     position: absolute;
     top: 20px;
@@ -293,12 +290,6 @@ div#required_email {
 #selectEmail.center {
     position: static;
     overflow-y: visible;
-}
-
-#forgotPassword {
-    color: #888784;
-    text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5);
-    font-size: 11px;
 }
 
 .inputs {
@@ -337,7 +328,7 @@ div#required_email {
 }
 
 #selectEmail > .inputs > li:only-child input[type=radio] {
-  display: none;
+    display: none;
 }
 
 .submit {
@@ -353,6 +344,15 @@ div#required_email {
     padding-left: 10px;
 }
 
+.tospp > a {
+    color: #333;
+    border-bottom: 1px dotted #999;
+}
+
+.tospp > a:hover {
+    color: #000;
+}
+
 a.emphasize {
   background-color: #F0EFED;
   color: #4E4E4E;
@@ -362,8 +362,21 @@ a.emphasize {
   line-height: 18px;
 }
 
+a.emphasize:hover {
+  background-color: #fbfafa;
+}
+
+
+#back {
+  color: #000;
+  border-bottom: 1px dotted;
+}
+
+.submit > button {
+    margin: 0 0 0 5px;
+}
+
 .newuser,
-.forgot,
 .returning {
     display: none;
 }

--- a/resources/static/dialog/views/add_email.ejs
+++ b/resources/static/dialog/views/add_email.ejs
@@ -42,7 +42,7 @@
           <p>
         <% } %>
           <button id="addNewEmail"><%= gettext('add') %></button>
-          <a href="#" id="cancel"><%= gettext('cancel') %></a>
+          <a href="#" id="cancel" class="action"><%= gettext('cancel') %></a>
         <% if (privacy_url && tos_url) { %>
           </p>
         <% } %>

--- a/resources/static/dialog/views/authenticate.ejs
+++ b/resources/static/dialog/views/authenticate.ejs
@@ -42,7 +42,7 @@
 
           <li class="returning">
 
-              <a id="forgotPassword" class="right" href="#" tabindex="4"><%= gettext('forgot your password?') %></a>
+              <a id="forgotPassword" class="forgot right" href="#" tabindex="4"><%= gettext('forgot your password?') %></a>
               <label for="password" class="serif"><%= gettext('Password') %></label>
 
               <input id="password" class="sans" type="password" maxlength="80" tabindex="2" />
@@ -60,7 +60,7 @@
 
       <div class="submit cf">
         <% if (privacy_url && tos_url) { %>
-           <p>
+           <p class="tospp">
             <%= format(
                   gettext('By clicking %s, you confirm that you accept this site\'s <a %s>Terms of Use</a> and <a %s>Privacy Policy</a>.'),
                        [ gettext('next'),

--- a/resources/static/dialog/views/forgot_password.ejs
+++ b/resources/static/dialog/views/forgot_password.ejs
@@ -25,6 +25,6 @@
 
       <div class="submit cf">
           <button tabindex="1"><%= gettext('reset password') %></button>
-          <a href="#" id="cancel" tabindex="2"><%= gettext('cancel') %></a>
+          <a href="#" id="cancel" class="action" tabindex="2"><%= gettext('cancel') %></a>
       </div>
   </div>

--- a/resources/static/dialog/views/required_email.ejs
+++ b/resources/static/dialog/views/required_email.ejs
@@ -31,7 +31,7 @@
 
           <% if (password) { %>
               <li id="password_section">
-                  <a id="forgotPassword" class="right" href="#" tabindex="4"><%= gettext("forgot your password?") %></a>
+                  <a id="forgotPassword" class="right forgot" href="#" tabindex="4"><%= gettext("forgot your password?") %></a>
                   <label for="password" class="serif"><%= gettext("Password") %></label>
 
                   <input id="password" class="sans" type="password" maxlength="80" tabindex="2" />
@@ -68,7 +68,7 @@
             <% } %>
 
             <% if (secondary_auth) { %>
-              <a href="#" id="cancel" tabindex="4"><%= gettext("cancel") %></a>
+              <a href="#" id="cancel" class="action" tabindex="4"><%= gettext("cancel") %></a>
             <% } %>
         <% if (privacy_url && tos_url) { %>
           </p>

--- a/resources/static/dialog/views/verify_primary_user.ejs
+++ b/resources/static/dialog/views/verify_primary_user.ejs
@@ -64,7 +64,7 @@
           <p>
         <% } %>
           <button id="verifyWithPrimary"><%= gettext("verify") %></button>
-          <a href="#" id="cancel"><%= gettext("cancel") %></a>
+          <a href="#" id="cancel" class="action"><%= gettext("cancel") %></a>
         <% if (privacy_url && tos_url) { %>
           </p>
         <% } %>

--- a/resources/views/about.ejs
+++ b/resources/views/about.ejs
@@ -6,9 +6,9 @@
     <div id="about">
 
         <div class="video">
-          <div class="description">
-            <b>BrowserID</b> is an <b>easier</b> way to sign in
-          </div>
+          <h1 class="serif">
+            <strong>BrowserID</strong> is an <strong>easier</strong> way to sign in
+          </h1>
         </div>
 
         <div class="row one cf">

--- a/resources/views/forgot.ejs
+++ b/resources/views/forgot.ejs
@@ -19,7 +19,7 @@
 
                   <br />
                   <p>
-                    If this is a mistake, just ignore the sent email and <a href="/signup" class="cancelVerify" id="back">use another email address</a>.
+                    If this is a mistake, just ignore the sent email and <a href="/signup" class="action cancelVerify" id="back">use another email address</a>.
                   </p>
                 </div>
             </div>
@@ -51,7 +51,7 @@
 
             <div class="submit cf forminputs">
                 <div class="remember cf">
-                    <a class="signUpIn" href="/signin">Know your password? Sign in.</a>
+                    <a class="action" href="/signin">Know your password? Sign in.</a>
                 </div>
                 <button>Reset Password</button>
             </div>

--- a/resources/views/index.ejs
+++ b/resources/views/index.ejs
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
   <div id="content" class="display_auth">
-      <div id="newuser">
+      <div class="newsbanner" id="newuser">
         New to BrowserID? <a href="/about">Learn more</a>
       </div>
 
@@ -48,13 +48,13 @@
           </section>
 
 
-          <p id="disclaimer">You may, at any time, <a href="#" id="cancelAccount">cancel your account</a></p>
+          <p id="disclaimer">You may, at any time, <a href="#" id="cancelAccount" class="action">cancel your account</a></p>
       </div>
   </div>
 
   <div id="vAlign" class="display_nonauth">
-      <div id="newsbanner">
-        BrowserID is graduating: we're launching <b>Mozilla Persona</b>. Find out more on <a href="http://identity.mozilla.com/">the identity blog</a>.
+      <div class="newsbanner">
+        BrowserID is graduating: we're launching Mozilla Persona. Find out more on <a href="http://identity.mozilla.com/">the identity blog</a>.
       </div>
 
       <div id="signUp">
@@ -64,7 +64,7 @@
 
           <p>Connect with <em>BrowserID</em>, the safest &amp; easiest way to sign in.</p>
           <p>
-            <a class="granted info" href="/about">Take the tour</a>
+            <a class="granted tour action" href="/about">Take the tour</a>
             <span class="require-js">or
               <a href="/signup" class="button granted create">sign up</a>
             </span>

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -22,9 +22,7 @@
 <div id="wrapper">
 
     <header id="header" class="cf">
-        <ul class="cf">
-            <li><a class="home" href="/"><%= gettext("BrowserID Home") %></a></li>
-        </ul>
+        <a class="home" href="/"><%= gettext("BrowserID Home") %></a>
 
         <ul class="nav cf">
             <li><a href="/about"><%= gettext("How it works") %></a></li>

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -13,7 +13,7 @@
 
                 <li class="notification" id="unknown_secondary">
                   <strong id="unknown_email">Email</strong> is not registered.
-                  Would you like to <a class="signUpIn" href="/signup">sign up</a> instead?
+                  Would you like to <a class="action" href="/signup">sign up</a> instead?
                 </li>
 
             </ul>
@@ -47,7 +47,7 @@
 
             <div class="submit cf forminputs">
                 <div class="remember cf">
-                    <a class="signUpIn" href="/signup">New to BrowserID? Sign up today.</a>
+                    <a class="action" href="/signup">New to BrowserID? Sign up today.</a>
                 </div>
                 <button tabindex="5">Sign In</button>
             </div>

--- a/resources/views/signup.ejs
+++ b/resources/views/signup.ejs
@@ -13,7 +13,7 @@
 
                 <li class="notification alreadyRegistered">
                   <strong id="registeredEmail"></strong> is already registered.
-                  Would you like to <a class="signUpIn" href="/signin">sign in</a> instead?
+                  Would you like to <a class="action" href="/signin">sign in</a> instead?
                 </li>
 
                 <li class="notification emailsent">
@@ -27,7 +27,7 @@
 
                   <br />
                   <p>
-                    If this is a mistake, just ignore the sent email and <a href="/signup" class="cancelVerify" id="back">use another email address</a>.
+                    If this is a mistake, just ignore the sent email and <a href="/signup" class="action cancelVerify" id="back">use another email address</a>.
                   </p>
                 </li>
 
@@ -54,7 +54,7 @@
 
             <div class="submit cf forminputs">
                 <div class="remember cf">
-                    <a class="signUpIn" href="/signin">Existing account? Sign in.</a>
+                    <a class="action" href="/signin">Existing account? Sign in.</a>
                 </div>
                 <button>Verify Email</button>
             </div>


### PR DESCRIPTION
- Secondary links all are some shade of dark grey/black with a dotted underline.
- Change the font used on the "about" page to be the standard Helvetica Neue except for the header.
- Change the style of link in the TOS/PP to black text with a dotted underline.
- Loads more link updates!
- A lot of cleanup to remove duplicate `color: #549fdc` entries by using the action class.
- On the main site, put the action links to the far left of the main button.
- Reduce the amount of "forgot password" CSS by generalizing.
- Generalize the yellow banner on the main site.

issue #702
