### PR TITLE
require the `fs` module in i18n.js instead of relying on a global `fs`

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -18,7 +18,8 @@
 var logger = require('./logging.js').logger,
     Gettext = require('node-gettext'),
     path = require('path'),
-    util = require('util');
+    util = require('util'),
+    fs = require('fs');
 
 const BIDI_RTL_LANGS = ['ar', 'db-LB', 'fa', 'he'];
 


### PR DESCRIPTION
issue #1699 - Certain code paths in i18n.js only run when JSON locales are present, so this was not caught in #1681.
