### PR TITLE
fix #error gradient on Android

### DIFF
--- a/resources/static/css/common.css
+++ b/resources/static/css/common.css
@@ -357,7 +357,7 @@ footer .help {
   font-weight: bold;
 }
 
-#wait, #delay, #error {
+#content, #wait, #delay, #error {
   background-color: #dadee1;
   background-image: url("/i/grain.png"), -moz-linear-gradient(top, #dadee1, #c7ccd0);
 }

--- a/resources/static/css/common.css
+++ b/resources/static/css/common.css
@@ -357,9 +357,14 @@ footer .help {
   font-weight: bold;
 }
 
-#content, #wait, #delay, #error {
+#wait, #delay, #error {
   background-color: #dadee1;
-  background-image: url("/i/grain.png"), -moz-linear-gradient(top, #dadee1, #c7ccd0);
+  background-image: url("/i/grain.png"), -webkit-gradient(linear, left top, left bottom, from(#dadee1), to(#c7ccd0));
+  background-image: url("/i/grain.png"), -webkit-linear-gradient(top, #dadee1, #c7ccd0);
+  background-image: url("/i/grain.png"),    -moz-linear-gradient(top, #dadee1, #c7ccd0);
+  background-image: url("/i/grain.png"),     -ms-linear-gradient(top, #dadee1, #c7ccd0);
+  background-image: url("/i/grain.png"),      -o-linear-gradient(top, #dadee1, #c7ccd0);
+  background-image: url("/i/grain.png"),         linear-gradient(top, #dadee1, #c7ccd0);
 }
 
 #wait, #delay {

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -159,14 +159,6 @@
     line-height: 40px;
   }
 
-  #error {
-    position: static;
-  }
-
-  #error .vertical, #delay .vertical, #wait .vertical {
-    height: 250px;
-  }
-
   #error .vertical {
     width: auto;
   }

--- a/resources/static/dialog/resources/screen_size_hacks.js
+++ b/resources/static/dialog/resources/screen_size_hacks.js
@@ -106,6 +106,8 @@
         contentHeight = Math.max(100, contentHeight, formHeight);
         contentEl.css("min-height", contentHeight + "px");
 
+        // Remove the explicit static position we added to let this go back to
+        // the position specified in CSS.
         $("section,#signIn").css("position", "");
 
         favIconHeight = $("#favicon").outerHeight();


### PR DESCRIPTION
it's gradient doesn't go all the way down either. We must keep
the backgrounds on #wait, #delay, and #error, since they are
needed to cover the #formWrap background.

the same background of #error is added to #content, so that
even though #error doesn't extend all the way down, the gradient
still does, and it looks correct on Android again.

fixes #1721

/cc @shane-tomlinson
