### PR TITLE
increase authenticated session duration to 4 weeks (was effectively 1 we...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 train-2012.06.08 (in progress):
   * Support non-english passwords: issue #1631
   * remove obsolete code - 'code_update' handler: issue #1645
+  * allow sessions to persist for 4 weeks after a user confirms ownership of a device (was effectively 1 week): #1632
 
 train-2012.05.25:
   * many KPI improvements: #1597, #1613

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -138,7 +138,7 @@ var conf = module.exports = convict({
   },
   authentication_duration_ms: {
     doc: "How long may a user stay signed?",
-    format: 'integer = 1209600000'
+    format: 'integer = 2419200000'
   },
   ephemeral_session_duration_ms: {
     doc: "How long a user on a shared computer shall be authenticated",

--- a/lib/wsapi.js
+++ b/lib/wsapi.js
@@ -145,12 +145,10 @@ exports.setup = function(options, app) {
   var cookieSessionMiddleware = sessions({
     secret: COOKIE_SECRET,
     cookieName: COOKIE_KEY,
-    duration: 7 * 24 * 60 * 60 * 1000, // 1 week
+    duration: config.get('authentication_duration_ms'),
     cookie: {
       path: '/wsapi',
       httpOnly: true,
-      // IMPORTANT: we allow users to go 1 weeks on the same device
-      // without entering their password again
       maxAge: config.get('authentication_duration_ms'),
       secure: overSSL
     }


### PR DESCRIPTION
...ek): issue #1632

NOTE:  The intention previously was to have duration set to 2 weeks.  Due to a bug in the code, it was effectively 1 week.  This patch fixes that bug too.
