### PR TITLE
moved node-statsd to optionalDependency

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -127,7 +127,7 @@ var conf = module.exports = convict({
   statsd: {
     enabled: {
       doc: "enable UDP based statsd reporting",
-      format: 'boolean = true',
+      format: 'boolean = false',
       env: 'ENABLE_STATSD'
     },
     host: "string?",

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -37,7 +37,7 @@ if (statsd_config && statsd_config.enabled) {
 
     statsd = new StatsD(options["host"], options["port"]);
   } else {
-	log.error('statsd config enabled, but node-statsd not installed.');
+	logger.error('statsd config enabled, but node-statsd not installed.');
   }
 }
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -3,8 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const
-StatsD = require("node-statsd").StatsD,
-config = require('./configuration');
+config = require('./configuration'),
+logger = require('./logging').logger;
+
+var StatsD = false;
+try {
+  StatsD = require("node-statsd").StatsD;
+} catch (requireError) {
+  // its ok, its an optionalDependency
+}
 
 const PREFIX = "browserid." + config.get('process_type') + ".";
 
@@ -23,11 +30,15 @@ module.exports = {
 var statsd_config = config.get('statsd');
 
 if (statsd_config && statsd_config.enabled) {
-  var options = {};
-  options["host"] = options["host"] || "localhost";
-  options["port"] = options["port"] || 8125;
+  if (StatsD) {
+    var options = {};
+    options["host"] = options["host"] || "localhost";
+    options["port"] = options["port"] || 8125;
 
-  statsd = new StatsD(options["host"], options["port"]);
+    statsd = new StatsD(options["host"], options["port"]);
+  } else {
+	log.error('statsd config enabled, but node-statsd not installed.');
+  }
 }
 
 process.on('uncaughtException', function(err) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
         "mustache": "0.3.1-dev",
         "jwcrypto": "0.3.2",
         "mysql": "0.9.5",
-        "node-statsd": "https://github.com/downloads/lloyd/node-statsd/0509f85.tgz",
         "nodemailer": "0.1.24",
         "mkdirp": "0.3.0",
         "optimist": "0.2.8",
@@ -33,6 +32,9 @@
         "urlparse": "0.0.1",
         "validator": "0.4.9",
         "winston": "0.6.2"
+    },
+    "optionalDependencies": {
+        "node-statsd": "https://github.com/downloads/lloyd/node-statsd/0509f85.tgz"
     },
     "devDependencies": {
         "vows": "0.5.13",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
         "start": "./scripts/run_locally.js"
     },
     "engines": {
-        "node": ">= 0.6.2"
+        "node": ">= 0.6.7"
     }
 }


### PR DESCRIPTION
also prevents error from require node-statsd if it wasn't installed,
but logs error if config says it should be enabled.

fixes #1751
