### PR TITLE
Node 0.8.x support

### DIFF
--- a/lib/db/json.js
+++ b/lib/db/json.js
@@ -16,6 +16,13 @@ logger = require('../logging.js').logger,
 configuration = require('../configuration.js'),
 temp = require('temp');
 
+// existsSync moved from path in 0.6.x to fs in 0.8.x
+if (typeof fs.existsSync === 'function') {
+  var existsSync = fs.existsSync;
+} else {
+  var existsSync = path.existsSync;
+}
+
 // a little alias for stringify
 const ESC = JSON.stringify;
 
@@ -59,7 +66,7 @@ function flush() {
 
 function sync() {
   // the database not existing yet just means its empty, don't log an error
-  if (fs.existsSync(dbPath)) {
+  if (existsSync(dbPath)) {
     try {
       db = JSON.parse(fs.readFileSync(dbPath));
 

--- a/lib/db/json.js
+++ b/lib/db/json.js
@@ -59,7 +59,7 @@ function flush() {
 
 function sync() {
   // the database not existing yet just means its empty, don't log an error
-  if (path.existsSync(dbPath)) {
+  if (fs.existsSync(dbPath)) {
     try {
       db = JSON.parse(fs.readFileSync(dbPath));
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -21,6 +21,13 @@ var logger = require('./logging.js').logger,
     util = require('util'),
     fs = require('fs');
 
+// existsSync moved from path in 0.6.x to fs in 0.8.x
+if (typeof fs.existsSync === 'function') {
+  var existsSync = fs.existsSync;
+} else {
+  var existsSync = path.existsSync;
+}
+
 const BIDI_RTL_LANGS = ['ar', 'db-LB', 'fa', 'he'];
 
 var mo_cache = {};
@@ -66,8 +73,8 @@ exports.abide = function (options) {
         default_locale = localeFrom(options.default_lang);
 
     mo_cache[l] = {
-      mo_exists: fs.existsSync(mo_file_path(l)),
-      json_exists: fs.existsSync(json_file_path(l)),
+      mo_exists: existsSync(mo_file_path(l)),
+      json_exists: existsSync(json_file_path(l)),
       gt: null
     };
     if (l !== debug_locale) {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -66,8 +66,8 @@ exports.abide = function (options) {
         default_locale = localeFrom(options.default_lang);
 
     mo_cache[l] = {
-      mo_exists: path.existsSync(mo_file_path(l)),
-      json_exists: path.existsSync(json_file_path(l)),
+      mo_exists: fs.existsSync(mo_file_path(l)),
+      json_exists: fs.existsSync(json_file_path(l)),
       gt: null
     };
     if (l !== debug_locale) {

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -25,7 +25,7 @@ var log_path = path.join(configuration.get('var_path'), 'log');
 
 // simple inline function for creation of dirs
 function mkdir_p(p) {
-  if (!path.existsSync(p)) {
+  if (!fs.existsSync(p)) {
     mkdir_p(path.dirname(p));
     fs.mkdirSync(p, "0755");
   }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -20,12 +20,19 @@ configuration = require("./configuration"),
 path = require('path'),
 fs = require('fs');
 
+// existsSync moved from path in 0.6.x to fs in 0.8.x
+if (typeof fs.existsSync === 'function') {
+  var existsSync = fs.existsSync;
+} else {
+  var existsSync = path.existsSync;
+}
+
 // go through the configuration and determine log location
 var log_path = path.join(configuration.get('var_path'), 'log');
 
 // simple inline function for creation of dirs
 function mkdir_p(p) {
-  if (!fs.existsSync(p)) {
+  if (!existsSync(p)) {
     mkdir_p(path.dirname(p));
     fs.mkdirSync(p, "0755");
   }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -33,7 +33,7 @@ var LOGGER;
 
 // simple inline function for creation of dirs
 function mkdir_p(p) {
-  if (!path.existsSync(p)) {
+  if (!fs.existsSync(p)) {
     mkdir_p(path.dirname(p));
     fs.mkdirSync(p, "0755");
   }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -24,6 +24,13 @@ path = require('path'),
 fs = require('fs'),
 urlparse = require('urlparse');
 
+// existsSync moved from path in 0.6.x to fs in 0.8.x
+if (typeof fs.existsSync === 'function') {
+  var existsSync = fs.existsSync;
+} else {
+  var existsSync = path.existsSync;
+}
+
 // go through the configuration and determine log location
 // for now we only log to one place
 // FIXME: separate logs depending on purpose?
@@ -33,7 +40,7 @@ var LOGGER;
 
 // simple inline function for creation of dirs
 function mkdir_p(p) {
-  if (!fs.existsSync(p)) {
+  if (!existsSync(p)) {
     mkdir_p(path.dirname(p));
     fs.mkdirSync(p, "0755");
   }


### PR DESCRIPTION
teensy patch, doesn't break 0.6, lets devs work with 0.8 if they want to and lets us start exploring it.  (really all this does is eliminate deprecation warnings)
