### PR TITLE
Clear the password if the user types a password then changes the email address.

### DIFF
--- a/resources/static/dialog/controllers/authenticate.js
+++ b/resources/static/dialog/controllers/authenticate.js
@@ -120,6 +120,8 @@ BrowserID.Modules.Authenticate = (function() {
   function enterPasswordState(callback) {
     var self=this;
 
+    dom.setInner("#password", "");
+
     self.publish("enter_password", addressInfo);
     self.submit = authenticate;
     showHint("returning", function() {

--- a/resources/static/test/cases/controllers/authenticate.js
+++ b/resources/static/test/cases/controllers/authenticate.js
@@ -117,6 +117,34 @@
     controller.checkEmail();
   });
 
+  asyncTest("clear password if user changes email address", function() {
+    xhr.useResult("known_secondary");
+    $("#email").val("registered@testuser.com");
+
+    var enterPasswordCount = 0;
+    mediator.subscribe("enter_password", function() {
+      // The first time the password is shown, change the email address.  The
+      // second time the password is shown, make sure the password was cleared.
+
+      if(enterPasswordCount == 0) {
+        // simulate the user changing the email address.  This should clear the
+        // password.
+        $("#password").val("password");
+        $("#email").val("testuser@testuser.com");
+        $("#email").keyup();
+        controller.checkEmail();
+      }
+      else {
+        equal($("#password").val(), "", "password field was cleared");
+        start();
+      }
+
+      enterPasswordCount++;
+    });
+
+    controller.checkEmail();
+  });
+
   asyncTest("checkEmail with email that has IdP support - 'primary_user' message", function() {
     $("#email").val("unregistered@testuser.com");
     xhr.useResult("primary");


### PR DESCRIPTION
Steps to check:

1) Open the BrowserID dialog.  If signed in, click "This is not me"
2) Enter a known secondary email address into the email field.
3) Begin typing a password.
4) Erase a character in the email address.  Finish the email address again and hit "enter"
5) Password field should be cleared.

issue #1540
