### PR TITLE
Fix the user being asked 4 times for a password when adding a secondary email to a primary account and verifying email ownership in a new browser.

### DIFF
--- a/resources/static/dialog/controllers/actions.js
+++ b/resources/static/dialog/controllers/actions.js
@@ -95,7 +95,7 @@ BrowserID.Modules.Actions = (function() {
     },
 
     doStageEmail: function(info) {
-      dialogHelpers.addSecondaryEmailWithPassword.call(this, info.email, info.password, info.ready);
+      dialogHelpers.addSecondaryEmail.call(this, info.email, info.password, info.ready);
     },
 
     doAuthenticate: function(info) {

--- a/resources/static/dialog/resources/helpers.js
+++ b/resources/static/dialog/resources/helpers.js
@@ -111,12 +111,12 @@
     }
   }
 
-  function addSecondaryEmailWithPassword(email, password, callback) {
+  function addSecondaryEmail(email, password, callback) {
     var self=this;
 
     user.addEmail(email, password, function(added) {
       if (added) {
-        var info = { email: email };
+        var info = { email: email, password: password };
         self.publish("email_staged", info, info );
       }
       else {
@@ -133,7 +133,7 @@
     authenticateUser: authenticateUser,
     createUser: createUser,
     addEmail: addEmail,
-    addSecondaryEmailWithPassword: addSecondaryEmailWithPassword,
+    addSecondaryEmail: addSecondaryEmail,
     resetPassword: resetPassword,
     cancelEvent: helpers.cancelEvent,
     animateClose: animateClose


### PR DESCRIPTION
@lloyd - can you review this one?  

I took the same approach for the "email_staged" message as you did for the "user_staged" message and pass the password.  The password gets handed to the check_registration controller which will try to log the user in if "email_addition_status" returns mustAuth.
- When "email_staged" is triggered, trigger it with the password.
- Rename helpers.addSecondaryEmailWithPassword to helpers.addSecondaryEmail
- Add unit tests for helpers.addSecondaryEmail
- Yak shave the unit tests to clean them up so that they are easier to follow.

issue #1555
