### PR TITLE
Ensure the cookies disabled check does not run on /tos, /about or /privacy

### DIFF
--- a/resources/static/pages/start.js
+++ b/resources/static/pages/start.js
@@ -24,7 +24,8 @@ $(function() {
       CookieCheck = modules.CookieCheck,
       XHRDelay = modules.XHRDelay,
       XHRDisableForm = modules.XHRDisableForm,
-      ANIMATION_TIME = 500;
+      ANIMATION_TIME = 500,
+      checkCookiePaths = [ "/signin", "/signup", "/forgot", "/add_email_address", "/verify_email_address" ];
 
 
   xhr.init({ time_until_delay: 10 * 1000 });
@@ -41,7 +42,7 @@ $(function() {
   moduleManager.register("xhr_disable_form", XHRDisableForm);
   moduleManager.start("xhr_disable_form");
 
-  if(path && path !== "/") {
+  if(path && (checkCookiePaths.indexOf(path) > -1)) {
     // do a cookie check on every page except the main page.
     moduleManager.register("cookie_check", CookieCheck);
     moduleManager.start("cookie_check", { ready: start });


### PR DESCRIPTION
- Create a list of pages where the cookie check should be run.

To test:
1) Disable cookies
2) Test for cookies disabled message on the following pages: /signup, /signin, /forgot, /add_email_address, /verify_email_address
3) Test cookies disabled message does not appear on the following pages: /, /tos, /privacy, /about

4) Enable cookies
5) Test cookies disabled message does not appear on: /signup, /signin, /forgot, /add_email_address, /verify_email_address, /, /tos, /privacy, /about

issue #1514
