### PR TITLE
Update "Developer" links to point to our MDN root

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -231,7 +231,7 @@ exports.setup = function(app) {
 
   // REDIRECTS
   const REDIRECTS = {
-    "/developers" : "https://developer.mozilla.org/en/BrowserID/Quick_Setup"
+    "/developers" : "https://developer.mozilla.org/en/BrowserID"
   };
 
   // set up all the redirects

--- a/resources/views/about.ejs
+++ b/resources/views/about.ejs
@@ -42,7 +42,7 @@
             </article>
         </section>
 
-        <a href="https://developer.mozilla.org/en/BrowserID/Quick_Setup" class="developers" target="_blank"><img src="<%- cachify('/pages/i/developers-link.png') %>" alt="<%- gettext('Persona for developers') %>"><span><%- gettext('Implement Persona on your site') %> </span><%- gettext('Developer guides and API documentation') %></a>
+        <a href="https://developer.mozilla.org/en/BrowserID" class="developers" target="_blank"><img src="<%- cachify('/pages/i/developers-link.png') %>" alt="<%- gettext('Persona for developers') %>"><span><%- gettext('Implement Persona on your site') %> </span><%- gettext('Developer guides and API documentation') %></a>
     </div><!-- #dashboard -->
 </div>
 

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -30,7 +30,7 @@
 
         <ul class="nav cf">
             <li><a href="/about"><%= gettext("How it works") %></a></li>
-            <li><a href="https://developer.mozilla.org/en/BrowserID/Quick_Setup" target="_blank"><%= gettext("Developers") %></a></li>
+            <li><a href="https://developer.mozilla.org/en/BrowserID" target="_blank"><%= gettext("Developers") %></a></li>
 
             <li class="signIn"><a class="signIn" href="/signin"><%= gettext("Sign In") %></a></li>
             <li class="signOut"><a class="signOut" href="/"><%= gettext("Sign Out") %></a></li>


### PR DESCRIPTION
Rather than going straight to the quick setup, we should link to somewhere that
gives a little more context.
