### PR TITLE
Fix the IE6 and IE7 black screens on the main site.

### DIFF
--- a/resources/static/css/style.css
+++ b/resources/static/css/style.css
@@ -21,6 +21,7 @@ noscript {
   right: 0;
   bottom: 0;
   left: 0;
+  filter: alpha(opacity=0); /* Needed for IE6 and IE7 on the main site */
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
   opacity: 0;
   z-index: -2;
@@ -42,6 +43,7 @@ noscript {
 
 #error, #wait, #delay {
   z-index: -2;
+  filter: alpha(opacity=0); /* Needed for IE6 and IE7 on the main site */
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
   opacity: 0;
   -webkit-transition: opacity 750ms;

--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -43,7 +43,7 @@ BrowserID.Storage = (function() {
   }
 
   function clear() {
-    storeEmails({});
+    storage.removeItem("emails");
     storage.removeItem("tempKeypair");
     storage.removeItem("stagedOnBehalfOf");
     storage.removeItem("siteInfo");


### PR DESCRIPTION
- css/style.css - where relevant and opacity's are used, use filters for IE6 and IE7.
- shared/storage.js - when clearing localStorage if the user is not authenticated, call removeItem for the emails.  The call to JSON.stringify was blowing up.

issue #1529
