### PR TITLE
Pr 1447 cancel state

### DIFF
--- a/resources/static/dialog/controllers/actions.js
+++ b/resources/static/dialog/controllers/actions.js
@@ -70,9 +70,7 @@ BrowserID.Modules.Actions = (function() {
     },
 
     doCancel: function() {
-      // do not call success with null here, let winchan's cancel handling do the work.
-      // this gives us consistent semantics across browsers on the RP side of the WinChan.
-      //      if(onsuccess) onsuccess(null);
+      if(onsuccess) onsuccess(null);
     },
 
     doConfirmUser: function(info) {

--- a/resources/static/dialog/controllers/required_email.js
+++ b/resources/static/dialog/controllers/required_email.js
@@ -91,7 +91,10 @@ BrowserID.Modules.RequiredEmail = (function() {
 
 
   function cancel() {
-    this.close(secondaryAuth ? "cancel_state" : "cancel");
+    // The cancel button is only shown to a user who has to enter their
+    // password to go from "assertion" authentication to "password"
+    // authentication.
+    this.close("cancel_state");
   }
 
   var RequiredEmail = bid.Modules.PageModule.extend({

--- a/resources/static/dialog/resources/state.js
+++ b/resources/static/dialog/resources/state.js
@@ -62,7 +62,9 @@ BrowserID.State = (function() {
     handleState("window_unload", function() {
       if (!self.success) {
         storage.setStagedOnBehalfOf("");
-        startAction("doCancel");
+        // do not call doCancel here, let winchan's cancel
+        // handling do the work. This gives us consistent semantics
+        // across browsers on the RP side of the WinChan.
       }
     });
 

--- a/resources/static/test/cases/controllers/required_email.js
+++ b/resources/static/test/cases/controllers/required_email.js
@@ -454,24 +454,7 @@
     });
   });
 
-  asyncTest("cancel normally raises the 'cancel' message", function() {
-    var email = "registered@testuser.com",
-        message = "cancel";
-
-    createController({
-      email: email,
-      ready: function() {
-        register(message, function(item, info) {
-          ok(true, message + " received");
-          start();
-        });
-
-        controller.cancel();
-      }
-    });
-  });
-
-  asyncTest("cancel with 'secondary_auth' raises the 'cancel_state' message", function() {
+  asyncTest("cancel raises the 'cancel_state' message", function() {
     var email = "registered@testuser.com",
         message = "cancel_state";
 


### PR DESCRIPTION
... email verification still works.
- A bit of code cleanup in required_email.js to remove the extra "cancel" message that was never called.

pull request 1447
