### PR TITLE
Slide the arrow all the way off the screen.

### DIFF
--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -20,7 +20,10 @@
         doAnimation = $("#signIn").length && bodyWidth > 640;
 
     if (doAnimation) {
-      var endWidth = bodyWidth - 10;
+      /**
+       * Force the arrow to slide all the way off the screen.
+       */
+      var endWidth = bodyWidth + $(".arrowContainer").outerWidth();
 
       body.addClass("completing");
       /**


### PR DESCRIPTION
In desktop browsers other than IE, when selecting an email address, force the arrow to slide all the way off the screen.

issue #1920
