### PR TITLE
Issue 1597 interaction data

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -80,6 +80,9 @@ var dialog_js = und.flatten([
     '/shared/history.js',
     '/shared/state_machine.js',
 
+    '/shared/models/models.js',
+    '/shared/models/interaction_data.js',
+
     '/shared/modules/interaction_data.js',
 
     '/dialog/resources/internal_api.js',

--- a/resources/static/shared/models/interaction_data.js
+++ b/resources/static/shared/models/interaction_data.js
@@ -25,7 +25,6 @@ BrowserID.Models.InteractionData = (function() {
     try {
       storage.interaction_data = JSON.stringify(data);
     } catch(e) {
-      console.log(e);
       storage.removeItem("interaction_data");
     }
   }

--- a/resources/static/shared/models/interaction_data.js
+++ b/resources/static/shared/models/interaction_data.js
@@ -1,0 +1,164 @@
+/*globals BrowserID: true */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+BrowserID.Models.InteractionData = (function() {
+  "use strict";
+
+  var bid = BrowserID,
+      storage = bid.getStorage(),
+      network = bid.Network,
+      complete = bid.Helpers.complete;
+
+  function getInteractionData() {
+    var interactionData;
+    try {
+      interactionData = JSON.parse(storage.interaction_data);
+    } catch(e) {
+    }
+
+    return interactionData || {};
+  }
+
+  function setInteractionData(data) {
+    try {
+      storage.interaction_data = JSON.stringify(data);
+    } catch(e) {
+      console.log(e);
+      storage.removeItem("interaction_data");
+    }
+  }
+
+  function push(newData) {
+    stageCurrent();
+
+    var interactionData = getInteractionData();
+    interactionData.current = newData;
+
+    setInteractionData(interactionData);
+  }
+
+  function getCurrent() {
+    var interactionData = getInteractionData();
+
+    return interactionData.current;
+  }
+
+  function setCurrent(data) {
+    var interactionData = getInteractionData();
+    interactionData.current = data;
+    setInteractionData(interactionData);
+  }
+
+  function stageCurrent() {
+    // Push existing current data to the staged list.  This allows
+    // us to get/clear the staged list without affecting the current data.
+    var interactionData = getInteractionData();
+
+    if (interactionData.current) {
+      var staged = interactionData.staged = interactionData.staged || [];
+      staged.unshift(interactionData.current);
+
+      delete interactionData.current;
+
+      setInteractionData(interactionData);
+    }
+  }
+
+  function getStaged() {
+    var interactionData = getInteractionData();
+    return interactionData.staged || [];
+  }
+
+  function clearStaged() {
+    var interactionData = getInteractionData();
+    delete interactionData.staged;
+    setInteractionData(interactionData);
+  }
+
+  // We'll try to publish past interaction data to the server if it exists.
+  // The psuedo transactional model employed here is to attempt to post, and
+  // only once we receive a server response do we purge data.  We don't
+  // care if the post is a success or failure as this data is not
+  // critical to the functioning of the system (and some failure scenarios
+  // simply won't resolve with retries - like corrupt data, or too much
+  // data)
+  function publishStaged(oncomplete) {
+     var data = getStaged();
+
+    // XXX: should we even try to post data if it's larger than some reasonable
+    // threshold?
+    if (data && data.length !== 0) {
+      network.sendInteractionData(data, function() {
+        clearStaged();
+        complete(oncomplete, true);
+      }, function(status) {
+        // if the server returns a 413 error, (too much data posted), then
+        // let's clear our local storage and move on.  This does mean we
+        // loose some interaction data, but it shouldn't be statistically
+        // significant.
+        if (status && status.network && status.network.status === 413) {
+          clearStaged();
+        }
+        complete(oncomplete, false);
+      });
+    }
+    else {
+      complete(oncomplete, false);
+    }
+  }
+
+  return {
+    /**
+     * add a new interaction blob to localstorage, this will *push* any stored
+     * blobs to the 'staged' backlog, and happens when a new dialog interaction
+     * begins.
+     * @method push
+     * @param {object} data - an object to push onto the queue
+     * @returns nada
+     */
+    push: push,
+    /**
+     * read the interaction data blob associated with the current interaction
+     * @method getCurrent
+     * @returns a JSON object containing the latest interaction data blob
+     */
+    getCurrent: getCurrent,
+    /**
+     * overwrite the interaction data blob associated with the current interaction
+     * @method setCurrent
+     * @param {object} data - the object to overwrite current with
+     */
+    setCurrent: setCurrent,
+    /**
+     * Shift any "current" data into the staged list.  No data will be listed
+     * as current afterwards.
+     * @method stageCurrent
+     */
+    stageCurrent: stageCurrent,
+    /**
+     * get all past saved interaction data (returned as a JSON array), excluding
+     * the "current" data (that which is being collected now).
+     * @method getStaged
+     * @returns an array, possibly of length zero if no past interaction data is
+     * available
+     */
+    getStaged: getStaged,
+    /**
+     * publish staged data. Staged data will be cleared if successfully posted
+     * to server or if server returns 413 - too much data.
+     * @param {function} [oncomplete] - function to call when complete.  Called
+     * with true if data was successfully sent to server, false otw.
+     * @method publishStaged
+     */
+    publishStaged: publishStaged,
+    /**
+     * clear all interaction data, except the current, in-progress
+     * collection.
+     * @method clearStaged()
+     */
+    clearStaged: clearStaged
+  };
+
+}());

--- a/resources/static/shared/models/models.js
+++ b/resources/static/shared/models/models.js
@@ -1,0 +1,7 @@
+/*globals BrowserID: true */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+BrowserID.Models = {};
+

--- a/resources/static/shared/modules/interaction_data.js
+++ b/resources/static/shared/modules/interaction_data.js
@@ -24,14 +24,13 @@
 
 BrowserID.Modules.InteractionData = (function() {
   var bid = BrowserID,
-      storage = bid.Storage.interactionData,
+      model = bid.Models.InteractionData,
       network = bid.Network,
       complete = bid.Helpers.complete,
       dom = bid.DOM,
       sc;
 
   function onSessionContext(msg, result) {
-    console.log("session context");
     var self=this;
 
     // defend against onSessionContext being called multiple times
@@ -43,103 +42,98 @@ BrowserID.Modules.InteractionData = (function() {
     // dialog session is allowed to sample data. This is because the original
     // dialog session has already decided whether to collect data.
 
-    // Continuation after publishing MUST be done
-    publishStored(function() {
-      // set the sample rate as defined by the server.  It's a value
-      // between 0..1, integer or float, and it specifies the percentage
-      // of the time that we should capture
-      var sampleRate = result.data_sample_rate || 0;
+    model.stageCurrent();
+    publishStored.call(self);
 
-      if (typeof self.samplingEnabled === "undefined") {
-        // now that we've got sample rate, let's smash it into a boolean
-        // probalistically
-        self.samplingEnabled = Math.random() <= sampleRate;
-      }
+    // set the sample rate as defined by the server.  It's a value
+    // between 0..1, integer or float, and it specifies the percentage
+    // of the time that we should capture
+    var sampleRate = result.data_sample_rate || 0;
 
-      // if we're not going to sample, kick out early.
-      if (!self.samplingEnabled) {
-        return;
-      }
+    if (typeof self.samplingEnabled === "undefined") {
+      // now that we've got sample rate, let's smash it into a boolean
+      // probalistically
+      self.samplingEnabled = Math.random() <= sampleRate;
+    }
 
-      var currentData = {
-        event_stream: self.initialEventStream,
-        sample_rate: sampleRate,
-        timestamp: result.server_time,
-        local_timestamp: self.startTime.toString(),
-        lang: dom.getAttr('html', 'lang') || null,
+    // if we're not going to sample, kick out early.
+    if (!self.samplingEnabled) {
+      return;
+    }
+
+    var currentData = {
+      event_stream: self.initialEventStream,
+      sample_rate: sampleRate,
+      timestamp: result.server_time,
+      local_timestamp: self.startTime.toString(),
+      lang: dom.getAttr('html', 'lang') || null,
+    };
+
+    if (window.screen) {
+      currentData.screen_size = {
+        width: window.screen.width,
+        height: window.screen.height
       };
+    }
 
-      if (window.screen) {
-        currentData.screen_size = {
-          width: window.screen.width,
-          height: window.screen.height
-        };
-      }
+    // cool.  now let's persist the initial data.  This data will be published
+    // as soon as the first session_context completes for the next dialog
+    // session.  Use a push because old data *may not* have been correctly
+    // published to a down server or erroring web service.
+    model.push(currentData);
 
-      // cool.  now let's persist the initial data.  This data will be published
-      // as soon as the first session_context completes for the next dialog
-      // session.  Use a push because old data *may not* have been correctly
-      // published to a down server or erroring web service.
-      console.log("pushing currentData");
-      storage.push(currentData);
+    self.initialEventStream = null;
 
-      self.initialEventStream = null;
-
-      self.samplesBeingStored = true;
-    });
+    self.samplesBeingStored = true;
   }
 
-  // At every load, after session_context returns, we'll try to publish
-  // past interaction data to the server if it exists.  The psuedo
-  // transactional model employed here is to attempt to post, and only
-  // once we receive a server response do we purge data.  We don't
-  // care if the post is a success or failure as this data is not
-  // critical to the functioning of the system (and some failure scenarios
-  // simply won't resolve with retries - like corrupt data, or too much
-  // data)
+  // At every load, after session_context returns, try to publish the previous
+  // data.  We have to wait until session_context completes so that we have
+  // a csrf token to send.
   function publishStored(oncomplete) {
-    var data = storage.get();
+    var self=this;
 
-    // XXX: should we even try to post data if it's larger than some reasonable
-    // threshold?
-    console.log(data);
-    if (data && data.length !== 0) {
-      network.sendInteractionData(data, function() {
-        console.log("clear");
-        storage.clear();
-        complete(oncomplete, true);
-      }, function(status) {
-        // if the server returns a 413 error, (too much data posted), then
-        // let's clear our local storage and move on.  This does mean we
-        // loose some interaction data, but it shouldn't be statistically
-        // significant.
-        if (status && status.network && status.network.status === 413) {
-          storage.clear();
-        }
-        complete(oncomplete, false);
-      });
-    }
-    else {
-      complete(oncomplete, false);
-    }
+    model.publishStaged(function(status) {
+      var msg = status ? "interaction_data_send_complete" : "interaction_data_send_error";
+      self.publish(msg);
+      complete(oncomplete, status);
+    });
   }
 
 
   function addEvent(eventName) {
     var self=this;
-
     if (self.samplingEnabled === false) return;
 
     var eventData = [ eventName, new Date() - self.startTime ];
     if (self.samplesBeingStored) {
-      console.log("add stored event:" + eventName);
-      var d = storage.current() || {};
+      var d = model.getCurrent() || {};
       if (!d.event_stream) d.event_stream = [];
       d.event_stream.push(eventData);
-      storage.setCurrent(d);
+      model.setCurrent(d);
     } else {
-      console.log("add initial event:" + eventName);
       self.initialEventStream.push(eventData);
+    }
+  }
+
+  function getCurrent() {
+    var self=this;
+    if(self.samplingEnabled === false) return;
+
+    if (self.samplesBeingStored) {
+      return model.getCurrent();
+    }
+  }
+
+  function getCurrentEventStream() {
+    var self=this;
+    if(self.samplingEnabled === false) return;
+
+    if (self.samplesBeingStored) {
+      return model.getCurrent().event_stream;
+    }
+    else {
+      return self.initialEventStream;
     }
   }
 
@@ -155,29 +149,28 @@ BrowserID.Modules.InteractionData = (function() {
       // a continuation, samplingEnabled will be decided on the first "
       // context_info" event, which corresponds to the first time
       // 'session_context' returns from the server.
+      // samplingEnabled flag ignored for a continuation.
       self.samplingEnabled = options.samplingEnabled;
 
       // continuation means the users dialog session is continuing, probably
       // due to a redirect to an IdP and then a return after authentication.
       if (options.continuation) {
-        var previousData = storage.current();
-
-        var samplingEnabled = self.samplingEnabled = !!previousData.event_stream;
-        if (samplingEnabled) {
+        // There will be no current data if the previous session was not
+        // allowed to save.
+        var previousData = model.getCurrent();
+        if (previousData) {
           self.startTime = Date.parse(previousData.local_timestamp);
 
-          if (typeof self.samplingEnabled === "undefined") {
-            self.samplingEnabled = samplingEnabled;
-          }
 
           // instead of waiting for session_context to start appending data to
           // localStorage, start saving into localStorage now.
-          self.samplesBeingStored = true;
+          self.samplingEnabled = self.samplesBeingStored = true;
         }
         else {
-          // If there was no previous event stream, that means data collection
+          // If there was no previous data, that means data collection
           // was not allowed for the previous session.  Return with no further
           // action, data collection is not allowed for this session either.
+          self.samplingEnabled = false;
           return;
         }
       }
@@ -187,7 +180,7 @@ BrowserID.Modules.InteractionData = (function() {
         // The initialEventStream is used to store events until onSessionContext
         // is called.  Once onSessionContext is called and it is known whether
         // the user's data will be saved, initialEventStream will either be
-        // discarded or added to the data set that is saved to localStorage.
+        // discarded or added to the data set that is saved to localmodel.
         self.initialEventStream = [];
         self.samplesBeingStored = false;
 
@@ -202,16 +195,8 @@ BrowserID.Modules.InteractionData = (function() {
     },
 
     addEvent: addEvent,
-
-    getCurrentStoredData: function() {
-      var und;
-      return this.samplesBeingStored ? storage.current() : und;
-    },
-
-    getEventStream: function() {
-      return this.samplesBeingStored ? storage.current().event_stream : this.initialEventStream || [];
-    },
-
+    getCurrent: getCurrent,
+    getCurrentEventStream: getCurrentEventStream,
     publishStored: publishStored
   });
 

--- a/resources/static/test/cases/shared/models/interaction_data.js
+++ b/resources/static/test/cases/shared/models/interaction_data.js
@@ -1,0 +1,108 @@
+
+/*jshint browsers:true, forin: true, laxbreak: true */
+/*global test: true, start: true, stop: true, module: true, ok: true, equal: true, BrowserID:true */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  var bid = BrowserID,
+      model = bid.Models.InteractionData,
+      testHelpers = bid.TestHelpers,
+      testObjectValuesEqual = testHelpers.testObjectValuesEqual,
+      xhr = bid.Mocks.xhr;
+
+  module("shared/models/interaction_data", {
+    setup: function() {
+      testHelpers.setup();
+      localStorage.removeItem("interaction_data");
+    },
+
+    teardown: function() {
+      testHelpers.teardown();
+    }
+  });
+
+  test("after push, most recently pushed data available through getCurrent, getStaged gets previous data sets", function() {
+    model.push({ foo: "bar" });
+    equal(model.getCurrent().foo, "bar",
+          "after pushing new interaction data, it's returned from .getCurrent()");
+
+    equal(model.getStaged().length, 0, "no data is yet staged");
+
+    model.push({ foo: "baz" });
+
+    equal(model.getCurrent().foo, "baz", "current points to new data set")
+    var staged = model.getStaged();
+
+    equal(staged.length, 1, "only one staged item");
+    testObjectValuesEqual(staged[0], { foo: "bar" });
+  });
+
+  test("setCurrent data overwrites current", function() {
+    model.clearStaged();
+    model.push({ foo: "bar" });
+    model.setCurrent({ foo: "baz" });
+    equal(model.getCurrent().foo, "baz",
+          "overwriting current interaction data works");
+  });
+
+  test("clearStaged clears staged interaction data but leaves current data unaffected", function() {
+    model.push({ foo: "bar" });
+    model.push({ foo: "baz" });
+    model.clearStaged();
+    equal(model.getStaged().length, 0,
+          "after clearStageding, interaction data is zero length");
+    equal(model.getCurrent().foo, "baz",
+          "after clearStageding, current data is unaffected");
+  });
+
+  test("stageCurrent - stage the current data, if any. no data is current afterwards", function() {
+    // There is no current data to stage.
+    model.stageCurrent();
+    equal(model.getStaged().length, 0, "no data to staged");
+
+    model.push({ foo: "bar" });
+    model.stageCurrent();
+
+    equal(model.getStaged().length, 1, "current data staged");
+    equal(typeof model.getCurrent(), "undefined", "current data removed after being staged");
+  });
+
+  asyncTest("publishStored - publish any staged data", function() {
+    // There is no currently staged data.
+    model.publishStaged(function(status) {
+      equal(status, false, "no data currently staged");
+
+      // Simulate a throttling
+      // desired result - data is purged from staging table
+
+      // The first pushed data will become staged.
+      model.push({ foo: "bar" });
+      model.stageCurrent();
+
+      xhr.useResult("throttle");
+      model.publishStaged(function(status) {
+        equal(false, status, "data throttling returns false status");
+        // the previously staged data should we wiped on a throttling response.
+
+        // When the interaction_data next completes, this will be the only data
+        // that is pushed.
+        model.push({ foo: "baz" });
+        model.stageCurrent();
+
+        xhr.useResult("valid");
+        model.publishStaged(function(status) {
+          equal(true, status, "data successfully posted");
+          var request = xhr.getLastRequest('/wsapi/interaction_data'),
+              previousSessionsData = JSON.parse(request.data).data;
+
+          equal(previousSessionsData.length, 1, "sending correct result sets");
+          equal(previousSessionsData[0].foo, "baz", "correct data sent");
+          start();
+        });
+      });
+
+    });
+
+  });
+}());

--- a/resources/static/test/cases/shared/modules/interaction_data.js
+++ b/resources/static/test/cases/shared/modules/interaction_data.js
@@ -170,23 +170,31 @@
 
 
   asyncTest("simulate failed starts - data not sent until second successful session_context", function() {
-    // simulate 3 dialog openings without session completing for any of them.
-    // On the forth attempt at opening the dialog, the data is successfully
-    // sent.
+    // simulate three dialogs being opened.
+    // The first open dialog does not complete session_context, so data is
+    // never collected/sent for this session.
+    // The second has session_context complete, it starts collecting data which
+    // is sent when the third dialog has its session_context complete.
+    // The third has session_context complete and sends data for the second
+    // dialog opening.
 
+
+    // First open dialog never has session_context complete. Data is not
+    // collected.
     createController();
     controller.addEvent("session1_before_session_context");
 
-    // simulate this as the first successful connection to backend to find out
-    // whether data collection is allowed.
+    // Second open dialog is the first to successfully complete
+    // session_context, data should be collected.
     createController();
     controller.addEvent("session2_before_session_context");
     network.withContext(function() {
 
+      // Third open dialog successfully completes session_context, should send
+      // data for the 2nd open dialog once session_context completes.
       createController();
       controller.addEvent("session2_before_session_context");
 
-      // Data is sent on the second successful call to session_context
       network.withContext(function() {
         var request = xhr.getLastRequest('/wsapi/interaction_data'),
             previousSessionsData = JSON.parse(request.data).data;

--- a/resources/static/test/cases/shared/storage.js
+++ b/resources/static/test/cases/shared/storage.js
@@ -179,37 +179,5 @@
     equal(typeof storage.signInEmail.get(), "undefined", "after remove, signInEmail is empty");
   });
 
-  test("push interaction data and get current", function() {
-    storage.interactionData.push({ foo: "bar" });
-    equal(storage.interactionData.current().foo, "bar",
-          "after pushing new interaction data, it's returned from .current()");
-  });
-
-  test("set interaction data overwrites current", function() {
-    storage.interactionData.clear();
-    storage.interactionData.push({ foo: "bar" });
-    storage.interactionData.setCurrent({ foo: "baz" });
-    equal(storage.interactionData.current().foo, "baz",
-          "overwriting current interaction data works");
-    equal(storage.interactionData.get().length, 1,
-          "overwriting doesn't append");
-  });
-
-  test("clear interaction data", function() {
-    storage.interactionData.push({ foo: "bar" });
-    storage.interactionData.push({ foo: "bar" });
-    storage.interactionData.clear();
-    equal(storage.interactionData.get().length, 0,
-          "after clearing, interaction data is zero length");
-  });
-
-  test("get interaction data returns all data", function() {
-    storage.interactionData.push({ foo: "old2" });
-    storage.interactionData.clear();
-    storage.interactionData.push({ foo: "old1" });
-    var d = storage.interactionData.get();
-    equal(d.length, 1, "get() returns complete unpublished data blobs");
-    equal(d[0].foo, 'old1', "get() returns complete unpublished data blobs");
-  });
 }());
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -181,7 +181,7 @@ BrowserID.TestHelpers = (function() {
         start();
       });
 
-      if(transport.resultType === "valid") {
+      if(transport.responseName === "valid") {
         transport.useResult("ajaxError");
       }
 
@@ -200,6 +200,11 @@ BrowserID.TestHelpers = (function() {
     },
 
     testKeysInObject: function(objToTest, expected, msg) {
+      if (!objToTest) {
+        ok(false, "Missing object to test against");
+        return;
+      }
+
       for(var i=0, key; key=expected[i]; ++i) {
         ok(key in objToTest, msg || ("object contains " + key));
       }

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -104,6 +104,9 @@
     <script src="/shared/history.js"></script>
     <script src="/shared/state_machine.js"></script>
 
+    <script src="/shared/models/models.js"></script>
+    <script src="/shared/models/interaction_data.js"></script>
+
     <script src="/shared/modules/page_module.js"></script>
     <script src="/shared/modules/xhr_delay.js"></script>
     <script src="/shared/modules/xhr_disable_form.js"></script>
@@ -154,6 +157,8 @@
     <script src="cases/shared/command.js"></script>
     <script src="cases/shared/history.js"></script>
     <script src="cases/shared/state_machine.js"></script>
+
+    <script src="cases/shared/models/interaction_data.js"></script>
 
     <script src="cases/shared/modules/page_module.js"></script>
     <script src="cases/shared/modules/xhr_delay.js"></script>


### PR DESCRIPTION
@jedp - Mind reviewing this one?

I did a serious yak shave, but I feel like the data model that is saved to localStorage is easier to understand.  I moved the localStorage component from storage.js into shared/models/interaction_data.js, hopefully simplifying as I went along.  Tests were beefed up to make sure we weren't clobbering any current data when we publish staged data.

We must wait until session_context to start writing data into localStorage because this is the first point at which we know whether the current session is allowed to publish collected data.  Because we only know whether we are allowed to publish a session's data once session_context completes, I kept the initial set of the timestamp, screen size, etc where it was.

If a session's session_context never returns, data for the session will not be saved - this is an acceptable data loss for user data privacy.
