### PR TITLE
Improve orphaned KPI reporting

### DIFF
--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -122,7 +122,7 @@ BrowserID.Modules.InteractionData = (function() {
     // if we were orphaned last time, but user is now authenticated,
     // lets see if their action end in success, and if so,
     // remove the orphaned flag
-    //"))
+    //
     // actions:
     // - user_staged => is authenticated?
     // - email_staged => email count is higher?
@@ -132,9 +132,7 @@ BrowserID.Modules.InteractionData = (function() {
     if (current && current.orphaned) {
       var events = current.event_stream || [];
       if (hasEvent(events, MediatorToKPINameTable.user_staged)) {
-        console.log('user staged!')
         network.checkAuth(function(auth) {
-          console.log('aut checked');
           if (!!auth) {
             current.orphaned = false;
             model.setCurrent(current);
@@ -152,6 +150,7 @@ BrowserID.Modules.InteractionData = (function() {
         complete(onComplete);
       }
     } else {
+      // not an orphan, move along
       complete(onComplete);
     }
   }

--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -36,18 +36,20 @@
     controller = BrowserID.Modules.InteractionData.create();
     controller.start(config);
 
-    controller.setNameTable({
-      before_session_context: null,
-      after_session_context: null,
-      session1_before_session_context: null,
-      session1_after_session_context: null,
-      session2_before_session_context: null,
-      session2_after_session_context: null,
-      initial_string_name: "translated_name",
-      initial_function_name: function(msg, data) {
-        return "function_translation." + msg;
-      }
-    });
+    if (setKPINameTable) {
+      controller.setNameTable({
+        before_session_context: null,
+        after_session_context: null,
+        session1_before_session_context: null,
+        session1_after_session_context: null,
+        session2_before_session_context: null,
+        session2_after_session_context: null,
+        initial_string_name: "translated_name",
+        initial_function_name: function(msg, data) {
+          return "function_translation." + msg;
+        }
+      });
+    }
 
   }
 
@@ -69,7 +71,7 @@
     // simulate data stored for last session
     model.push({ timestamp: new Date().getTime() });
 
-    createController();
+    createController(true);
 
     controller.addEvent("before_session_context");
 
@@ -122,7 +124,7 @@
   });
 
   asyncTest("samplingEnabled set to false - no data collection occurs", function() {
-    createController({ samplingEnabled: false });
+    createController(true, { samplingEnabled: false });
 
     // the initial with_context will send off any stored data, there should be
     // no stored data.
@@ -140,7 +142,7 @@
   });
 
   asyncTest("continue: true, data collection permitted on previous session - continue appending data to previous session", function() {
-    createController();
+    createController(true);
 
     controller.addEvent("session1_before_session_context");
     network.withContext(function() {
@@ -150,7 +152,7 @@
       // re-get session context.
       controller = null;
       network.clearContext();
-      createController({ continuation: true });
+      createController(true, { continuation: true });
 
       controller.addEvent("session2_before_session_context");
       network.withContext(function() {

--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -259,4 +259,33 @@
     });
   });
 
+  asyncTest("kpi orphans are adopted if user is signed in", function() {
+    // 1. user.user_staged
+    // 2. dialog is orphaned
+    // 3. user comes back, authenticated
+    // 4. the orphan found a good home
+    createController(false);
+    network.withContext(function() {
+      // user is staged
+      controller.addEvent("user_staged");
+      // dialog all done, its orphaned, oh noes! think of the kids!
+      mediator.publish("kpi_data", {
+        orphaned: true
+      });
+      network.clearContext();
+
+
+      // new page
+      createController(false);
+      // make user authenticated
+      xhr.setContextInfo("auth_level", "password");
+      network.withContext(function() {
+        var request = xhr.getLastRequest('/wsapi/interaction_data');
+        var data = JSON.parse(request.data).data[0];
+        equal(data.orphaned, false, "orphaned is not sent")
+        start();
+      });
+    });
+  });
+
 }());


### PR DESCRIPTION
If a dialog was orphaned previously, but the user was able to confirm their email address and hence be logged in, update the KPI to say that `orphaned` is false.

See #1827 for more.
