### PR TITLE
Filter and namespace the interaction data.

### DIFF
--- a/resources/static/dialog/controllers/actions.js
+++ b/resources/static/dialog/controllers/actions.js
@@ -11,6 +11,7 @@ BrowserID.Modules.Actions = (function() {
       serviceManager = bid.module,
       user = bid.User,
       errors = bid.Errors,
+      mediator = bid.Mediator,
       dialogHelpers = bid.Helpers.Dialog,
       runningService,
       onsuccess,
@@ -26,6 +27,7 @@ BrowserID.Modules.Actions = (function() {
       runningService = name;
     }
 
+    mediator.publish("service", { name: name });
     bid.resize();
 
     return module;

--- a/resources/static/dialog/controllers/pick_email.js
+++ b/resources/static/dialog/controllers/pick_email.js
@@ -89,8 +89,12 @@ BrowserID.Modules.PickEmail = (function() {
 
       dom.addClass("body", "pickemail");
 
+      var identities = getSortedIdentities();
+
+      self.publish("emails_displayed", { count: identities.length });
+
       self.renderDialog("pick_email", {
-        identities: getSortedIdentities(),
+        identities: identities,
         siteemail: storage.site.get(origin, "email"),
         privacy_url: options.privacyURL,
         tos_url: options.tosURL

--- a/resources/static/lib/hub.js
+++ b/resources/static/lib/hub.js
@@ -34,6 +34,11 @@ Hub = (function() {
   }
 
   function fire(message) {
+    for(var j = 0, glistener; glistener = globalListeners[j]; ++j) {
+      // global listeners get the message name as the first argument
+      glistener.callback.apply(null, arguments);
+    }
+
     var messageListeners = listeners[message];
 
     if(messageListeners) {
@@ -44,11 +49,6 @@ Hub = (function() {
       for(var i = 0, listener; listener = messageListeners[i]; ++i) {
         listener.callback.apply(null, arguments);
       }
-    }
-
-    for(var j = 0, glistener; glistener = globalListeners[j]; ++j) {
-      // global listeners get the message name as the first argument
-      glistener.callback.apply(null, arguments);
     }
   }
 

--- a/resources/static/test/cases/controllers/pick_email.js
+++ b/resources/static/test/cases/controllers/pick_email.js
@@ -37,10 +37,15 @@
     controller.start({});
   }
 
-  test("multiple emails - print emails in alphabetical order", function() {
+  asyncTest("multiple emails - print emails in alphabetical order, emails_displayed triggered", function() {
     storage.addEmail("third@testuser.com", {});
     storage.addEmail("second@testuser.com", {});
     storage.addEmail("first@testuser.com", {});
+
+    register("emails_displayed", function(msg, data) {
+      equal(data.count, 3, "emails_displayed triggered with correct email count");
+      start();
+    });
 
     createController();
 

--- a/resources/static/test/cases/shared/modules/interaction_data.js
+++ b/resources/static/test/cases/shared/modules/interaction_data.js
@@ -26,10 +26,29 @@
     }
   });
 
-  function createController(config) {
+  function createController(setKPINameTable, config) {
+    if (typeof setKPINameTable !== "boolean") {
+      config = setKPINameTable;
+      setKPINameTable = false;
+    }
+
     config = _.extend({ samplingEnabled: true }, config);
     controller = BrowserID.Modules.InteractionData.create();
     controller.start(config);
+
+    controller.setNameTable({
+      before_session_context: null,
+      after_session_context: null,
+      session1_before_session_context: null,
+      session1_after_session_context: null,
+      session2_before_session_context: null,
+      session2_after_session_context: null,
+      initial_string_name: "translated_name",
+      initial_function_name: function(msg, data) {
+        return "function_translation." + msg;
+      }
+    });
+
   }
 
   function indexOfEvent(eventStream, eventName) {
@@ -68,12 +87,23 @@
       testHelpers.testKeysInObject(data, ["event_stream", "sample_rate", "timestamp", "lang"]);
 
       controller.addEvent("after_session_context");
+      controller.addEvent("after_session_context");
+
+      // The next two are translated from mediator names to names usable by the
+      // KPI backend.
+
+      // translated to "translated_name"
+      controller.addEvent("initial_string_name");
+      // translated to "function_translation.initial_function_name"
+      controller.addEvent("initial_function_name");
 
       events = controller.getCurrentEventStream();
       // Make sure both the before_session_context and after_session_context
       // are both on the event stream.
       ok(indexOfEvent(events, "before_session_context") > -1, "before_session_context correctly saved to current event stream");
       ok(indexOfEvent(events, "after_session_context") > -1, "after_session_context correctly saved to current event stream");
+      ok(indexOfEvent(events, "translated_name") > -1, "string translation - translated_name correctly saved to current event stream");
+      ok(indexOfEvent(events, "function_translation.initial_function_name") > -1, "function translation - function_translation.initial_function_name correctly saved to current event stream");
 
 
       // Ensure that the event name as well as relative time are saved for an


### PR DESCRIPTION
@jedp - mind reviewing this?
- Set up a table that says which events are noteworthy
- Save the number of emails a user has.
- All screens are namespaced under the screen namespace
- User interactions are saved under the user namespace
- window related events are under the window namespace
- Modify the hub to call global listeners before exact match listeners - this keeps events in the correct order in the store - the previous way had a new screen show up in the KPI event log before the "screen.cancel" event that triggered its display.

issue #1614
issue #1619
