### PR TITLE
Adding timestamp server side to get an intial integration going.

### DIFF
--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -28,6 +28,10 @@ var store = function (kpi_json, cb) {
       kpi_resp = function (res) {
         logger.debug('KPI Backend responded ' + res.statusCode);
       };
+  // TODO - timestamp should be client or server side?
+  if (! kpi_json.timestamp) {
+    kpi_json.timestamp = new Date().getTime();
+  }
   if (!! config.get('kpi_backend_db_url')) {
 
     var post_data = querystring.stringify({


### PR DESCRIPTION
Per an email, our basic integration isn't putting data into KPIggybank properly.

Do we want to land this for this train, so stage records data?

I'm not sure if timestamp should be added client side, or server side.

This should get us going, but pointing my local dev to 

```
"kpi_backend_db_url": "http://23.20.153.45/wsapi/interaction_data",
```

I still don't see the data if I visit that URL and grep through the returned JSON.
