### PR TITLE
disable email field after pressing next

### DIFF
--- a/resources/static/dialog/controllers/authenticate.js
+++ b/resources/static/dialog/controllers/authenticate.js
@@ -43,6 +43,7 @@ BrowserID.Modules.Authenticate = (function() {
 
     if (!email) return;
 
+    dom.setAttr('#email', 'disabled', 'disabled');
     if(info && info.type) {
       onAddressInfo(info);
     }
@@ -54,6 +55,7 @@ BrowserID.Modules.Authenticate = (function() {
 
     function onAddressInfo(info) {
       addressInfo = info;
+      dom.removeAttr('#email', 'disabled');
 
       if(info.type === "primary") {
         self.close("primary_user", info, info);

--- a/resources/static/pages/signin.js
+++ b/resources/static/pages/signin.js
@@ -48,7 +48,9 @@ BrowserID.signIn = (function() {
         email = helpers.getAndValidateEmail("#email");
 
     if(email) {
+      dom.setAttr('#email', 'disabled', 'disabled');
       user.addressInfo(email, function(info) {
+        dom.removeAttr('#email', 'disabled');
         addressInfo = info;
 
         if(info.type === "secondary") {

--- a/resources/static/pages/signup.js
+++ b/resources/static/pages/signup.js
@@ -99,15 +99,17 @@ BrowserID.signUp = (function() {
           self = this;
 
       if (email) {
-
+        dom.setAttr('#email', 'disabled', 'disabled');
         user.isEmailRegistered(email, function(isRegistered) {
           if(isRegistered) {
+            dom.removeAttr('#email', 'disabled');
             $('#registeredEmail').html(email);
             showNotice(".alreadyRegistered");
             oncomplete && oncomplete(false);
           }
           else {
             user.addressInfo(email, function(info) {
+              dom.removeAttr('#email', 'disabled');
               if(info.type === "primary") {
                 createPrimaryUser.call(self, info, oncomplete);
               }


### PR DESCRIPTION
re-enabled after request finishes

Checking in Android Browser, the keyboard goes away automatically when you submit the form (pressing Go in the keyboard). Also, re-enabling it does not make the Android keyboard re-appear. So the current Android flow isn't altered at all.

fixes #1661

/cc @shane-tomlinson
