### PR TITLE
Place the entire "If you're at a public computer such as a library or internet cafe, we'll ask you..." on a single line.

### DIFF
--- a/resources/static/dialog/views/is_this_your_computer.ejs
+++ b/resources/static/dialog/views/is_this_your_computer.ejs
@@ -12,8 +12,7 @@
 
     <p>
       <button class="this_is_not_my_computer negative" tabindex="3"><%= gettext('no') %></button>
-      <%= gettext('If you\'re at a public computer such as a library or internet cafe, we\'ll ask you ' +
-                  'for your password again in an hour.') %>
+      <%= gettext('If you\'re at a public computer such as a library or internet cafe, we\'ll ask you for your password again in an hour.') %>
     </p>
   </div>
 


### PR DESCRIPTION
This should fix the l10n extraction tools cutting the string off.

issue #1425
