### PR TITLE
issue 1464 ie exception check registration

### DIFF
--- a/resources/static/test/cases/controllers/check_registration.js
+++ b/resources/static/test/cases/controllers/check_registration.js
@@ -47,18 +47,18 @@
     controller.startCheck();
   }
 
-  asyncTest("user validation with mustAuth result", function() {
+  asyncTest("user validation with mustAuth result - callback with email, type and known set to true", function() {
     xhr.useResult("mustAuth");
     createController("waitForUserValidation");
     register("authenticate", function(msg, info) {
+      // we want the email, type and known all sent back to the caller so that
+      // this information does not need to be queried again.
       equal(info.email, "registered@testuser.com", "correct email");
       ok(info.type, "type sent with info");
       ok(info.known, "email is known");
       start();
     });
     controller.startCheck();
-
-    testVerifiedUserEvent("authenticate", "User Must Auth");
   });
 
   asyncTest("user validation with pending->complete result ~3 seconds", function() {


### PR DESCRIPTION
Fix the broken test in check_registration.  It was starting the registration check twice, meaning there were two concurrent polls happening.

I am submitting this pull request against the current beta because that is where @jrgm reported the problem.  A hotfix is not needed because this is not a user facing problem.

issue #1464
