### PR TITLE
Remove the "submit form on enter" fix for IE8, it causes forms to be submitted twice in Firefox and Chrome.

### DIFF
--- a/resources/static/shared/modules/page_module.js
+++ b/resources/static/shared/modules/page_module.js
@@ -15,16 +15,6 @@ BrowserID.Modules.PageModule = (function() {
       cancelEvent = helpers.cancelEvent,
       mediator = bid.Mediator;
 
-   function onKeyup(event) {
-    if (event.which === 13) {
-      // IE8 does not trigger the submit event when hitting enter. Submit the
-      // form if the key press was an enter and prevent the default action so
-      // the form is not submitted twice.
-      event.preventDefault();
-      this.submit();
-    }
-   }
-
    function onSubmit() {
      if (!dom.hasClass("body", "submit_disabled") && this.validate()) {
        this.submit();
@@ -69,7 +59,6 @@ BrowserID.Modules.PageModule = (function() {
       self.options = options || {};
 
       self.bind("form", "submit", cancelEvent(onSubmit));
-      self.bind("input", "keyup", onKeyup);
     },
 
     stop: function() {

--- a/resources/static/test/cases/shared/modules/page_module.js
+++ b/resources/static/test/cases/shared/modules/page_module.js
@@ -200,34 +200,5 @@
     equal(submitCalled, true, "submit permitted to complete");
   });
 
-  test("form is submitted on 'enter keyup' event", function() {
-    createController();
-    controller.renderDialog("test_template_with_input", {
-      title: "Test title",
-      message: "Test message"
-    });
-
-    controller.start();
-
-
-    var submitCalled = 0;
-    controller.submit = function() {
-      submitCalled++;
-    };
-
-    // synthesize the entire series of key* events so we replicate the behavior
-    // of keyboard interaction.  The order of events is keydown, keypress,
-    // keyup (http://unixpapa.com/js/key.html).
-    var e = jQuery.Event("keydown", { keyCode: 13, which: 13 });
-    $("#templateInput").trigger(e);
-
-    var e = jQuery.Event("keypress", { keyCode: 13, which: 13 });
-    $("#templateInput").trigger(e);
-
-    var e = jQuery.Event("keyup", { keyCode: 13, which: 13 });
-    $("#templateInput").trigger(e);
-
-    equal(submitCalled, 1, "submit called a single time");
-  });
 }());
 


### PR DESCRIPTION
issue #1813
