### PR TITLE
Fix up controllers/rp_info front end tests in IE8.  Only the assertion timeout check fails now.

### DIFF
--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -53,6 +53,7 @@ var jwcrypto = require("./lib/jwcrypto");
 
       // expiration date must be within 5 seconds of 2 minutes from now - see
       // issue 433 (https://github.com/mozilla/browserid/issues/433)
+      // An IE8 VM takes about 7 seconds to generate an assertion.
       var diff = Math.abs(expires - nowPlus2Mins);
       ok(diff < 5000, "expiration date must be within 5 seconds of 2 minutes from now: " + diff);
 

--- a/resources/static/test/cases/dialog/js/modules/rp_info.js
+++ b/resources/static/test/cases/dialog/js/modules/rp_info.js
@@ -31,8 +31,12 @@
           // could already be destroyed from the close
         }
       }
-      window.scriptRun = null;
-      delete window.scriptRun;
+      try {
+        var und;
+        window.scriptRun = und;
+        delete window.scriptRun;
+      } catch(e) { /* IE8 blows up trying to delete scriptRun */ }
+
       testHelpers.teardown();
     }
   });

--- a/resources/static/test/mocks/provisioning.js
+++ b/resources/static/test/mocks/provisioning.js
@@ -23,7 +23,7 @@ BrowserID.Mocks.Provisioning = (function() {
         // network.withContext, add a random seed to ensure that we can get our
         // keypair.
         jwcrypto.addEntropy("H+ZgKuhjVckv/H4i0Qvj/JGJEGDVOXSIS5RCOjY9/Bo=");
-        jwcrypto.generateKeypair({algorithm: "DS", keysize: 256}, function(err, kp) {
+        jwcrypto.generateKeypair({algorithm: "DS", keysize: BrowserID.KEY_LENGTH}, function(err, kp) {
           keypair = kp;
           if (onsuccess) onsuccess(keypair, cert);
         });


### PR DESCRIPTION
Testing:

Please see the issue for instructions to disable the "this script is taking too long" warning.

@lloyd - there is only one test failing in IE8 now, that is the check to make sure an assertion's expiration time is valid.  In IE8, it is off by a couple of seconds, could you have a look at this?

issue #1783
