### PR TITLE
Fix the "communicating with server" text being placed behind the arrow when the wait screen is being hidden.

### DIFF
--- a/resources/static/dialog/css/popup.css
+++ b/resources/static/dialog/css/popup.css
@@ -165,11 +165,11 @@ section > .contents {
     -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
     opacity: 0;
 
-    -webkit-transition-property: opacity;
-    -moz-transition-property: opacity;
-    -ms-transition-property: opacity;
-    -o-transition-property: opacity;
-    transition-property: opacity;
+    -webkit-transition-property: all;
+    -moz-transition-property: all;
+    -ms-transition-property: all;
+    -o-transition-property: all;
+    transition-property: all;
 
     -webkit-transition-duration: 0.25s;
     -moz-transition-duration: 0.25s;


### PR DESCRIPTION
@jedp or @ozten - mind reviewing this one?

Easy way to test:
1) Load up the dialog
2) Click the upper right hand corner 4 times.
3) When menu appears, click "Show Delay"
4) Click "Hide Screens"
5) Watch the "Delay" screen fade out - does its text get hidden behind the arrow?

issue #1684
