### PR TITLE
Hotfix1429

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ train-2012.03.28:
   * (hotfix 2012.04.10) final 40 production locales merged: #1412
   * (hotfix 2012.04.10) update l10n-all.json to have all locales (complete and in-progress) as well as en-US and db-LB
   * (hotfix 2012.04.10) fix more rigorous checking of email inputs to WSAPI: domain checking of 'site' parameter was validating hostnames rather than domains.
+  * (hotfix 2012.04.12) fix /signup page on browserid.org: #1429
 
 train-2012.03.14:
   * BrowserID now speaks Bulgarian

--- a/lib/wsapi/stage_email.js
+++ b/lib/wsapi/stage_email.js
@@ -24,10 +24,15 @@ exports.i18n = true;
 
 exports.process = function(req, res) {
   // validate
-  // should do this one but it's failing for some reason
-  sanitize(req.body.email).isEmail();
-  sanitize(req.body.site).isOrigin();
-  
+  try {
+    sanitize(req.body.email).isEmail();
+    sanitize(req.body.site).isOrigin();
+  } catch(e) {
+    var msg = "invalid arguments: " + e;
+    logger.warn("bad request received: " + msg);
+    return httputils.badRequest(resp, msg);
+  }
+
   db.lastStaged(req.body.email, function (err, last) {
     if (err) return wsapi.databaseDown(res, err);
 

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -29,8 +29,14 @@ exports.process = function(req, resp) {
   wsapi.clearAuthenticatedUser(req.session);
 
   // validate
-  sanitize(req.body.email).isEmail();
-  sanitize(req.body.site).isOrigin();
+  try {
+    sanitize(req.body.email).isEmail();
+    sanitize(req.body.site).isOrigin();
+  } catch(e) {
+    var msg = "invalid arguments: " + e;
+    logger.warn("bad request received: " + msg);
+    return httputils.badRequest(resp, msg);
+  }
 
   db.lastStaged(req.body.email, function (err, last) {
     if (err) return wsapi.databaseDown(resp, err);

--- a/resources/static/shared/user.js
+++ b/resources/static/shared/user.js
@@ -1111,10 +1111,17 @@ BrowserID.User = (function() {
 
       onComplete(hasSecondary);
     }
-
-
   };
 
-  User.setOrigin(document.location.host);
+  // Set origin to default to the current domain.  Other contexts that use user.js,
+  // like dialogs or iframes, will call setOrigin themselves to update this to
+  // the origin of the of the RP.  On browserid.org, it will remain the origin of
+  // browserid.org
+  var currentOrigin = window.location.protocol + '//' + window.location.hostname;
+  if (window.location.port) {
+    currentOrigin += ':' + window.location.port;
+  }
+  User.setOrigin(currentOrigin);
+
   return User;
 }());

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2012.03.28
-Release:       6%{?dist}_%{svnrev}
+Release:       7%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Pete Fritchman <petef@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
this will fix `/signup` on browserid.org.  The current code in production is sending a domain for the site parameter to the WSAPI rather than an origin.
