### PR TITLE
Hotfix 1390 fix ie6 ie7

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -956,12 +956,21 @@
         throw "navigator.id.get() requires a callback argument";
       }
 
+      var browserSupported = BrowserSupport.isSupported();
+
       if (options && options.silent) {
-        _noninteractiveCall('getPersistentAssertion', { }, function(rv) {
-          callback(rv);
-        }, function(e, msg) {
+        // We MUST check for browser support or else an exception will be
+        // thrown in the _noninteractiveCall when a JSChannel is created.
+        if(browserSupported) {
+          _noninteractiveCall('getPersistentAssertion', { }, function(rv) {
+            callback(rv);
+          }, function(e, msg) {
+            callback(null);
+          });
+        }
+        else {
           callback(null);
-        });
+        }
       } else {
         // focus an existing window
         if (w) {
@@ -974,7 +983,7 @@
           return;
         }
 
-        if (!BrowserSupport.isSupported()) {
+        if (!browserSupported) {
           var reason = BrowserSupport.getNoSupportReason(),
               url = "unsupported_dialog";
 

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -5,7 +5,7 @@
 BrowserID.Storage = (function() {
 
   var jwk,
-      storage = localStorage;
+      storage = window.localStorage;
 
   function prepareDeps() {
     if (!jwk) {


### PR DESCRIPTION
- storage.js - change var storage = localStorage to storage = window.localStorage in case localStorage does not exist.
- include.js - check to ensure the browser is supported before getting a silent assertion or else an exception is thrown when trying to build the JSChannel.

issue #1390
issue #1481
