### PR TITLE
Fix primary email being set as most recently used if the user cancels redirect to authenticate with primary.

### DIFF
--- a/resources/static/dialog/controllers/pick_email.js
+++ b/resources/static/dialog/controllers/pick_email.js
@@ -48,9 +48,6 @@ BrowserID.Modules.PickEmail = (function() {
 
     var valid = checkEmail.call(self, email);
     if (valid) {
-      var origin = user.getOrigin();
-      storage.site.set(origin, "email", email);
-
       self.close("email_chosen", { email: email });
     }
   }

--- a/resources/static/test/cases/controllers/pick_email.js
+++ b/resources/static/test/cases/controllers/pick_email.js
@@ -76,7 +76,7 @@
     equal(label.hasClass("preselected"), false, "the label has no class");
   });
 
-  asyncTest("signIn - saves picked email to storage", function() {
+  asyncTest("signIn - trigger 'email_chosen message'", function() {
     storage.addEmail("testuser@testuser.com", {});
     storage.addEmail("testuser2@testuser.com", {});
 
@@ -87,7 +87,6 @@
     var assertion;
 
     register("email_chosen", function(msg, info) {
-      equal(storage.site.get(testOrigin, "email"), "testuser2@testuser.com", "email saved correctly");
       ok(info.email, "email_chosen message triggered with email");
       start();
     });


### PR DESCRIPTION
- all emails are set for the origin in user.getAssertion.  Having it in pick_email meant that as soon as a user chose an address and the controller was closed, the email was marked as the most recently used when this may not always be the case.

issue #968
