### PR TITLE
setting a timeout for provisioning of 20s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /resources/static/build
 /resources/static/production
 .DS_Store
+Thumbs.db
 /locale

--- a/resources/static/common/js/provisioning.js
+++ b/resources/static/common/js/provisioning.js
@@ -57,6 +57,7 @@ BrowserID.Provisioning = (function() {
     // positives if the user is on a slow connection.
     // the timeout should only happen if the provisioning site doesn't
     // want to provision for us.
+    // see https://github.com/mozilla/browserid/pull/1954
     function iframeOnLoad() {
       if (timeoutID) {
         clearTimeout(timeoutID);

--- a/resources/static/common/js/provisioning.js
+++ b/resources/static/common/js/provisioning.js
@@ -53,6 +53,10 @@ BrowserID.Provisioning = (function() {
     iframe.setAttribute('src', args.url);
     iframe.style.display = "none";
 
+    // start the timeout once the iframe loads, so we don't get false
+    // positives if the user is on a slow connection.
+    // the timeout should only happen if the provisioning site doesn't
+    // want to provision for us.
     function iframeOnLoad() {
       if (timeoutID) {
         clearTimeout(timeoutID);

--- a/resources/static/common/js/provisioning.js
+++ b/resources/static/common/js/provisioning.js
@@ -52,6 +52,24 @@ BrowserID.Provisioning = (function() {
     var iframe = document.createElement("iframe");
     iframe.setAttribute('src', args.url);
     iframe.style.display = "none";
+
+    function iframeOnLoad() {
+      if (timeoutID) {
+        clearTimeout(timeoutID);
+      }
+      // a timeout for the amount of time that provisioning is allowed to take
+      timeoutID = setTimeout(function provisionTimedOut() {
+        fail('timeoutError', 'Provisioning timed out.');
+      }, MAX_TIMEOUT);
+    }
+
+    if (iframe.addEventListener) {
+      iframe.addEventListener('load', iframeOnLoad, false);
+    } else if (iframe.attachEvent) {
+      iframe.attachEvent('onload', iframeOnLoad);
+    }
+    // else ruh-roh?
+
     document.body.appendChild(iframe);
 
     var chan = Channel.build({
@@ -97,10 +115,6 @@ BrowserID.Provisioning = (function() {
       successCB(keypair, cert);
     });
 
-    // a timeout for the amount of time that provisioning is allowed to take
-    timeoutID = setTimeout(function provisionTimedOut() {
-      fail('timeoutError', 'Provisioning timed out.');
-    }, MAX_TIMEOUT);
   };
 
   return Provisioning;

--- a/resources/static/common/js/provisioning.js
+++ b/resources/static/common/js/provisioning.js
@@ -7,9 +7,13 @@ BrowserID.Provisioning = (function() {
   "use strict";
 
   var jwcrypto = require("./lib/jwcrypto");
+  var MAX_TIMEOUT = 20000; // 20s
 
   var Provisioning = function(args, successCB, failureCB) {
+    var timeoutID;
+
     function tearDown() {
+      if (timeoutID) timeoutID = clearTimeout(timeoutID);
       if (chan) chan.destroy();
       chan = undefined;
       if (iframe) document.body.removeChild(iframe);
@@ -35,8 +39,9 @@ BrowserID.Provisioning = (function() {
     // extract the expected origin from the provisioning url
     // (this may be a different domain than the email domain part, if the
     //  domain delates authority)
+    var origin;
     try {
-      var origin = /^(https?:\/\/[^\/]+)\//.exec(args.url)[1];
+      origin = /^(https?:\/\/[^\/]+)\//.exec(args.url)[1];
     } catch(e) { alert(e); }
     if (!origin) {
       return fail('internal', 'bad provisioning url, can\'t extract origin');
@@ -92,7 +97,10 @@ BrowserID.Provisioning = (function() {
       successCB(keypair, cert);
     });
 
-    // XXX: set a timeout for the amount of time that provisioning is allowed to take
+    // a timeout for the amount of time that provisioning is allowed to take
+    timeoutID = setTimeout(function provisionTimedOut() {
+      fail('timeoutError', 'Provisioning timed out.');
+    }, MAX_TIMEOUT);
   };
 
   return Provisioning;


### PR DESCRIPTION
if `teardown` doesn't happen within 20 seconds, provisioning will `fail` with a timeoutError.

I couldn't find where these `msg` and `code` lineup with anything in the UI. However, #1570 doesn't say anything about the UI. That's in another issue.

fixes #1570
