### PR TITLE
Allow assertions issued by person to be used to authenticate.  This make...

### DIFF
--- a/lib/primary.js
+++ b/lib/primary.js
@@ -12,7 +12,8 @@ http = require('http'),
 logger = require('./logging.js').logger,
 urlparse = require('urlparse'),
 jwcrypto = require("jwcrypto"),
-config = require("./configuration.js");
+config = require("./configuration.js"),
+secrets = require("./secrets.js");
 
 // alg
 require("jwcrypto/lib/algs/rs");
@@ -26,6 +27,14 @@ const MAX_AUTHORITY_DELEGATIONS = 6;
 const HOSTNAME = urlparse(config.get('public_url')).host;
 
 var g_shim_cache = {};
+
+try {
+  const PUBLIC_KEY = secrets.loadPublicKey();
+  if (typeof PUBLIC_KEY !== 'object') throw "secrets.loadPublicKey() returns non-object, load failure";
+} catch(e){
+  logger.error("can't read public key, exiting: " + e);
+  setTimeout(function() { process.exit(1); }, 0);
+}
 
 // This becomes async
 function parseWellKnownBody(body, domain, delegates, cb) {
@@ -274,9 +283,10 @@ exports.verifyAssertion = function(assertion, cb) {
   }
 
   var getRoot = function(issuer, next) {
-    // issuer cannot be the browserid
+    // allow assertions rooted in certs issued by us.  this occurs in the proxy_idp case
+    // where we sign assertions for other domains.
     if (issuer === HOSTNAME) {
-      next("cannot authenticate to browserid with a certificate issued by it.");
+      next(null, PUBLIC_KEY);
     } else {
       exports.getPublicKey(issuer, function(err, pubKey) {
         if (err) return next(err);
@@ -293,7 +303,7 @@ exports.verifyAssertion = function(assertion, cb) {
     // for now, to be extra safe, we don't allow cert chains
     if (certParamsArray.length > 1)
       return cb("certificate chaining is not yet allowed");
-    
+
     // audience must be browserid itself
     var want = urlparse(config.get('public_url')).originOnly();
     var got = urlparse(assertionParams.audience).originOnly();

--- a/tests/lib/primary.js
+++ b/tests/lib/primary.js
@@ -24,18 +24,18 @@ User.prototype.setup = function(cb) {
   // upon allocation of a user, we'll gen a keypair and get a signed cert
   jwcrypto.generateKeypair({algorithm:"DS", keysize:256}, function(err, kp) {
     if (err) return cb(err);
-    
+
     self._keyPair = kp;
-    
+
     var expiration = new Date();
     expiration.setTime(new Date().valueOf() + 60 * 60 * 1000);
-    
+
     jwcrypto.cert.sign(self._keyPair.publicKey, {email: self.options.email},
                        {expiresAt: expiration, issuer: self.options.domain, issuedAt: new Date()},
-                       {}, g_privKey, function(err, signedCert) {
+                       {}, self.options.privKey || g_privKey, function(err, signedCert) {
                          if (err) return cb(err);
                          self._cert = signedCert;
-                         
+
                          cb(null);
                        });
   });

--- a/tests/proxy-idp-test.js
+++ b/tests/proxy-idp-test.js
@@ -81,7 +81,9 @@ suite.addBatch({
   }
 });
 
-// and now let's verify a primary
+// We've verified that the proxy IDP configuration allows us to simulate a delegated authority.
+// Now let's test the other part of this puzzle - that users can log in with certs issued
+// by our proxy idp servers. (for which the issuer is login.persona.org).
 var primaryUser = new primary({
   email: "bartholomew@yahoo.com",
   domain: "127.0.0.1",
@@ -91,7 +93,7 @@ var primaryUser = new primary({
 });
 
 suite.addBatch({
-  "set things up": {
+  "initializing a primary user": {
     topic: function() {
       primaryUser.setup(this.callback);
     },
@@ -101,25 +103,23 @@ suite.addBatch({
   }
 });
 
-// now let's generate an assertion using this user
 suite.addBatch({
-  "generating an assertion": {
+  "generating an assertion targeted at the persona service": {
     topic: function() {
       primaryUser.getAssertion('http://127.0.0.1:10002', this.callback);
     },
     "succeeds": function(err, r) {
       assert.isString(r);
     },
-    "and logging in with the assertion succeeds": {
+    "and logging in with the assertion": {
       topic: function(err, assertion)  {
         wsapi.post('/wsapi/auth_with_assertion', {
           assertion: assertion,
           ephemeral: true
         }).call(this);
       },
-      "works": function(err, r) {
+      "succeeds": function(err, r) {
         var resp = JSON.parse(r.body);
-        console.log(resp);
         assert.isObject(resp);
         assert.isTrue(resp.success);
       }


### PR DESCRIPTION
...s it possible for "proxy idps" to work without the implementation details leaking out into others verifier implementations.
