### PR TITLE
Fix the trailing ') in the "bad password" tooltip on the signin page.

### DIFF
--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -42,7 +42,7 @@
                     </div>
 
                     <div id="cannot_authenticate" class="tooltip" for="password">
-                      The account cannot be logged in with this username and password.')
+                      The account cannot be logged in with this username and password.
 
                 </li>
             </ul>


### PR DESCRIPTION
issue #1716
