### PR TITLE
Make the in dialog set-password flow work with requiredEmail.

### DIFF
--- a/resources/static/dialog/controllers/set_password.js
+++ b/resources/static/dialog/controllers/set_password.js
@@ -35,7 +35,8 @@ BrowserID.Modules.SetPassword = (function() {
       options = options || {};
 
       self.renderDialog("set_password", {
-        password_reset: !!options.password_reset
+        password_reset: !!options.password_reset,
+        cancelable: options.cancelable !== false
       });
 
       self.click("#cancel", cancel);

--- a/resources/static/dialog/resources/helpers.js
+++ b/resources/static/dialog/resources/helpers.js
@@ -104,7 +104,7 @@
           complete(callback, true);
         }
         else {
-          self.publish("add_email_submit_with_secondary", { email: email });
+          self.publish("stage_email", { email: email });
           complete(callback, true);
         }
       }, self.getErrorDialog(errors.addressInfo, callback));

--- a/resources/static/dialog/resources/state.js
+++ b/resources/static/dialog/resources/state.js
@@ -94,6 +94,10 @@ BrowserID.State = (function() {
 
     handleState("new_user", function(msg, info) {
       self.newUserEmail = info.email;
+
+      // cancel is disabled if the user is doing the initial password set
+      // for a requiredEmail.
+      info.cancelable = !requiredEmail;
       startAction(false, "doSetPassword", info);
     });
 
@@ -347,15 +351,20 @@ BrowserID.State = (function() {
       startAction("doAddEmail", info);
     });
 
-    handleState("add_email_submit_with_secondary", function(msg, info) {
+    handleState("stage_email", function(msg, info) {
       user.passwordNeededToAddSecondaryEmail(function(passwordNeeded) {
         if(passwordNeeded) {
           self.addEmailEmail = info.email;
+          // cancel is disabled if the user is doing the initial password set
+          // for a requiredEmail.
+          info.cancelable = !requiredEmail;
           startAction(false, "doSetPassword", info);
         }
         else {
           startAction(false, "doStageEmail", info);
         }
+
+        complete(info.complete);
       });
     });
 

--- a/resources/static/dialog/views/set_password.ejs
+++ b/resources/static/dialog/views/set_password.ejs
@@ -6,11 +6,13 @@
 
   <div class="form_section" id="set_password">
       <ul class="inputs">
-          <% if(!password_reset) { %>
-            <li>
-                <%= gettext("Next, choose a new password you'll use when you sign in with BrowserID.") %>
-            </li>
-          <% } %>
+          <li>
+            <% if(password_reset || !cancelable) { %>
+              <%= gettext("Choose a new password you'll use when you sign in with BrowserID.") %>
+            <% } else { %>
+              <%= gettext("Next, choose a new password you'll use when you sign in with BrowserID.") %>
+            <% } %>
+          </li>
 
 
           <li>
@@ -49,6 +51,8 @@
           <button tabindex="1" id="<%= password_reset ? "password_reset" : "verify_user" %>">
             <%= password_reset ? gettext('reset password') : gettext('verify email') %>
           </button>
-          <a id="cancel" class="action" href="#"><%= gettext('cancel') %></a>
+          <% if(cancelable) { %>
+            <a id="cancel" class="action" href="#"><%= gettext('cancel') %></a>
+          <% } %>
       </div>
   </div>

--- a/resources/static/test/cases/controllers/add_email.js
+++ b/resources/static/test/cases/controllers/add_email.js
@@ -56,7 +56,7 @@
     ok($("#newEmail").val(), "testuser@testuser.com", "email prepopulated");
   });
 
-  asyncTest("addEmail with first valid unknown secondary email - trigger add_email_submit_with_secondary", function() {
+  asyncTest("addEmail with first valid unknown secondary email - trigger stage_email", function() {
     createController();
     xhr.useResult("unknown_secondary");
 
@@ -64,15 +64,15 @@
 
     $("#newEmail").val("unregistered@testuser.com");
 
-    register("add_email_submit_with_secondary", function(msg, info) {
-      equal(info.email, "unregistered@testuser.com", "add_email_submit_with_secondary called with correct email");
+    register("stage_email", function(msg, info) {
+      equal(info.email, "unregistered@testuser.com", "stage_email called with correct email");
       start();
     });
 
     controller.addEmail();
   });
 
-  asyncTest("addEmail with second valid unknown secondary email - trigger add_email_submit_with_secondary", function() {
+  asyncTest("addEmail with second valid unknown secondary email - trigger stage_email", function() {
     createController();
     xhr.useResult("unknown_secondary");
 
@@ -80,8 +80,8 @@
 
     $("#newEmail").val("unregistered@testuser.com");
 
-    register("add_email_submit_with_secondary", function(msg, info) {
-      equal(info.email, "unregistered@testuser.com", "add_email_submit_with_secondary called with correct email");
+    register("stage_email", function(msg, info) {
+      equal(info.email, "unregistered@testuser.com", "stage_email called with correct email");
       start();
     });
 
@@ -89,13 +89,13 @@
     controller.addEmail();
   });
 
-  asyncTest("addEmail with valid unknown secondary email with leading/trailing whitespace - allows address, triggers add_email_submit_with_secondary", function() {
+  asyncTest("addEmail with valid unknown secondary email with leading/trailing whitespace - allows address, triggers stage_email", function() {
     createController();
     xhr.useResult("unknown_secondary");
 
     $("#newEmail").val("   unregistered@testuser.com  ");
-    register("add_email_submit_with_secondary", function(msg, info) {
-      equal(info.email, "unregistered@testuser.com", "add_email_submit_with_secondary called with correct email");
+    register("stage_email", function(msg, info) {
+      equal(info.email, "unregistered@testuser.com", "stage_email called with correct email");
       start();
     });
     controller.addEmail();
@@ -106,12 +106,12 @@
 
     $("#newEmail").val("unregistered");
     var handlerCalled = false;
-    register("add_email_submit_with_secondary", function(msg, info) {
+    register("stage_email", function(msg, info) {
       handlerCalled = true;
-      ok(false, "add_email_submit_with_secondary should not be called on invalid email");
+      ok(false, "stage_email should not be called on invalid email");
     });
     controller.addEmail(function() {
-      equal(handlerCalled, false, "the add_email_submit_with_secondary handler should have never been called");
+      equal(handlerCalled, false, "the stage_email handler should have never been called");
       start();
     });
   });
@@ -121,8 +121,8 @@
 
     $("#newEmail").val("registered@testuser.com");
 
-    register("add_email_submit_with_secondary", function(msg, info) {
-      ok(false, "unexpected add_email_submit_with_secondary message");
+    register("stage_email", function(msg, info) {
+      ok(false, "unexpected stage_email message");
     });
 
     // simulate the email being already added.
@@ -142,8 +142,8 @@
     xhr.useResult("known_secondary");
 
     $("#newEmail").val("registered@testuser.com");
-    register("add_email_submit_with_secondary", function(msg, info) {
-      equal(info.email, "registered@testuser.com", "add_email_submit_with_secondary called with correct email");
+    register("stage_email", function(msg, info) {
+      equal(info.email, "registered@testuser.com", "stage_email called with correct email");
       start();
     });
     controller.addEmail();

--- a/resources/static/test/cases/controllers/set_password.js
+++ b/resources/static/test/cases/controllers/set_password.js
@@ -31,9 +31,10 @@
   });
 
 
-  test("create with no options - show template, user must verify email", function() {
+  test("create with no options - show template, user must verify email, can cancel", function() {
     ok($("#set_password").length, "set_password template added");
     equal($("#verify_user").length, 1, "correct button shown");
+    equal($("#cancel").length, 1, "cancel button shown");
   });
 
   test("create with password_reset option - show template, show reset password button", function() {
@@ -41,6 +42,13 @@
     createController({ password_reset: true });
     ok($("#set_password").length, "set_password template added");
     equal($("#password_reset").length, 1, "correct button shown");
+    equal($("#cancel").length, 1, "cancel button shown");
+  });
+
+  test("create with cancelable=false option - cancel button not shown", function() {
+    controller.destroy();
+    createController({ cancelable: false });
+    equal($("#cancel").length, 0, "cancel button not shown");
   });
 
   asyncTest("submit with good password/vpassword - password_set message raised", function() {

--- a/resources/static/test/cases/resources/helpers.js
+++ b/resources/static/test/cases/resources/helpers.js
@@ -145,12 +145,11 @@
     });
   });
 
-  asyncTest("addEmail with secondary email - trigger add_email_submit_with_secondary", function() {
+  asyncTest("addEmail with secondary email - trigger stage_email", function() {
     xhr.useResult("unknown_secondary");
-    expectedMessage("add_email_submit_with_secondary", {
+    expectedMessage("stage_email", {
       email: "unregistered@testuser.com"
     });
-
     dialogHelpers.addEmail.call(controllerMock, "unregistered@testuser.com", function(success) {
       equal(success, true, "success status");
       start();


### PR DESCRIPTION
- In set_password.ejs, only show the "cancel" button if not setting the initial password for a required email.
- Update required_email.js to handle the set-password in dialog flow.
- Clean up required_email.js so that it is easier to follow.
- Rename the "add_email_submit_with_secondary" message to "stage_email" - much clearer.
- Show a message whenever resetting the account password.

issue #1638
issue #1580
