### PR TITLE
Hotfix 1484 chrome exception signup

### DIFF
--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -28,6 +28,14 @@ BrowserID.Storage = (function() {
     }
   }
 
+  function logError(msg) {
+    // Check for the existence of window.console for IE.  IE does not support console
+    // logging unless its dev tools are open.
+    if(window.console && console.log) {
+      console.log(msg);
+    }
+  }
+
   function storeEmails(emails) {
     storage.emails = JSON.stringify(emails);
   }
@@ -128,6 +136,7 @@ BrowserID.Storage = (function() {
     }
     catch(e) {
       // Chrome, Safari and FF will blow up here if cookies are disabled.
+      logError("error writing to storage: " + e);
     }
   }
 
@@ -187,6 +196,7 @@ BrowserID.Storage = (function() {
     } catch(e) {
       // Do nothing, Chrome, Safari and FF will blow up here if cookies are
       // disabled.
+      logError("error writing to storage: " + e);
     }
   }
 
@@ -195,6 +205,7 @@ BrowserID.Storage = (function() {
       var allInfo = JSON.parse(storage[namespace] || "{}");
       return allInfo[key];
     } catch(e) {
+      logError("error reading from storage: " + e);
       return undefined;
     }
   }

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -29,10 +29,13 @@ BrowserID.Storage = (function() {
   }
 
   function logError(msg) {
-    // Check for the existence of window.console for IE.  IE does not support console
-    // logging unless its dev tools are open.
-    if(window.console && console.log) {
+    try {
       console.log(msg);
+    } catch(e) {
+      // Do nothing. The console.log is inside of a try/catch because some
+      // versions of IE do not have window.console unless the dev tools are
+      // open.  This ensures that any browser that does not support console.log
+      // will not cause any problems while we are trying to log errors.
     }
   }
 

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -120,10 +120,15 @@ BrowserID.Storage = (function() {
   }
 
   function setStagedOnBehalfOf(origin) {
-    storage.stagedOnBehalfOf = JSON.stringify({
-      at: new Date().toString(),
-      origin: origin
-    });
+    try {
+      storage.stagedOnBehalfOf = JSON.stringify({
+        at: new Date().toString(),
+        origin: origin
+      });
+    }
+    catch(e) {
+      // Chrome, Safari and FF will blow up here if cookies are disabled.
+    }
   }
 
   function getStagedOnBehalfOf() {
@@ -175,14 +180,23 @@ BrowserID.Storage = (function() {
   }
 
   function generic2KeySet(namespace, key, value) {
-    var allInfo = JSON.parse(storage[namespace] || "{}");
-    allInfo[key] = value;
-    storage[namespace] = JSON.stringify(allInfo);
+    try {
+      var allInfo = JSON.parse(storage[namespace] || "{}");
+      allInfo[key] = value;
+      storage[namespace] = JSON.stringify(allInfo);
+    } catch(e) {
+      // Do nothing, Chrome, Safari and FF will blow up here if cookies are
+      // disabled.
+    }
   }
 
   function generic2KeyGet(namespace, key) {
-    var allInfo = JSON.parse(storage[namespace] || "{}");
-    return allInfo[key];
+    try {
+      var allInfo = JSON.parse(storage[namespace] || "{}");
+      return allInfo[key];
+    } catch(e) {
+      return undefined;
+    }
   }
 
   function generic2KeyRemove(namespace, key) {


### PR DESCRIPTION
Swallow exceptions that Chrome throws when writing to localStorage if cookies are disabled.

I am not fully happy with this solution as it is a bandaid instead of a true fix for the root cause. I am writing a fuller solution against the current dev to show the cookies disabled error screen as soon as the user lands on the majority of main site pages.

issue #1484.
