### PR TITLE
remove dead, untested code - retrieveTemporaryKeypair and storeTemporary...

### DIFF
--- a/resources/static/shared/storage.js
+++ b/resources/static/shared/storage.js
@@ -124,28 +124,6 @@ BrowserID.Storage = (function() {
     }
   }
 
-  function storeTemporaryKeypair(keypair) {
-    storage.tempKeypair = JSON.stringify({
-      publicKey: keypair.publicKey.toSimpleObject(),
-      secretKey: keypair.secretKey.toSimpleObject()
-    });
-  }
-
-  function retrieveTemporaryKeypair() {
-    var raw_kp = JSON.parse(storage.tempKeypair || "");
-    storage.tempKeypair = null;
-    if (raw_kp) {
-      prepareDeps();
-
-      var kp = {};
-      kp.publicKey = jwcrypto.loadPublicKeyFromObject(raw_kp.publicKey);
-      kp.secretKey = jwcrypto.loadSecretKeyFromObject(raw_kp.secretKey);
-      return kp;
-    } else {
-      return null;
-    }
-  }
-
   function setReturnTo(returnToURL) {
     storage.returnTo = JSON.stringify({
       at: new Date().toString(),
@@ -588,8 +566,6 @@ BrowserID.Storage = (function() {
      * @method clear
      */
     clear: clear,
-    storeTemporaryKeypair: storeTemporaryKeypair,
-    retrieveTemporaryKeypair: retrieveTemporaryKeypair,
     setReturnTo: setReturnTo,
     getReturnTo: getReturnTo
   };

--- a/resources/static/test/cases/shared/storage.js
+++ b/resources/static/test/cases/shared/storage.js
@@ -155,15 +155,6 @@
     storage.clear();
     equal(typeof storage.manage_page.get("user_has_visited"), "undefined", "after reset, user_has_visited reset correctly");
   });
-
-  test("storeTemporaryKeypair", function() {
-    // XXX needs a test
-  });
-
-  test("retrieveTemporaryKeypair", function() {
-    // XXX needs a test
-  });
-
   test("setReturnTo", function() {
     storage.setReturnTo("http://some.domain/path");
     equal(storage.getReturnTo(), "http://some.domain/path", "setReturnTo/getReturnTo working as expected");


### PR DESCRIPTION
...Keypair are referenced nowhere, have no tests, and were introduced in sept 8th 2011.  they should be removed.

did I mention these functions are undocumented too?
