### PR TITLE
Make redirect countdown and redirect in sync

### DIFF
--- a/resources/static/pages/js/page_helpers.js
+++ b/resources/static/pages/js/page_helpers.js
@@ -73,26 +73,19 @@ BrowserID.PageHelpers = (function() {
 
   function replaceFormWithNotice(selector, onComplete) {
     $("form").hide();
-    $(selector).fadeIn(ANIMATION_SPEED);
-    // If there is more than one .forminputs, the onComplete callback is called
-    // multiple times, we only want once.
-    onComplete && setTimeout(onComplete, ANIMATION_SPEED);
+    $(selector).fadeIn(ANIMATION_SPEED).promise().done(onComplete);
   }
 
   function replaceInputsWithNotice(selector, onComplete) {
     $('.forminputs').hide();
-    $(selector).stop().hide().css({opacity:1}).fadeIn(ANIMATION_SPEED);
-    // If there is more than one .forminputs, the onComplete callback is called
-    // multiple times, we only want once.
-    onComplete && setTimeout(onComplete, ANIMATION_SPEED);
+    $(selector).stop().hide().css({opacity:1}).fadeIn(ANIMATION_SPEED)
+      .promise().done(onComplete);
   }
 
   function showInputs(onComplete) {
     $('.notification').hide();
-    $('.forminputs').stop().hide().css({opacity:1}).fadeIn(ANIMATION_SPEED);
-    // If there is more than one .forminputs, the onComplete callback is called
-    // multiple times, we only want once.
-    onComplete && setTimeout(onComplete, ANIMATION_SPEED);
+    $('.forminputs').stop().hide().css({opacity:1}).fadeIn(ANIMATION_SPEED)
+      .promise().done(onComplete);
   }
 
   function emailSent(onComplete) {

--- a/resources/static/test/cases/pages/js/verify_secondary_address.js
+++ b/resources/static/test/cases/pages/js/verify_secondary_address.js
@@ -11,6 +11,7 @@
       xhr = bid.Mocks.xhr,
       WindowMock = bid.Mocks.WindowMock,
       dom = bid.DOM,
+      pageHelpers = bid.PageHelpers,
       testHelpers = bid.TestHelpers,
       testHasClass = testHelpers.testHasClass,
       testVisible = testHelpers.testVisible,
@@ -26,19 +27,24 @@
     setup: function() {
       testHelpers.setup();
       bid.Renderer.render("#page_head", "site/confirm", {});
+      $(document.body).append($('<div id=redirectTimeout>'));
       $(".siteinfo,.password_entry").hide();
     },
     teardown: function() {
+      $('#redirectTimeout').remove();
       testHelpers.teardown();
     }
   });
 
   function createController(options, callback) {
     controller = BrowserID.verifySecondaryAddress.create();
-    options = options || {};
-    options.document = doc = new WindowMock().document;
-    options.redirectTimeout = 0;
-    options.ready = callback;
+    // defaults, but options can override
+    options = _.extend({
+      document: new WindowMock().document,
+      redirectTimeout: 0,
+      ready: callback
+    }, options || {});
+    doc = options.document;
     controller.start(options);
   }
 
@@ -152,6 +158,34 @@
     xhr.useResult("invalid");
     createController(config, function() {
       testCannotConfirm();
+      start();
+    });
+  });
+
+  asyncTest("redirect: message shows with correct timeout", function() {
+    var returnTo = 'http://test.domain/path';
+    storage.setReturnTo(returnTo);
+    var timeout = 2;
+
+    //mock out helper so we can check progress of redirectTimeout el
+    var replaceFormWithNotice = pageHelpers.replaceFormWithNotice;
+    pageHelpers.replaceFormWithNotice = function(selector, cb) {
+      // mock out 2s network response
+      setTimeout(function mockedNetwork() {
+        replaceFormWithNotice.call(this, selector, function intercepted() {
+          equal(parseInt($('#redirectTimeout').html(), 10), timeout,
+            'timeout should not have started countdown yet');
+
+          //at the end, finish with cb
+          cb && cb();
+        });
+      }, (timeout - 1) * 1000);
+    };
+
+    var options = _.extend({ redirectTimeout: timeout * 1000 }, config);
+    createController(options, function() {
+      // teardown
+      pageHelpers.replaceFormWithNotice = replaceFormWithNotice;
       start();
     });
   });


### PR DESCRIPTION
This moves the countdown and the redirect timeout into the same timeout, and they don't start until after the animation has faded in, and the possible network request has finished.

issue #2007
