### PR TITLE
Center the "take the tour or sign up" text so that it matches the text above it.

### DIFF
--- a/resources/static/pages/css/m.css
+++ b/resources/static/pages/css/m.css
@@ -180,6 +180,13 @@
     display: none;
   }
 
+  .tour {
+    /* The "take the tour or sign up" text is left justified by default when
+     * everything else is centered.  Match everything up.  issue #1967
+     */
+    text-align: center;
+  }
+
   .tour .button {
     font-size: 18px;
   }


### PR DESCRIPTION
test specifically on mobile phones.

issue #1967
