### PR TITLE
fix issue GH-1958; add '/production/authenticate_with_primary.js' to ite...

### DIFF
--- a/tests/static-resource-test.js
+++ b/tests/static-resource-test.js
@@ -23,7 +23,15 @@ suite.addBatch({
       var res = resources.resources;
       assert.ok(files['/production/dialog.css'].length >= 3);
       // Get ride of non-localized asset bundles
-      ['/production/communication_iframe.js', '/production/include.js', '/production/dialog.css', '/production/browserid.css', '/production/ie8_main.css', '/production/ie8_dialog.css', '/production/relay.js', '/production/html5shim.js'].forEach(
+      ['/production/communication_iframe.js',
+       '/production/include.js',
+       '/production/dialog.css',
+       '/production/browserid.css',
+       '/production/ie8_main.css',
+       '/production/ie8_dialog.css',
+       '/production/relay.js',
+       '/production/html5shim.js',
+       '/production/authenticate_with_primary.js'].forEach(
         function (nonLocaleAsset) {
           delete res[nonLocaleAsset];
           delete files[nonLocaleAsset];


### PR DESCRIPTION
...ms to exclude and reformat the single line array

Seems right to me and back/back_mysql/front tests pass locally, but I'm only pattern matching from the commit to fix GH-1937 https://github.com/mozilla/browserid/commit/a3e88e7815cc38d531ad1a9e8d8842c64f344d4c
