### PR TITLE
fix load_gen to call /verify with the right args

### DIFF
--- a/lib/load_gen/common.js
+++ b/lib/load_gen/common.js
@@ -47,7 +47,7 @@ exports.authAndKey = function(cfg, user, ctx, email, cb) {
           try {
             if (err) throw err;
             if (resp.code !== 200) throw "non-200 status: " + resp.code +
-              + " - " + resp.body;
+              " - " + resp.body;
             if (typeof resp.body !== 'string') throw cb("no response body");
             userdb.addCertToUserCtx(ctx, email, resp.body);
             cb();
@@ -75,7 +75,9 @@ exports.genAssertionAndVerify = function(cfg, user, ctx, email, audience, cb) {
     // the contents so much
     try {
       if (err) throw err;
-      if (!typeof JSON.parse(r.body) === 'object') throw 'bogus response';
+      if (typeof JSON.parse(r.body) !== 'object') {
+        throw 'response is not a JSON object: ' + r.body;
+      }
     } catch(e) {
       return cb(e.toString() + (r ? (" - " + r.body) : ""));
     }
@@ -98,7 +100,8 @@ exports.genAssertionAndVerify = function(cfg, user, ctx, email, audience, cb) {
         try {
           if (err) throw err;
           if (r.code !== 200) throw "non-200 status: " + r.code;
-          if (!JSON.parse(r.body).status === 'okay') throw "verification failed with: " + r.reason;
+          var body = JSON.parse(r.body);
+          if (body.status !== 'okay') throw "verification failed with: " + body.reason;
           cb(undefined);
         } catch(e) {
           return cb("can't verify: " + e.toString());

--- a/lib/load_gen/crypto.js
+++ b/lib/load_gen/crypto.js
@@ -59,9 +59,10 @@ exports.getAssertion = function(obj, cb) {
       {
         audience: obj.audience,
         expiresAt: expirationDate
-      }, obj.secretKey, function(err, assertion) {
+      }, obj.secretKey, function(err, signedAssertion) {
         if (err) cb(err);
         else {
+          var assertion = jwcrypto.cert.bundle(obj.cert, signedAssertion);
           cb(null, {
             audience: obj.audience,
             assertion: assertion,


### PR DESCRIPTION
- send the right assertion to /verify -- (lib/load_gen/crypto.js)
- fix two comparisons I noticed would always be false (one of which was hiding the /verify failure)
- fix a trivial error message formatting bug GH-1278

fixes GH-1770 and GH-1278
