### PR TITLE
Fix IE8 not submitting the password field on the enter key.

### DIFF
--- a/resources/static/dialog/views/test_template_with_input.ejs
+++ b/resources/static/dialog/views/test_template_with_input.ejs
@@ -2,5 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<input id="templateInput" type="text" value="" />
+<form>
+  <input id="templateInput" type="text" value="" />
+</form>
 

--- a/resources/static/shared/modules/page_module.js
+++ b/resources/static/shared/modules/page_module.js
@@ -15,6 +15,16 @@ BrowserID.Modules.PageModule = (function() {
       cancelEvent = helpers.cancelEvent,
       mediator = bid.Mediator;
 
+   function onKeypress(event) {
+    if (event.which === 13) {
+      // IE8 does not trigger the submit event when hitting enter. Submit the
+      // form if the key press was an enter and prevent the default action so
+      // the form is not submitted twice.
+      event.preventDefault();
+      this.submit();
+    }
+   }
+
    function onSubmit() {
      if (!dom.hasClass("body", "submit_disabled") && this.validate()) {
        this.submit();
@@ -59,6 +69,7 @@ BrowserID.Modules.PageModule = (function() {
       self.options = options || {};
 
       self.bind("form", "submit", cancelEvent(onSubmit));
+      self.bind("input", "keypress", onKeypress);
     },
 
     stop: function() {

--- a/resources/static/test/cases/shared/modules/page_module.js
+++ b/resources/static/test/cases/shared/modules/page_module.js
@@ -198,6 +198,35 @@
     $("body").removeClass("submit_disabled");
     controller.onSubmit();
     equal(submitCalled, true, "submit permitted to complete");
-  })
+  });
+
+  test("form is submitted once 'enter keypress' event", function() {
+    createController();
+    controller.renderDialog("test_template_with_input", {
+      title: "Test title",
+      message: "Test message"
+    });
+
+    controller.start();
+
+
+    var submitCalled = 0;
+    controller.submit = function() {
+      submitCalled++;
+    };
+
+    // synthesize the entire series of key* events so we replicate the behavior
+    // of keyboard interaction.
+    var e = jQuery.Event("keydown", { keyCode: 13, which: 13 });
+    $("#templateInput").trigger(e);
+
+    var e = jQuery.Event("keyup", { keyCode: 13, which: 13 });
+    $("#templateInput").trigger(e);
+
+    var e = jQuery.Event("keypress", { keyCode: 13, which: 13 });
+    $("#templateInput").trigger(e);
+
+    equal(submitCalled, 1, "submit called a single time");
+  });
 }());
 


### PR DESCRIPTION
To test:

1) To avoid the "script taking too long" message in IE8, run <server>/test/index.html?filter=shared/modules/page_module
2) In IE8, open the dialog.  If logged in, click "this is not me".  
3) Enter in a known secondary email, press "enter".  Enter in password, press enter.  If fix is working, second "enter" will work.
4) Follow same steps in other browsers to make sure pressing "enter" in other browsers does not cause a double submit.

issue #1376
