### PR TITLE
Issue1645 - remove dead code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 train-2012.06.08 (in progress):
   * Support non-english passwords: issue #1631
+  * remove obsolete code - 'code_update' handler: issue #1645
 
 train-2012.05.25:
   * many KPI improvements: #1597, #1613

--- a/bin/browserid
+++ b/bin/browserid
@@ -157,17 +157,7 @@ wsapi.setup({
 // #9 - handle views for dynamicish content
 views.setup(app);
 
-function doShutdown(readyForShutdownCB) {
-  require('../lib/bcrypt.js').shutdown();
-  db.close(readyForShutdownCB)
-}
-
-// #11 - calls to /code_update from localhost will restart the daemon,
-// this feature is not externally accessible and is only used by
-// the update logic
-shutdown.installUpdateHandler(app, doShutdown);
-
-// #12 if the BROWSERID_FAKE_VERIFICATION env var is defined, we'll include
+// #10 if the BROWSERID_FAKE_VERIFICATION env var is defined, we'll include
 // fake_verification.js.  This is used during testing only and should
 // never be included in a production deployment
 if (process.env['BROWSERID_FAKE_VERIFICATION']) {
@@ -192,7 +182,10 @@ db.open(config.get('database'), function (error) {
   }
 
   // shut down express gracefully on SIGINT
-  shutdown.handleTerminationSignals(app, doShutdown);
+  shutdown.handleTerminationSignals(app, function(readyForShutdownCB) {
+    require('../lib/bcrypt.js').shutdown();
+    db.close(readyForShutdownCB)
+  });
 
   var bindTo = config.get('bind_to');
   app.listen(bindTo.port, bindTo.host, function() {

--- a/bin/dbwriter
+++ b/bin/dbwriter
@@ -96,11 +96,6 @@ function doShutdown(readyForShutdownCB) {
   db.close(readyForShutdownCB)
 }
 
-// calls to /code_update from localhost will restart the daemon,
-// this feature is not externally accessible and is only used by
-// the update logic
-shutdown.installUpdateHandler(app, doShutdown);
-
 // open the databse
 db.open(config.get('database'), function (error) {
   if (error) {

--- a/bin/keysigner
+++ b/bin/keysigner
@@ -101,9 +101,6 @@ app.post('/wsapi/cert_key', validate(["email", "pubkey", "ephemeral"]), function
   });
 });
 
-// shutdown when code_update is invoked
-shutdown.installUpdateHandler(app);
-
 // shutdown nicely on signals
 shutdown.handleTerminationSignals(app, function() {
   cc.exit();

--- a/bin/verifier
+++ b/bin/verifier
@@ -126,9 +126,6 @@ app.post('/verify', function(req, resp, next) {
   });
 });
 
-// shutdown when /code_update is invoked
-shutdown.installUpdateHandler(app);
-
 // shutdown nicely on signals
 shutdown.handleTerminationSignals(app, function() {
   cc.exit();

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,6 +2,10 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
+**NOTE:** this document is outdated and should be updated, it's left here
+because there is *some* still some potentially useful information.  
+Reader beware.
+
 # How to deploy BrowserID
 
 This describes how to take the code here, put it on a server, and build
@@ -142,9 +146,8 @@ if [ "x$GL_REPO" == 'xbrowserid' ] ; then
     echo "generating production resources"
     cd $NEWCODE/browserid && ./compress.sh && cd -
 
-    # stop the servers
-    curl -o --url http://localhost:62700/code_update > /dev/null 2>&1
-    curl -o --url http://localhost:62800/code_update > /dev/null 2>&1
+    # XXX: stop the servers!  you should deliver SIGINT to each
+    # process
 
     # now move code into place, and keep a backup of the last code
     # that was in production in .old
@@ -274,11 +277,6 @@ http {
 server {
     listen       80 default;
     server_name  browserid.org;
-
-    # disallow external server restart.
-    location = /code_update {
-        internal;
-    }
 
     # pass /verify invocations to the verifier
     location /verify {

--- a/lib/shutdown.js
+++ b/lib/shutdown.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* code_update is a tiny abstraction of a handler that can be
- * used to shutdown gracefully upon signals, and can be used
- * to install a 'code_update' hook into a running express
- * server.
+/* shutdown.js is an abstraction for installing graceful shutdown
+ * handlers into processes so that they gracefully shutdown upon
+ * signals.
  */
 
 const logger = require("./logging.js").logger;
@@ -77,18 +76,4 @@ exports.handleTerminationSignals = function(app, callback) {
   }
 
   process.on('SIGINT', endIt('INT')).on('SIGTERM', endIt('TERM')).on('SIGQUIT', endIt('QUIT'));
-};
-
-const CODE_UPDATE_URL = '/code_update';
-
-exports.installUpdateHandler = function(app, callback) {
-  var terminate = connectionListener(app);
-  app.get(CODE_UPDATE_URL, function(req, resp, next) {
-    // don't allow an imprecise match (like one with a trailing slash) to shut the server down.
-    // bug #699171
-    if (req.url !== CODE_UPDATE_URL) return next();
-
-    logger.warn("code updated.  closing " + app.connections + " connections and shutting down.");
-    terminate(callback);
-  });
 };


### PR DESCRIPTION
the code_update handler was a way to shut down a process via localhost HTTP.  This is no longer neccesary, our deployment mechanisms have grown up.  This particular bit of code is not something that's very smart to leave lying around.
