### PR TITLE
fix regression where an undefined second argument to .get() would cause ...

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1122,6 +1122,7 @@
       },
       // get an assertion
       get: function(callback, options) {
+        options = options || {};
         checkCompat(true);
         internalWatch({
           onlogin: function(assertion) {


### PR DESCRIPTION
...a javascript error - issue #1442
