### PR TITLE
Enforce post size limit in the router only - issue #1713

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -60,10 +60,6 @@ app.use(i18n.abide({
   disable_locale_check: config.get('disable_locale_check')
 }));
 
-// limit all content bodies to 10kb, at which point we'll forcefully
-// close down the connection.
-app.use(express.limit("10kb"));
-
 var statsd_config = config.get('statsd');
 if (statsd_config && statsd_config.enabled) {
   logger_statsd = require("connect-logger-statsd");


### PR DESCRIPTION
In cases where the content-length header isn't set, the router streams requests to the browserid process and destroys the request if it goes over the size limit. When both the router and browserid processes perform this check, an error occurs as both attempt to destroy the same connection.
