### PR TITLE
Fix submit occuring when selecting an email address in Firefox from the autocomplete list.

### DIFF
--- a/resources/static/shared/modules/page_module.js
+++ b/resources/static/shared/modules/page_module.js
@@ -15,7 +15,7 @@ BrowserID.Modules.PageModule = (function() {
       cancelEvent = helpers.cancelEvent,
       mediator = bid.Mediator;
 
-   function onKeypress(event) {
+   function onKeyup(event) {
     if (event.which === 13) {
       // IE8 does not trigger the submit event when hitting enter. Submit the
       // form if the key press was an enter and prevent the default action so
@@ -69,7 +69,7 @@ BrowserID.Modules.PageModule = (function() {
       self.options = options || {};
 
       self.bind("form", "submit", cancelEvent(onSubmit));
-      self.bind("input", "keypress", onKeypress);
+      self.bind("input", "keyup", onKeyup);
     },
 
     stop: function() {

--- a/resources/static/test/cases/shared/modules/page_module.js
+++ b/resources/static/test/cases/shared/modules/page_module.js
@@ -200,7 +200,7 @@
     equal(submitCalled, true, "submit permitted to complete");
   });
 
-  test("form is submitted once 'enter keypress' event", function() {
+  test("form is submitted on 'enter keyup' event", function() {
     createController();
     controller.renderDialog("test_template_with_input", {
       title: "Test title",
@@ -216,14 +216,15 @@
     };
 
     // synthesize the entire series of key* events so we replicate the behavior
-    // of keyboard interaction.
+    // of keyboard interaction.  The order of events is keydown, keypress,
+    // keyup (http://unixpapa.com/js/key.html).
     var e = jQuery.Event("keydown", { keyCode: 13, which: 13 });
     $("#templateInput").trigger(e);
 
-    var e = jQuery.Event("keyup", { keyCode: 13, which: 13 });
+    var e = jQuery.Event("keypress", { keyCode: 13, which: 13 });
     $("#templateInput").trigger(e);
 
-    var e = jQuery.Event("keypress", { keyCode: 13, which: 13 });
+    var e = jQuery.Event("keyup", { keyCode: 13, which: 13 });
     $("#templateInput").trigger(e);
 
     equal(submitCalled, 1, "submit called a single time");


### PR DESCRIPTION
Ephemeral deployment at http://enter-key.123done.org/

Testing:
From Firefox, check that it is possible to select an address from the autocomplete box without a tooltip showing.
From IE8, make sure it is still possible to authenticate to dialog by pressing "enter" key in the password field.

issue #1780
