### PR TITLE
Show content for cookies_disabled and unsupported_dialog on mobile devic...

### DIFF
--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -188,5 +188,13 @@
   .inputs > li {
     margin-top: 12px;
   }
+
+  /* The unsupported and cookies_disabled dialogs have to be position: static
+   * or else their content is not displayed on mobile devices. See issue #1998
+   */
+  #error.unsupported, #error.cookies_disabled {
+    position: static;
+    height: 250px;
+  }
 }
 


### PR DESCRIPTION
...es.
- This is still not pretty, but it is a safe for hotfix into staging. This makes the unsupported dialog and cookies disabled screens look equivalent to the current prod.
