### PR TITLE
Fix the slow Fennec key press response in the email field.

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -18,7 +18,8 @@ BrowserID.Modules.Authenticate = (function() {
       dom = bid.DOM,
       lastEmail = "",
       addressInfo,
-      hints = ["returning","start","addressInfo"];
+      hints = ["returning","start","addressInfo"],
+      currentHint;
 
   function getEmail() {
     return helpers.getAndValidateEmail("#email");
@@ -101,6 +102,12 @@ BrowserID.Modules.Authenticate = (function() {
   }
 
   function showHint(showSelector, callback) {
+    // Only show the hint if it is not already shown. Showing the same hint
+    // on every keypress massively slows down Fennec. See issue #2010
+    // https://github.com/mozilla/browserid/issues/2010
+    if (currentHint === showSelector) return;
+    currentHint = showSelector;
+
     _.each(hints, function(className) {
       if(className != showSelector) {
         dom.hide("." + className + ":not(." + showSelector + ")");


### PR DESCRIPTION
- Only show a hint if it is not already shown.

issue #2010
