### PR TITLE
Hotfix 1390 min browser reqs

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -958,10 +958,16 @@
       }
     }
 
-    var commChan;
+    var commChan,
+        browserSupported = BrowserSupport.isSupported();
 
     // this is for calls that are non-interactive
     function _open_hidden_iframe() {
+      // If this is an unsupported browser, do not even attempt to add the
+      // IFRAME as doing so will cause an exception to be thrown in IE6 and IE7
+      // from within the communication_iframe.
+      if(!browserSupported) return;
+
       try {
         if (!commChan) {
           var doc = window.document;
@@ -996,8 +1002,8 @@
           });
         }
       } catch(e) {
-        // channel building failed!  this is probably an unsupported browser.  let's ignore
-        // the error and allow higher level code to handle user messaging.
+        // channel building failed!  let's ignore the error and allow higher
+        // level code to handle user messaging.
         commChan = undefined;
       }
     }
@@ -1116,8 +1122,8 @@
       logout: function(callback) {
         // allocate iframe if it is not allocated
         _open_hidden_iframe();
-        // send logout message
-        commChan.notify({ method: 'logout' });
+        // send logout message if the commChan exists
+        if (commChan) commChan.notify({ method: 'logout' });
         if (typeof callback === 'function') setTimeout(callback, 0);
       },
       // get an assertion

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -12,8 +12,9 @@ BrowserID.Storage = (function() {
   }
   catch(e) {
     // Fx with cookies disabled will except while trying to access
-    // localStorage.  Because of this, and because the new API requires access
-    // to localStorage
+    // localStorage.  IE6/IE7 will just plain blow up because they have no
+    // notion of localStorage.  Because of this, and because the new API
+    // requires access to localStorage, create a fake one with removeItem.
     storage = {
       removeItem: function(key) {
         this[key] = null;


### PR DESCRIPTION
@lloyd - can you review this?  With this change, I am no longer adding the communication_iframe to the page if the user's browser does not meet the minimum browser requirements.  I did this because IE6 and IE7 throw an exception from within the communication_iframe.  We can prevent the iframe from being added on browsers we know do not meet minimum requirements, saving the users a few KB and keeping this error from happening.

A second change is on line 1126, in the logout function.  Before sending a message to the commChan, check to see if it exists.

To fully test this:
- Check both IE6 and IE7 to ensure they no longer throw an exception when loading the dev RP.
- Check browsers we know support the protocol to ensure they still get their silent assertions.

Changes:
- include.js - check to ensure the browser is supported before setting up the communication_iframe.  Adding the iframe in unsupported browsers will cause an exception within the iframe.

issue #1390
