### PR TITLE
Change the order of assertion generation to be after the user is asked "is this your computer?"

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -97,7 +97,7 @@ var dialog_js = und.flatten([
     '/dialog/controllers/verify_primary_user.js',
     '/dialog/controllers/provision_primary_user.js',
     '/dialog/controllers/primary_user_provisioned.js',
-    '/dialog/controllers/email_chosen.js',
+    '/dialog/controllers/generate_assertion.js',
     '/dialog/controllers/is_this_your_computer.js',
 
     '/dialog/start.js'

--- a/resources/static/dialog/controllers/actions.js
+++ b/resources/static/dialog/controllers/actions.js
@@ -105,16 +105,6 @@ BrowserID.Modules.Actions = (function() {
       startRegCheckService.call(this, info, "waitForEmailValidation", "email_confirmed");
     },
 
-    doEmailConfirmed: function(info) {
-      var self=this;
-      // yay!  now we need to produce an assertion.
-      user.getAssertion(info.email, user.getOrigin(), function(assertion) {
-        self.publish("assertion_generated", {
-          assertion: assertion
-        });
-      }, self.getErrorDialog(errors.getAssertion));
-    },
-
     doAssertionGenerated: function(info) {
       // Clear onerror before the call to onsuccess - the code to onsuccess
       // calls window.close, which would trigger the onerror callback if we
@@ -160,8 +150,8 @@ BrowserID.Modules.Actions = (function() {
       startService("is_this_your_computer", info);
     },
 
-    doEmailChosen: function(info) {
-      startService("email_chosen", info);
+    doGenerateAssertion: function(info) {
+      startService("generate_assertion", info);
     }
   });
 

--- a/resources/static/dialog/controllers/generate_assertion.js
+++ b/resources/static/dialog/controllers/generate_assertion.js
@@ -3,7 +3,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-BrowserID.Modules.EmailChosen = (function() {
+BrowserID.Modules.GenerateAssertion = (function() {
   "use strict";
 
   var bid = BrowserID,
@@ -12,7 +12,7 @@ BrowserID.Modules.EmailChosen = (function() {
       user = bid.User,
       storage = bid.Storage;
 
-  var EmailChosen = bid.Modules.PageModule.extend({
+  var GenerateAssertion = bid.Modules.PageModule.extend({
     start: function(options) {
       var email = options.email,
           self=this;
@@ -28,9 +28,9 @@ BrowserID.Modules.EmailChosen = (function() {
     }
   });
 
-  sc = EmailChosen.sc;
+  sc = GenerateAssertion.sc;
 
-  return EmailChosen;
+  return GenerateAssertion;
 
 }());
 

--- a/resources/static/dialog/resources/state.js
+++ b/resources/static/dialog/resources/state.js
@@ -194,7 +194,9 @@ BrowserID.State = (function() {
         if (idInfo.type === "primary") {
           if (idInfo.cert) {
             // Email is a primary and the cert is available - the user can log
-            // in without authenticated with the primary.
+            // in without authenticating with the IdP. All invalid/expired
+            // certs are assumed to have been checked and removed by this
+            // point.
             redirectToState("email_valid_and_ready", info);
           }
           else {
@@ -230,13 +232,12 @@ BrowserID.State = (function() {
     });
 
     handleState("email_valid_and_ready", function(msg, info) {
-      // At this stage, we know that the email the user is trying to
-      // authenticate with is valid, it has been confirmed, and it has a valid
-      // key.  Before generating an assertion, check to see if the user has
-      // verified whether the ownership status of this computer. If the user
-      // needs asked, ask them and generate the assertion once they finish the
-      // response.  If they do not need to be asked, generate the assertion
-      // now.
+      // this state is only called after all checking is done on the email
+      // address.  For secondaries, this means the email has been validated and
+      // the user is authenticated to the password level.  For primaries, this
+      // means the user is authenticated with their IdP and the certificate for
+      // the address is valid.  An assertion can be generated, but first we
+      // may have to check whether the user owns the computer.
       user.shouldAskIfUsersComputer(function(shouldAsk) {
         if (shouldAsk) {
           redirectToState("is_this_your_computer", info);

--- a/resources/static/dialog/resources/state.js
+++ b/resources/static/dialog/resources/state.js
@@ -23,7 +23,7 @@ BrowserID.State = (function() {
         handleState = self.subscribe.bind(self),
         redirectToState = mediator.publish.bind(mediator),
         startAction = function(save, msg, options) {
-          if(typeof save !== "boolean") {
+          if (typeof save !== "boolean") {
             options = msg;
             msg = save;
             save = true;
@@ -46,7 +46,7 @@ BrowserID.State = (function() {
         // Invalid format
         startAction("doError", "invalid_required_email", {email: requiredEmail});
       }
-      else if(info.email && info.type === "primary") {
+      else if (info.email && info.type === "primary") {
         primaryVerificationInfo = info;
         redirectToState("primary_user", info);
       }
@@ -101,7 +101,7 @@ BrowserID.State = (function() {
 
     handleState("user_confirmed", function() {
       self.email = self.stagedEmail;
-      startAction("doEmailConfirmed", { email: self.stagedEmail} );
+      redirectToState("email_chosen", { email: self.stagedEmail} );
     });
 
     handleState("primary_user", function(msg, info) {
@@ -109,7 +109,7 @@ BrowserID.State = (function() {
       email = info.email;
 
       var idInfo = storage.getEmail(email);
-      if(idInfo && idInfo.cert) {
+      if (idInfo && idInfo.cert) {
         redirectToState("primary_user_ready", info);
       }
       else {
@@ -123,6 +123,10 @@ BrowserID.State = (function() {
     handleState("primary_user_provisioned", function(msg, info) {
       info = info || {};
       info.add = !!addPrimaryUser;
+      // The user is is authenticated with their IdP. Two possibilities exist
+      // for the email - 1) create a new account or 2) add address to the
+      // existing account. If the user is authenticated with BrowserID, #2
+      // will happen. If not, #1.
       startAction("doPrimaryUserProvisioned", info);
     });
 
@@ -135,12 +139,12 @@ BrowserID.State = (function() {
         tosURL: self.tosURL
       });
 
-      if(primaryVerificationInfo) {
+      if (primaryVerificationInfo) {
         primaryVerificationInfo = null;
-        if(requiredEmail) {
+        if (requiredEmail) {
           startAction("doCannotVerifyRequiredPrimary", info);
         }
-        else if(info.add) {
+        else if (info.add) {
           // Add the pick_email in case the user cancels the add_email screen.
           // The user needs something to go "back" to.
           redirectToState("pick_email");
@@ -186,22 +190,24 @@ BrowserID.State = (function() {
         complete(info.complete);
       }
 
-      if(idInfo) {
-        if(idInfo.type === "primary") {
-          if(idInfo.cert) {
-            startAction("doEmailChosen", info);
+      if (idInfo) {
+        if (idInfo.type === "primary") {
+          if (idInfo.cert) {
+            // Email is a primary and the cert is available - the user can log
+            // in without authenticated with the primary.
+            redirectToState("email_valid_and_ready", info);
           }
           else {
-            // If the email is a primary, and their cert is not available,
-            // throw the user down the primary flow.
-            // Doing so will catch cases where the primary certificate is expired
+            // If the email is a primary and the cert is not available,
+            // throw the user down the primary flow. The primary flow will
+            // catch cases where the primary certificate is expired
             // and the user must re-verify with their IdP.
             redirectToState("primary_user", info);
           }
         }
         else {
           user.checkAuthentication(function(authentication) {
-            if(authentication === "assertion") {
+            if (authentication === "assertion") {
               // user must authenticate with their password, kick them over to
               // the required email screen to enter the password.
               startAction("doAuthenticateWithRequiredEmail", {
@@ -212,7 +218,7 @@ BrowserID.State = (function() {
               });
             }
             else {
-              startAction("doEmailChosen", info);
+              redirectToState("email_valid_and_ready", info);
             }
             oncomplete();
           }, oncomplete);
@@ -220,6 +226,59 @@ BrowserID.State = (function() {
       }
       else {
         throw "invalid email";
+      }
+    });
+
+    handleState("email_valid_and_ready", function(msg, info) {
+      // At this stage, we know that the email the user is trying to
+      // authenticate with is valid, it has been confirmed, and it has a valid
+      // key.  Before generating an assertion, check to see if the user has
+      // verified whether the ownership status of this computer. If the user
+      // needs asked, ask them and generate the assertion once they finish the
+      // response.  If they do not need to be asked, generate the assertion
+      // now.
+      user.shouldAskIfUsersComputer(function(shouldAsk) {
+        if (shouldAsk) {
+          redirectToState("is_this_your_computer", info);
+        }
+        else {
+          redirectToState("generate_assertion", info);
+        }
+      });
+    });
+
+    handleState("is_this_your_computer", function(msg, info) {
+      // We have to confirm the user's computer ownership status.  Save off
+      // the selected email info for when the user_computer_status_set is
+      // complete so that the user can continue the flow with the correct
+      // email address.
+      self.chosenEmailInfo = info;
+      startAction("doIsThisYourComputer", info);
+    });
+
+    handleState("user_computer_status_set", function(msg, info) {
+      // User's status has been confirmed, an assertion can safely be
+      // generated as there are no more delays introduced by user interaction.
+      // Use the email address that was stored in the call to
+      // "is_this_your_computer".
+      var emailInfo = self.chosenEmailInfo;
+      self.chosenEmailInfo = null;
+      redirectToState("generate_assertion", emailInfo);
+    });
+
+    handleState("generate_assertion", function(msg, info) {
+      startAction("doGenerateAssertion", info);
+    });
+
+    handleState("assertion_generated", function(msg, info) {
+      self.success = true;
+      if (info.assertion !== null) {
+        // XXX TODO - move the setLoggedIn to the getAssertion perhaps?
+        storage.setLoggedIn(user.getOrigin(), self.email);
+        startAction("doAssertionGenerated", { assertion: info.assertion, email: self.email });
+      }
+      else {
+        redirectToState("pick_email");
       }
     });
 
@@ -253,38 +312,6 @@ BrowserID.State = (function() {
       startAction(false, "doResetPassword", info);
     });
 
-    handleState("assertion_generated", function(msg, info) {
-      self.success = true;
-      if (info.assertion !== null) {
-        user.shouldAskIfUsersComputer(function(shouldAsk) {
-          if (shouldAsk) {
-            // We have to confirm the user's status
-            self.assertion_info = info;
-            redirectToState("is_this_your_computer", info);
-          }
-          else {
-            storage.setLoggedIn(user.getOrigin(), self.email);
-            startAction("doAssertionGenerated", { assertion: info.assertion, email: self.email });
-          }
-        });
-      }
-      else {
-        redirectToState("pick_email");
-      }
-    });
-
-    handleState("is_this_your_computer", function(msg, info) {
-      startAction("doIsThisYourComputer", info);
-    });
-
-    handleState("user_computer_status_set", function(msg, info) {
-      // User's status has been confirmed, redirect them back to the
-      // assertion_generated state with the stored assertion_info
-      var assertion_info = self.assertion_info;
-      self.assertion_info = null;
-      redirectToState("assertion_generated", assertion_info);
-    });
-
     handleState("add_email", function(msg, info) {
       info = helpers.extend(info || {}, {
         privacyURL: self.privacyURL,
@@ -301,7 +328,7 @@ BrowserID.State = (function() {
     });
 
     handleState("email_confirmed", function() {
-      startAction("doEmailConfirmed", { email: self.stagedEmail} );
+      redirectToState("email_chosen", { email: self.stagedEmail} );
     });
 
     handleState("cancel_state", function(msg, info) {

--- a/resources/static/dialog/start.js
+++ b/resources/static/dialog/start.js
@@ -30,7 +30,7 @@
       moduleManager.register("verify_primary_user", modules.VerifyPrimaryUser);
       moduleManager.register("provision_primary_user", modules.ProvisionPrimaryUser);
       moduleManager.register("primary_user_provisioned", modules.PrimaryUserProvisioned);
-      moduleManager.register("email_chosen", modules.EmailChosen);
+      moduleManager.register("generate_assertion", modules.GenerateAssertion);
       moduleManager.register("xhr_delay", modules.XHRDelay);
       moduleManager.register("xhr_disable_form", modules.XHRDisableForm);
 

--- a/resources/static/shared/network.js
+++ b/resources/static/shared/network.js
@@ -258,6 +258,11 @@ BrowserID.Network = (function() {
         url: "/wsapi/user_creation_status?email=" + encodeURIComponent(email),
         success: function(status, textStatus, jqXHR) {
           if (status.status === 'complete' && status.userid) {
+            // The user at this point can ONLY be logged in with password
+            // authentication. Once the registration is complete, that means
+            // the server has updated the user's cookies and the user is
+            // officially authenticated.
+            auth_status = 'password';
             setUserID(status.userid);
           }
           complete(onComplete, status.status);

--- a/resources/static/test/cases/controllers/actions.js
+++ b/resources/static/test/cases/controllers/actions.js
@@ -10,11 +10,28 @@
       user = bid.User,
       controller,
       el,
-      testHelpers = bid.TestHelpers;
+      testHelpers = bid.TestHelpers,
+      TEST_EMAIL = "testuser@testuser.com";
 
   function createController(config) {
     controller = BrowserID.Modules.Actions.create();
     controller.start(config);
+  }
+
+  function testActionStartsModule(actionName, actionOptions, expectedModule) {
+    createController({
+      ready: function() {
+        var error;
+        try {
+          controller[actionName](actionOptions);
+        } catch(e) {
+          error = e;
+        }
+
+        equal(error, "module not registered for " + expectedModule, "correct service started");
+        start();
+      }
+    });
   }
 
   module("controllers/actions", {
@@ -55,35 +72,13 @@
   });
 
   asyncTest("doProvisionPrimaryUser - start the provision_primary_user service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doProvisionPrimaryUser({email: "testuser@testuser.com"});
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for provision_primary_user", "correct service started");
-        start();
-      }
-    });
+    testActionStartsModule("doProvisionPrimaryUser", {email: TEST_EMAIL},
+      "provision_primary_user");
   });
 
   asyncTest("doVerifyPrimaryUser - start the verify_primary_user service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doVerifyPrimaryUser();
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for verify_primary_user", "correct service started");
-        start();
-      }
-    });
+    testActionStartsModule("doVerifyPrimaryUser", {},
+      "verify_primary_user");
   });
 
   asyncTest("doCannotVerifyRequiredPrimary - show the error screen", function() {
@@ -99,83 +94,23 @@
   });
 
   asyncTest("doPrimaryUserProvisioned - start the primary_user_verified service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doPrimaryUserProvisioned();
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for primary_user_provisioned", "correct service started");
-        start();
-      }
-    });
-  });
-
-  asyncTest("doEmailChosen - start the email_chosen service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doEmailChosen({email: "testuser@testuser.com"});
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for email_chosen", "correct service started");
-        start();
-      }
-    });
+    testActionStartsModule("doPrimaryUserProvisioned", {},
+      "primary_user_provisioned");
   });
 
   asyncTest("doConfirmUser - start the check_registration service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doConfirmUser({email: "testuser@testuser.com"});
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for check_registration", "correct service started");
-        start();
-      }
-    });
+    testActionStartsModule("doConfirmUser", {email: TEST_EMAIL},
+      "check_registration");
   });
 
   asyncTest("doConfirmEmail - start the check_registration service", function() {
-    createController({
-      ready: function() {
-        var error;
-        try {
-          controller.doConfirmEmail({email: "testuser@testuser.com"});
-        } catch(e) {
-          error = e;
-        }
-
-        equal(error, "module not registered for check_registration", "correct service started");
-        start();
-      }
-    });
-
+    testActionStartsModule("doConfirmEmail", {email: TEST_EMAIL},
+      "check_registration");
   });
 
-  asyncTest("doEmailConfirmed - generate an assertion for the email", function() {
-    createController({
-      ready: function() {
-        testHelpers.register("assertion_generated", function(msg, info) {
-          ok(info.assertion, "assertion generated");
-          start();
-        });
-
-        user.syncEmailKeypair("testuser@testuser.com", function() {
-          controller.doEmailConfirmed({email: "testuser@testuser.com"});
-        });
-      }
-    });
+  asyncTest("doGenerateAssertion - start the generate_assertion service", function() {
+    testActionStartsModule('doGenerateAssertion', { email: TEST_EMAIL }, "generate_assertion");
   });
+
 }());
 

--- a/resources/static/test/cases/controllers/generate_assertion.js
+++ b/resources/static/test/cases/controllers/generate_assertion.js
@@ -17,7 +17,7 @@
     config = config || {};
     config.ready = complete;
 
-    controller = BrowserID.Modules.EmailChosen.create();
+    controller = BrowserID.Modules.GenerateAssertion.create();
     controller.start(config);
   }
 

--- a/resources/static/test/cases/resources/state.js
+++ b/resources/static/test/cases/resources/state.js
@@ -93,10 +93,21 @@
     equal(actions.info.doConfirmUser.required, true, "doConfirmUser called with required flag");
   });
 
-  test("user_confirmed - call doEmailConfirmed", function() {
-    mediator.publish("user_confirmed");
+  test("user_confirmed - redirect to email_chosen", function() {
+    mediator.subscribe("email_chosen", function(msg, info) {
+      equal(info.email, TEST_EMAIL, "correct email passed");
+      start();
+    });
 
-    ok(actions.called.doEmailConfirmed, "user was confirmed");
+    // simulate the flow of a user being staged through to confirmation. Since
+    // we are not actually doing the middle bits and saving off a cert for the
+    // email address, we get an invalid email exception thrown.
+    mediator.publish("user_staged", { email: TEST_EMAIL });
+    try {
+      mediator.publish("user_confirmed");
+    } catch(e) {
+      equal(e.toString(), "invalid email", "expected failure");
+    }
   });
 
   test("email_staged - call doConfirmEmail", function() {
@@ -112,10 +123,13 @@
     equal(actions.info.doConfirmEmail.required, true, "doConfirmEmail called with required flag");
   });
 
-  test("primary_user with already provisioned primary user - call doEmailChosen", function() {
+  asyncTest("primary_user with already provisioned primary user - redirect to primary_user_ready", function() {
     storage.addEmail(TEST_EMAIL, { type: "primary", cert: "cert" });
+    mediator.subscribe("primary_user_ready", function(msg, info) {
+      equal(info.email, TEST_EMAIL, "primary_user_ready triggered with correct email");
+      start();
+    });
     mediator.publish("primary_user", { email: TEST_EMAIL });
-    ok(actions.called.doEmailChosen, "doEmailChosen called");
   });
 
   test("primary_user with unprovisioned primary user - call doProvisionPrimaryUser", function() {
@@ -246,7 +260,20 @@
     });
   });
 
-  asyncTest("assertion_generated with assertion, need to ask user whether it's their computer - redirect to is_this_your_computer", function() {
+  test("assertion_generated with assertion - doAssertionGenerated called", function() {
+    setContextInfo("password");
+    storage.addEmail(TEST_EMAIL, {});
+    mediator.publish("assertion_generated", {
+      assertion: "assertion"
+    });
+
+    equal(actions.info.doAssertionGenerated.assertion, "assertion",
+        "doAssertionGenerated called with assertion");
+  });
+
+
+
+  asyncTest("email_valid_and_ready, need to ask user whether it's their computer - redirect to is_this_your_computer", function() {
     setContextInfo("password");
     storage.usersComputer.forceAsk(network.userid());
     mediator.subscribe("is_this_your_computer", function() {
@@ -254,31 +281,37 @@
       start();
     });
 
-    mediator.publish("assertion_generated", {
+    mediator.publish("email_valid_and_ready", {
       assertion: "assertion"
     });
   });
 
-  test("assertion_generated with assertion, do not ask user whether it's their computer - doAssertionGenerated called", function() {
+  test("email_valid_and_ready, do not need to ask user whether it's their computer - redirect to email_ready", function() {
     setContextInfo("password");
     // First, set up the context info for the email.
 
     storage.addEmail(TEST_EMAIL, {});
-    mediator.publish("email_chosen", { email: TEST_EMAIL });
-    mediator.publish("assertion_generated", {
-      assertion: "assertion"
+    mediator.subscribe("email_ready", function() {
+      ok(true, "redirect to email_ready");
+      start();
     });
-
-    equal(actions.info.doAssertionGenerated.assertion, "assertion",
-        "doAssertionGenerated called with assertion");
-    equal(actions.info.doAssertionGenerated.email, TEST_EMAIL,
-        "doAssertionGenerated called with email");
+    mediator.publish("email_valid_and_ready", { email: TEST_EMAIL });
   });
 
   test("email_confirmed", function() {
-    mediator.publish("email_confirmed");
-
-    ok(actions.called.doEmailConfirmed, "user has confirmed the email");
+    mediator.subscribe("email_chosen", function(msg, info) {
+      equal(info.email, TEST_EMAIL, "correct email passed");
+      start();
+    });
+    mediator.publish("email_staged", { email: TEST_EMAIL });
+    // simulate the flow of a user being staged through to confirmation. Since
+    // we are not actually doing the middle bits and saving off a cert for the
+    // email address, we get an invalid email exception thrown.
+    try {
+      mediator.publish("email_confirmed");
+    } catch(e) {
+      equal(e.toString(), "invalid email", "expected failure");
+    }
   });
 
   test("cancel_state goes back to previous state if available", function() {
@@ -365,17 +398,17 @@
     });
   });
 
-  asyncTest("email_chosen with secondary email, user authenticated to secondary - call doEmailChosen", function() {
-    var email = TEST_EMAIL;
-    storage.addEmail(email, { type: "secondary" });
+  asyncTest("email_chosen with secondary email, user authenticated to secondary - redirect to email_valid_and_ready", function() {
+    storage.addEmail(TEST_EMAIL, { type: "secondary" });
     xhr.setContextInfo("auth_level", "password");
 
+    mediator.subscribe("email_valid_and_ready", function(msg, info) {
+      equal(info.email, TEST_EMAIL, "correctly redirected to email_valid_and_ready with correct email");
+      start();
+    });
+
     mediator.publish("email_chosen", {
-      email: email,
-      complete: function() {
-        equal(actions.called.doEmailChosen, true, "doEmailChosen called");
-        start();
-      }
+      email: TEST_EMAIL
     });
   });
 

--- a/resources/static/test/cases/resources/state.js
+++ b/resources/static/test/cases/resources/state.js
@@ -224,9 +224,15 @@
     // screen.
 
     // user_confirmed means the user has confirmed their email and the dialog
-    // has received the "complete" message from /wsapi/user_creation_status
-    mediator.publish("user_confirmed");
-    equal(actions.info.doEmailConfirmed.email, TEST_EMAIL, "email successfully verified, doEmailConfirmed called with the correct email");
+    // has received the "complete" message from /wsapi/user_creation_status.
+    try {
+      mediator.publish("user_confirmed");
+    } catch(e) {
+      // Exception is expected because as part of the user confirmation
+      // process, before user_confirmed is called, email addresses are synced.
+      // Addresses are not synced in this test.
+      equal(e.toString(), "invalid email", "expected failure");
+    }
   });
 
 
@@ -241,14 +247,6 @@
     mediator.publish("cancel_state");
     equal(actions.info.doAuthenticate.email, TEST_EMAIL, "authenticate called with the correct email");
   });
-
-  test("reset_password through to validation on same browser - call doEmailConfirmed with email address", function() {
-    mediator.publish("reset_password", { email: TEST_EMAIL });
-    mediator.publish("user_confirmed");
-
-    equal(actions.info.doEmailConfirmed.email, TEST_EMAIL, "doEmailConfirmed called with correct email");
-  });
-
 
   asyncTest("assertion_generated with null assertion - redirect to pick_email", function() {
     mediator.subscribe("pick_email", function() {

--- a/resources/static/test/cases/shared/network.js
+++ b/resources/static/test/cases/shared/network.js
@@ -212,21 +212,51 @@
     failureCheck(network.createUser, "validuser", "origin");
   });
 
-  asyncTest("checkUserRegistration with pending email", function() {
+  asyncTest("checkUserRegistration returns pending - pending status, user is not logged in", function() {
     transport.useResult("pending");
 
-    network.checkUserRegistration("registered@testuser.com", function(status) {
-      equal(status, "pending");
-      start();
+    // To properly check the user registration status, we first have to
+    // simulate the first checkAuth or else network has no context from which
+    // to work.
+    network.checkAuth(function(auth_status) {
+      equal(!!auth_status, false, "user not yet authenticated");
+      network.checkUserRegistration("registered@testuser.com", function(status) {
+        equal(status, "pending");
+        network.checkAuth(function(auth_status) {
+          equal(!!auth_status, false, "user not yet authenticated");
+          start();
+        }, testHelpers.unexpectedFailure);
+      }, testHelpers.unexpectedFailure);
     }, testHelpers.unexpectedFailure);
   });
 
-  asyncTest("checkUserRegistration with complete email", function() {
+  asyncTest("checkUserRegistration returns mustAuth - mustAuth status, user is not logged in", function() {
+    transport.useResult("mustAuth");
+
+    network.checkAuth(function(auth_status) {
+      equal(!!auth_status, false, "user not yet authenticated");
+      network.checkUserRegistration("registered@testuser.com", function(status) {
+        equal(status, "mustAuth");
+        network.checkAuth(function(auth_status) {
+          equal(!!auth_status, false, "user not yet authenticated");
+          start();
+        }, testHelpers.unexpectedFailure);
+      }, testHelpers.unexpectedFailure);
+    }, testHelpers.unexpectedFailure);
+  });
+
+  asyncTest("checkUserRegistration returns complete - complete status, user is logged in", function() {
     transport.useResult("complete");
 
-    network.checkUserRegistration("registered@testuser.com", function(status) {
-      equal(status, "complete");
-      start();
+    network.checkAuth(function(auth_status) {
+      equal(!!auth_status, false, "user not yet authenticated");
+      network.checkUserRegistration("registered@testuser.com", function(status) {
+        equal(status, "complete");
+        network.checkAuth(function(auth_status) {
+          equal(auth_status, "password", "user authenticated after checkUserRegistration returns complete");
+          start();
+        }, testHelpers.unexpectedFailure);
+      }, testHelpers.unexpectedFailure);
     }, testHelpers.unexpectedFailure);
   });
 

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -122,7 +122,7 @@
     <script src="/dialog/controllers/forgot_password.js"></script>
     <script src="/dialog/controllers/required_email.js"></script>
     <script src="/dialog/controllers/verify_primary_user.js"></script>
-    <script src="/dialog/controllers/email_chosen.js"></script>
+    <script src="/dialog/controllers/generate_assertion.js"></script>
     <script src="/dialog/controllers/provision_primary_user.js"></script>
     <script src="/dialog/controllers/primary_user_provisioned.js"></script>
     <script src="/dialog/controllers/is_this_your_computer.js"></script>
@@ -181,7 +181,7 @@
     <script src="cases/controllers/forgot_password.js"></script>
     <script src="cases/controllers/required_email.js"></script>
     <script src="cases/controllers/verify_primary_user.js"></script>
-    <script src="cases/controllers/email_chosen.js"></script>
+    <script src="cases/controllers/generate_assertion.js"></script>
     <script src="cases/controllers/provision_primary_user.js"></script>
     <script src="cases/controllers/primary_user_provisioned.js"></script>
     <script src="cases/controllers/is_this_your_computer.js"></script>


### PR DESCRIPTION
It started as a simple exercise.  It ended in a yak shave.
- This fixes a problem where it is possible that a user takes more than 2 minutes to answer, making the already generated assertion invalid.
- A lot of general cleanup of the state machine.
- Push all post email selection flows to a new state, "email_valid_and_ready" which decides whether to ask the user the computer ownership status.
- Assertions are generated after the "is this your computer" is asked.
- doEmailChosen is replaced with doGenerateAssertion - there were multiple calls to generate an assertion, not very DRY.
- Fix a problem in network.js where a user who completes user registration should be marked as authenticated.
- rename email_chosen.js to generate_assertion.js to clarify its purpose.

issue #1460
