### PR TITLE
Issue 1597 - ensure that kpi data always includes core metadata (lang, window size, etc.)

### DIFF
--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -9,7 +9,8 @@ const coarse = require('../coarse_user_agent_parser'),
       querystring = require('querystring'),
       und = require('underscore'),
       urlparse = require('urlparse'),
-      wsapi = require('../wsapi.js');
+      wsapi = require('../wsapi.js'),
+      TEN_MIN_IN_MS = 10 * 60 * 1000;
 
 // Accept JSON formatted interaction data and send it to the KPI Backend
 
@@ -28,11 +29,22 @@ var store = function (kpi_json, cb) {
       kpi_resp = function (res) {
         logger.debug('KPI Backend responded ' + res.statusCode);
       };
-  // TODO - timestamp should be client or server side?
-  und.each(kpi_json, function (kpi) {
+
+  // Out of concern for the user's privacy, scrub the data of identifying
+  // details before storing it.
+  //
+  // - Remove the local_timestamp: This was necessary for the client to keep
+  //   track of the start time for the event stream, but it should not be part 
+  //   of the final record.
+  // 
+  // - Round the server timestamp off to the nearest 10-minute mark.
+  und.each(kpi_json, function (kpi) { delete kpi.local_timestamp;
+    delete kpi.local_timestamp;
+
     if (! kpi.timestamp) {
       kpi.timestamp = new Date().getTime();
     }
+    kpi.timestamp = kpi.timestamp - (kpi.timestamp % TEN_MIN_IN_MS);
   });
   if (!! config.get('kpi_backend_db_url')) {
 


### PR DESCRIPTION
I've explained my thinking in a comment on the commits.  It's not the most beautiful solution, I admit, but it keeps things moving forward.

Passes tests without modification to test suite.  (that was actually rather challenging)

When inspected in kpiggybank, resulting data looks good.

@shane-tomlinson was a huge help earlier today, spending a fair chunk of time so we could work out what was going on together.  Thanks also to @ozten for letting me talk through this with him.
