### PR TITLE
Add the correct URL to the firefox logo.

### DIFF
--- a/resources/views/unsupported_dialog.ejs
+++ b/resources/views/unsupported_dialog.ejs
@@ -9,7 +9,7 @@
 
 
       <a href="http://getfirefox.com" target="_blank">
-        <img src="/i/firefox_logo.png" width="250" height="88" alt="Firefox logo" />
+        <img src="<%- cachify('/dialog/i/firefox_logo.png') %>" width="250" height="88" alt="Firefox logo" />
       </a>
 
       <p>


### PR DESCRIPTION
Cachify the logo as well.

issue #1999
