### PR TITLE
Fix IE6 and IE7 throwing exceptions in the communication iframe.

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -958,10 +958,16 @@
       }
     }
 
-    var commChan;
+    var commChan,
+        browserSupported = BrowserSupport.isSupported();
 
     // this is for calls that are non-interactive
     function _open_hidden_iframe() {
+      // If this is an unsupported browser, do not even attempt to add the
+      // IFRAME as doing so will cause an exception to be thrown in IE6 and IE7
+      // from within the communication_iframe.
+      if(!browserSupported) return;
+
       try {
         if (!commChan) {
           var doc = window.document;
@@ -996,8 +1002,8 @@
           });
         }
       } catch(e) {
-        // channel building failed!  this is probably an unsupported browser.  let's ignore
-        // the error and allow higher level code to handle user messaging.
+        // channel building failed!  let's ignore the error and allow higher
+        // level code to handle user messaging.
         commChan = undefined;
       }
     }
@@ -1122,8 +1128,8 @@
       logout: function(callback) {
         // allocate iframe if it is not allocated
         _open_hidden_iframe();
-        // send logout message
-        commChan.notify({ method: 'logout' });
+        // send logout message if the commChan exists
+        if (commChan) commChan.notify({ method: 'logout' });
         if (typeof callback === 'function') setTimeout(callback, 0);
       },
       // get an assertion

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -12,8 +12,9 @@ BrowserID.Storage = (function() {
   }
   catch(e) {
     // Fx with cookies disabled will except while trying to access
-    // localStorage.  Because of this, and because the new API requires access
-    // to localStorage
+    // localStorage.  IE6/IE7 will just plain blow up because they have no
+    // notion of localStorage.  Because of this, and because the new API
+    // requires access to localStorage, create a fake one with removeItem.
     storage = {
       removeItem: function(key) {
         this[key] = null;


### PR DESCRIPTION
Pull request to replace https://github.com/mozilla/browserid/pull/1494.  This is against the current dev instead of the past train.
- include.js - check to ensure the browser is supported before setting up the communication_iframe.  Adding the iframe in unsupported browsers will cause an exception within the iframe.

issue #1390

Conflicts:

```
resources/static/include_js/include.js
resources/static/shared/storage.js
```
