### PR TITLE
add access-control-allow-origin to all static resources (excluding views...

### DIFF
--- a/bin/static
+++ b/bin/static
@@ -90,11 +90,15 @@ app.use(cachify.setup(assets(config.get('supported_languages')),
           root: static_root,
         }));
 
-
-// if nothing else has caught this request, serve static files, but ensure
-// that proper vary headers are installed to prevent unwanted caching
+// add 'Access-Control-Allow-Origin' headers to static resources that will be served
+// from the CDN.  We explicitly allow resources served from public_url to access these.
 app.use(function(req, res, next) {
-  res.setHeader('Vary', 'Accept-Encoding,Accept-Language');
+  res.on('header', function() {
+    // this allows fonts to be requested cross domain
+    res.setHeader("Access-Control-Allow-Origin", config.get('public_url'));
+    // this makes sure caches properly consider language headers
+    res.setHeader('Vary', 'Accept-Encoding,Accept-Language');
+  });
   next();
 });
 

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -107,7 +107,6 @@ exports.setup = function(app) {
   });
 
   app.get('/communication_iframe', function(req, res, next ) {
-
     renderCachableView(req, res, 'communication_iframe.ejs', {
       layout: false,
       production: config.get('use_minified_resources')

--- a/tests/cache-header-tests.js
+++ b/tests/cache-header-tests.js
@@ -74,8 +74,6 @@ function hasProperCacheHeaders(path) {
       assert.strictEqual(r.statusCode, 200);
       // check X-Frame-Option headers
       hasProperFramingHeaders(r, path);
-      // ensure vary headers
-      assert.strictEqual(r.headers['vary'], 'Accept-Encoding,Accept-Language');
       // ensure public, max-age=0
       assert.strictEqual(r.headers['cache-control'], 'public, max-age=0');
       // the behavior of combining a last-modified date and an etag is undefined by
@@ -135,6 +133,20 @@ suite.addBatch({
   '/confirm': hasProperCacheHeaders('/confirm'),
 //  '/pk': hasProperCacheHeaders('/pk'),
 //  '/.well-known/browserid': hasProperCacheHeaders('/.well-known/browserid')
+});
+
+// related to cache headers are correct headers which let us serve static resources
+// (not rendered views) from a different domain, to support CDN compat
+suite.addBatch({
+  "static resources": {
+    topic: function() {
+      doRequest("/favicon.ico", {}, this.callback);
+    },
+    "have proper access control headers": function(err, r) {
+      assert.strictEqual(r.statusCode, 200);
+      assert.strictEqual(r.headers['access-control-allow-origin'],"http://127.0.0.1:10002");
+    }
+  }
 });
 
 // shut the server down and cleanup


### PR DESCRIPTION
...), to allow fonts to be requested cross domain.  fixes a regression introduced during the merge of router, for issue #1973
