### PR TITLE
Add new authentication related KPIs for @nmalkin

### DIFF
--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -79,7 +79,11 @@ BrowserID.Modules.InteractionData = (function() {
     user_confirmed: "user.user_confirmed",
     email_staged: "user.email_staged",
     email_confirmed: "user.email_confrimed",
-    notme: "user.logout"
+    notme: "user.logout",
+    enter_password: "authenticate.enter_password",
+    password_submit: "authenticate.password_submitted",
+    authentication_success: "authenticate.password_success",
+    authentication_fail: "authenticate.password_fail"
   };
 
   function getKPIName(msg, data) {
@@ -204,7 +208,7 @@ BrowserID.Modules.InteractionData = (function() {
     self.initialEventStream = null;
 
     self.samplesBeingStored = true;
-    
+
   }
 
   function indexOfEvent(eventStream, eventName) {

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -62,9 +62,14 @@
 
   function authenticateUser(email, pass, callback) {
     var self=this;
+    self.publish("password_submit");
     user.authenticate(email, pass,
       function (authenticated) {
-        if (!authenticated) {
+        if (authenticated) {
+          self.publish("authentication_success");
+        }
+        else {
+          self.publish("authentication_fail");
           tooltip.showTooltip("#cannot_authenticate");
         }
         complete(callback, authenticated);

--- a/resources/static/test/cases/dialog/js/misc/helpers.js
+++ b/resources/static/test/cases/dialog/js/misc/helpers.js
@@ -18,6 +18,8 @@
       mediator = bid.Mediator,
       errorCB,
       expectedError = testHelpers.expectedXHRFailure,
+      expectedMessage = testHelpers.expectedMessage,
+      unexpectedMessage = testHelpers.unexpectedMessage,
       badError = testHelpers.unexpectedXHRFailure;
 
   var controllerMock = {
@@ -29,22 +31,7 @@
     }
   };
 
-  function expectedMessage(message, expectedFields) {
-    mediator.subscribe(message, function(m, info) {
-      equal(m, message, "correct message: " + message);
-
-      testHelpers.testObjectValuesEqual(info, expectedFields);
-    });
-  }
-
-
-  function unexpectedMessage(message) {
-    mediator.subscribe(message, function(m, info) {
-      ok(false, "close should have never been called");
-    });
-  }
-
-  module("resources/helpers", {
+  module("dialog/js/misc/helpers", {
     setup: function() {
       testHelpers.setup();
       errorCB = null;
@@ -78,10 +65,12 @@
 
     xhr.useResult("ajaxError");
     storage.addEmail("registered@testuser.com", {});
-    dialogHelpers.getAssertion.call(controllerMock, "registered@testuser.com", testHelpers.unexpectedSuccess);
+    dialogHelpers.getAssertion.call(controllerMock, "registered@testuser.com", testHelpers.expectedFailure);
   });
 
   asyncTest("authenticateUser happy case", function() {
+    expectedMessage("password_submit");
+    expectedMessage("authentication_success");
     dialogHelpers.authenticateUser.call(controllerMock, "testuser@testuser.com", "password", function(authenticated) {
       equal(authenticated, true, "user is authenticated");
       start();
@@ -90,6 +79,8 @@
 
   asyncTest("authenticateUser invalid credentials", function() {
     xhr.useResult("invalid");
+    expectedMessage("password_submit");
+    expectedMessage("authentication_fail");
     dialogHelpers.authenticateUser.call(controllerMock, "testuser@testuser.com", "password", function(authenticated) {
       equal(authenticated, false, "user is not authenticated");
       start();
@@ -100,6 +91,7 @@
     errorCB = expectedError;
 
     xhr.useResult("ajaxError");
+    expectedMessage("password_submit");
     dialogHelpers.authenticateUser.call(controllerMock, "testuser@testuser.com", "password", testHelpers.unexpectedSuccess);
   });
 
@@ -209,7 +201,7 @@
   });
 
   asyncTest("resetPassword happy case", function() {
-    expectedMessage("password_reset", {
+    expectedMessage("reset_password_staged", {
       email: "registered@testuser.com"
     });
 


### PR DESCRIPTION
new KPIs in the event stream:
- authenticate.enter_password
- authenticate.password_submitted
- authenticate.password_success
- authenticate.password_fail

Added a couple of new testHelper functions, expectedMessage and unexpectedMessage

issue #1825
