### PR TITLE
Fix the link color of the cancel button in the required email check email screen.

### DIFF
--- a/resources/static/dialog/controllers/check_registration.js
+++ b/resources/static/dialog/controllers/check_registration.js
@@ -18,12 +18,13 @@ BrowserID.Modules.CheckRegistration = (function() {
       options.required = !!options.required;
 
       self.renderWait("confirm_email", options);
+
       self.email = options.email;
       self.verifier = options.verifier;
       self.verificationMessage = options.verificationMessage;
+      self.required = options.required;
 
       self.click("#back", self.back);
-      self.click("#cancel", self.cancel);
 
       Module.sc.start.call(self, options);
     },
@@ -46,16 +47,9 @@ BrowserID.Modules.CheckRegistration = (function() {
     },
 
     back: function() {
-      // XXX this should change to cancelEmailValidation for email, but this
-      // will work.
       user.cancelUserValidation();
-      this.close("cancel_state");
-    },
-
-    cancel: function() {
-      this.close("cancel");
+      this.publish(this.required ? "cancel" : "cancel_state");
     }
-
   });
 
   return Module;

--- a/resources/static/dialog/views/confirm_email.ejs
+++ b/resources/static/dialog/views/confirm_email.ejs
@@ -15,9 +15,9 @@
 
     <p>
       <% if(required) { %>
-        <%= gettext('If this is a mistake, just ignore the sent email and <a href="#" id="cancel">cancel</a>.') %>
+        <%= format(gettext('If this is a mistake, just ignore the sent email and <a %s>cancel</a>.'), [' href="#" id="back"']) %>
       <% } else { %>
-        <%= gettext('If this is a mistake, just ignore the sent email and <a href="#" id="back">use another email address</a>.') %>
+        <%= format(gettext('If this is a mistake, just ignore the sent email and <a %s>use another email address</a>.'), [' href="#" id="back"']) %>
       <% } %>
     </p>
 

--- a/resources/static/test/cases/controllers/check_registration.js
+++ b/resources/static/test/cases/controllers/check_registration.js
@@ -13,12 +13,13 @@
       testHelpers = bid.TestHelpers,
       register = testHelpers.register;
 
-  function createController(verifier, message) {
+  function createController(verifier, message, required) {
     controller = bid.Modules.CheckRegistration.create();
     controller.start({
       email: "registered@testuser.com",
       verifier: verifier,
-      verificationMessage: message
+      verificationMessage: message,
+      required: required
     });
   }
 
@@ -76,7 +77,7 @@
     });
   });
 
-  asyncTest("back - raise cancel_state", function() {
+  asyncTest("back for normal account creation/email addition - raise cancel_state", function() {
     createController("waitForUserValidation", "user_verified");
     controller.startCheck(function() {
       register("cancel_state", function() {
@@ -87,14 +88,14 @@
     });
   });
 
-  asyncTest("cancel - raise cancel", function() {
-    createController("waitForUserValidation", "user_verified");
+  asyncTest("back for required email - raise cancel", function() {
+    createController("waitForUserValidation", "user_verified", true);
     controller.startCheck(function() {
       register("cancel", function() {
         ok(true, "cancel is triggered");
         start();
       });
-      controller.cancel();
+      controller.back();
     });
   });
 


### PR DESCRIPTION
- A little bit of cleanup to simplify the check_registration controller - there is only a back button now.
- In the ejs template, remove the href and id attributes from the strings passed to localizers. Always use back for the id.
- Add a test to make sure the correct messages are triggered whenever pressing the back button.

issue #1453
