### PR TITLE
fixes to get it running on Windows

### DIFF
--- a/lib/shutdown.js
+++ b/lib/shutdown.js
@@ -75,9 +75,7 @@ exports.handleTerminationSignals = function(app, callback) {
     };
   }
 
-  try {
+  if (!process.env.NO_SIGNALS) {
     process.on('SIGINT', endIt('INT')).on('SIGTERM', endIt('TERM')).on('SIGQUIT', endIt('QUIT'));
-  } catch (noSignals) {
-    // Window doesn't support signals
   }
 };

--- a/lib/shutdown.js
+++ b/lib/shutdown.js
@@ -75,5 +75,9 @@ exports.handleTerminationSignals = function(app, callback) {
     };
   }
 
-  process.on('SIGINT', endIt('INT')).on('SIGTERM', endIt('TERM')).on('SIGQUIT', endIt('QUIT'));
+  try {
+    process.on('SIGINT', endIt('INT')).on('SIGTERM', endIt('TERM')).on('SIGQUIT', endIt('QUIT'));
+  } catch (noSignals) {
+    // Window doesn't support signals
+  }
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "scripts": {
         "postinstall": "./scripts/generate_ephemeral_keys.sh",
         "test": "./scripts/test",
-        "start": "./scripts/run_locally.js"
+        "start": "node ./scripts/run_locally.js"
     },
     "engines": {
         "node": ">= 0.6.2"


### PR DESCRIPTION
- Windows doesn't have signals, so process.on("SIGINT") throws
- changing process.env.PATH is a bad idea

covers parts of #1769

_note_: it won't actually run on Windows till all other PRs addressing #1769 are merged also.
