### PR TITLE
Issues 2088 2104 address verification

### DIFF
--- a/lib/wsapi/email_for_token.js
+++ b/lib/wsapi/email_for_token.js
@@ -55,7 +55,8 @@ exports.process = function(req, res) {
                req.params.token === req.session.pendingCreation) {
         must_auth = false;
       }
-      else if (typeof req.session.pendingReverification === 'string') {
+      else if (typeof req.session.pendingReverification === 'string' ||
+               typeof req.session.pendingAddition === 'string') {
         must_auth = false;
       }
       // NOTE: for reverification, we require you're authenticated.  it's not enough

--- a/lib/wsapi/email_for_token.js
+++ b/lib/wsapi/email_for_token.js
@@ -42,20 +42,20 @@ exports.process = function(req, res) {
 
     function checkMustAuth() {
       // must the user authenticate?  This is true if they are not authenticated
-      // as the uid who initiated the verification, and they are not on the same
+      // as the uid who initiated the verification, or they are not on the same
       // browser as the initiator
       var must_auth = true;
 
-      if (uid && req.session.userid === uid) {
+      if (uid && req.session.userid === uid &&
+               typeof req.session.pendingReset === 'string' &&
+               req.params.token === req.session.pendingReset) {
         must_auth = false;
       }
       else if (!uid && typeof req.session.pendingCreation === 'string' &&
                req.params.token === req.session.pendingCreation) {
         must_auth = false;
       }
-      else if (typeof req.session.pendingReset === 'string' &&
-               req.params.token === req.session.pendingReset)
-      {
+      else if (typeof req.session.pendingReverification === 'string') {
         must_auth = false;
       }
       // NOTE: for reverification, we require you're authenticated.  it's not enough

--- a/lib/wsapi/email_for_token.js
+++ b/lib/wsapi/email_for_token.js
@@ -46,7 +46,7 @@ exports.process = function(req, res) {
       // browser as the initiator
       var must_auth = true;
 
-      if (uid && req.session.userid === uid &&
+      if (((uid && req.session.userid === uid) || !req.session.userid) &&
                typeof req.session.pendingReset === 'string' &&
                req.params.token === req.session.pendingReset) {
         must_auth = false;

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -101,15 +101,8 @@ BrowserID.Network = (function() {
   }
 
   function handleAddressVerifyCheckResponse(onComplete, status, textStatus, jqXHR) {
-    if (status.status === 'complete') {
-      // The user at this point can ONLY be logged in with password
-      // authentication. Once the registration is complete, that means
-      // the server has updated the user's cookies and the user is
-      // officially authenticated.
-      auth_status = 'password';
-
-      if (status.userid) setUserID(status.userid);
-    }
+    if (status.status === 'complete' && status.userid)
+      setUserID(status.userid);
     complete(onComplete, status.status);
   }
 

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -17,7 +17,9 @@ BrowserID.User = (function() {
       addressCache = {},
       primaryAuthCache = {},
       complete = bid.Helpers.complete,
-      registrationComplete = false;
+      registrationComplete = false,
+      POLL_TIMEOUT = 3000,
+      pollTimeout = POLL_TIMEOUT;
 
   function prepareDeps() {
     if (!jwcrypto) {
@@ -193,7 +195,7 @@ BrowserID.User = (function() {
           else complete(onSuccess, status);
         }
         else if (status === 'pending') {
-          pollTimeout = setTimeout(poll, 3000);
+          pollTimeout = setTimeout(poll, pollTimeout);
         }
         else if (onFailure) {
             onFailure(status);
@@ -283,12 +285,17 @@ BrowserID.User = (function() {
         provisioning = config.provisioning;
       }
 
+      if (config.pollTimeout) {
+        pollTimeout = config.pollTimeout;
+      }
+
     },
 
     reset: function() {
       provisioning = BrowserID.Provisioning;
       User.resetCaches();
       registrationComplete = false;
+      pollTimeout = POLL_TIMEOUT;
     },
 
     resetCaches: function() {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -18,8 +18,8 @@ BrowserID.User = (function() {
       primaryAuthCache = {},
       complete = bid.Helpers.complete,
       registrationComplete = false,
-      POLL_TIMEOUT = 3000,
-      pollTimeout = POLL_TIMEOUT;
+      POLL_DURATION = 3000,
+      pollDuration = POLL_DURATION;
 
   function prepareDeps() {
     if (!jwcrypto) {
@@ -195,7 +195,7 @@ BrowserID.User = (function() {
           else complete(onSuccess, status);
         }
         else if (status === 'pending') {
-          pollTimeout = setTimeout(poll, pollTimeout);
+          pollTimeout = setTimeout(poll, pollDuration);
         }
         else if (onFailure) {
             onFailure(status);
@@ -285,9 +285,11 @@ BrowserID.User = (function() {
         provisioning = config.provisioning;
       }
 
-      if (config.pollTimeout) {
-        pollTimeout = config.pollTimeout;
+      // BEGIN TESTING API
+      if (config.pollDuration) {
+        pollDuration = config.pollDuration;
       }
+      // END TESTING API
 
     },
 
@@ -295,7 +297,7 @@ BrowserID.User = (function() {
       provisioning = BrowserID.Provisioning;
       User.resetCaches();
       registrationComplete = false;
-      pollTimeout = POLL_TIMEOUT;
+      pollDuration = POLL_DURATION;
     },
 
     resetCaches: function() {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -116,6 +116,12 @@ BrowserID.User = (function() {
     complete(onComplete, status);
   }
 
+  function markAddressVerified(email) {
+    var idInfo = storage.getEmail(email) || {};
+    idInfo.verified = true;
+    storage.addSecondaryEmail(email, idInfo);
+  }
+
   function completeAddressVerification(completeFunc, token, password, onComplete, onFailure) {
     User.tokenInfo(token, function(info) {
       var invalidInfo = { valid: false };
@@ -125,17 +131,10 @@ BrowserID.User = (function() {
 
           if (valid) {
             result = _.extend({ valid: valid }, info);
-            var email = info.email,
-                idInfo = storage.getEmail(email);
-
             // Now that the address is verified, its verified bit has to be
             // updated as well or else the user will be forced to verify the
             // address again.
-            if (idInfo) {
-              idInfo.verified = true;
-              storage.addEmail(email, idInfo);
-            }
-
+            markAddressVerified(info.email);
             storage.setReturnTo("");
           }
 
@@ -162,6 +161,11 @@ BrowserID.User = (function() {
           // ensure that the stagedOnBehalfOf is cleared so there is no stale
           // data.
           storage.setReturnTo("");
+
+          // Now that the address is verified, its verified bit has to be
+          // updated as well or else the user will be forced to verify the
+          // address again.
+          markAddressVerified(email);
 
           // To avoid too many address_info requests, returns from each
           // address_info request are cached.  If the user is doing
@@ -290,7 +294,6 @@ BrowserID.User = (function() {
         pollDuration = config.pollDuration;
       }
       // END TESTING API
-
     },
 
     reset: function() {

--- a/resources/static/dialog/js/modules/check_registration.js
+++ b/resources/static/dialog/js/modules/check_registration.js
@@ -56,15 +56,11 @@ BrowserID.Modules.CheckRegistration = (function() {
                   oncomplete && oncomplete();
                 });
               } else {
-                user.addressInfo(self.email, function(info) {
-                  self.close("authenticate", info);
-                });
+                self.close("authenticate_specified_email", { email: self.email });
               }
             });
           } else {
-            user.addressInfo(self.email, function(info) {
-              self.close("authenticate", info);
-            });
+            self.close("authenticate_specified_email", { email: self.email });
           }
 
           oncomplete && oncomplete();

--- a/resources/static/dialog/js/modules/check_registration.js
+++ b/resources/static/dialog/js/modules/check_registration.js
@@ -41,7 +41,7 @@ BrowserID.Modules.CheckRegistration = (function() {
         if (status === "complete") {
           // TODO - move the syncEmails somewhere else, perhaps into user.js
           user.syncEmails(function() {
-            self.close(self.verificationMessage);
+            self.close(self.verificationMessage, { mustAuth: false });
             oncomplete && oncomplete();
           });
         }
@@ -49,18 +49,22 @@ BrowserID.Modules.CheckRegistration = (function() {
           // if we have a password (because it was just chosen in dialog),
           // then we can authenticate the user and proceed
           if (self.password) {
+            // XXX Move all of this authentication stuff into user.js.  This
+            // high level shouldn't have to worry about this stuff.
             user.authenticate(self.email, self.password, function (authenticated) {
               if (authenticated) {
                 user.syncEmails(function() {
-                  self.close(self.verificationMessage);
+                  self.close(self.verificationMessage, { mustAuth: false });
                   oncomplete && oncomplete();
                 });
               } else {
-                self.close("authenticate_specified_email", { email: self.email });
+                // unable to log the user in, make them authenticate manually.
+                self.close(self.verificationMessage, { mustAuth: true });
               }
             });
           } else {
-            self.close("authenticate_specified_email", { email: self.email });
+            // no password to log the user in, make them authenticate manually.
+            self.close(self.verificationMessage, { mustAuth: true });
           }
 
           oncomplete && oncomplete();

--- a/resources/static/dialog/js/modules/required_email.js
+++ b/resources/static/dialog/js/modules/required_email.js
@@ -124,7 +124,8 @@ BrowserID.Modules.RequiredEmail = (function() {
           showTemplate({
             signin: true,
             password: auth_level !== "password",
-            secondary_auth: secondaryAuth
+            secondary_auth: secondaryAuth,
+            cancelable: options.cancelable
           });
           ready();
         }
@@ -219,7 +220,8 @@ BrowserID.Modules.RequiredEmail = (function() {
           password: false,
           secondary_auth: false,
           primary: false,
-          personaTOSPP: false
+          personaTOSPP: false,
+          cancelable: true
         }, templateData);
 
         self.renderDialog("required_email", templateData);

--- a/resources/static/dialog/views/required_email.ejs
+++ b/resources/static/dialog/views/required_email.ejs
@@ -57,7 +57,7 @@
               <button id="verify_address" tabindex="3"><%= gettext("verify email") %></button>
             <% } %>
 
-            <% if (secondary_auth) { %>
+            <% if (cancelable && secondary_auth) { %>
               <a href="#" id="cancel" class="action" tabindex="4"><%= gettext("cancel") %></a>
             <% } %>
           </p>

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -55,10 +55,7 @@
       transport.useResult("complete");
       network[funcName]("registered@testuser.com", function(status) {
         equal(status, "complete");
-        network.checkAuth(function(auth_level) {
-          equal(auth_level, "password", "user can only be authenticated to password level after verification is complete");
-          start();
-        });
+        start();
       }, testHelpers.unexpectedFailure);
     });
   }
@@ -257,53 +254,11 @@
     failureCheck(network.createUser, "validuser", "password", "origin");
   });
 
-  asyncTest("checkUserRegistration returns pending - pending status, user is not logged in", function() {
-    transport.useResult("pending");
+  asyncTest("checkUserRegistration returns pending - pending status, user is not logged in", testVerificationPending.curry("checkUserRegistration"));
 
-    // To properly check the user registration status, we first have to
-    // simulate the first checkAuth or else network has no context from which
-    // to work.
-    network.checkAuth(function(auth_status) {
-      equal(!!auth_status, false, "user not yet authenticated");
-      network.checkUserRegistration("registered@testuser.com", function(status) {
-        equal(status, "pending");
-        network.checkAuth(function(auth_status) {
-          equal(!!auth_status, false, "user not yet authenticated");
-          start();
-        }, testHelpers.unexpectedFailure);
-      }, testHelpers.unexpectedFailure);
-    }, testHelpers.unexpectedFailure);
-  });
+  asyncTest("checkUserRegistration returns mustAuth - mustAuth status, user is not logged in", testVerificationMustAuth.curry("checkUserRegistration"));
 
-  asyncTest("checkUserRegistration returns mustAuth - mustAuth status, user is not logged in", function() {
-    transport.useResult("mustAuth");
-
-    network.checkAuth(function(auth_status) {
-      equal(!!auth_status, false, "user not yet authenticated");
-      network.checkUserRegistration("registered@testuser.com", function(status) {
-        equal(status, "mustAuth");
-        network.checkAuth(function(auth_status) {
-          equal(!!auth_status, false, "user not yet authenticated");
-          start();
-        }, testHelpers.unexpectedFailure);
-      }, testHelpers.unexpectedFailure);
-    }, testHelpers.unexpectedFailure);
-  });
-
-  asyncTest("checkUserRegistration returns complete - complete status, user is logged in", function() {
-    transport.useResult("complete");
-
-    network.checkAuth(function(auth_status) {
-      equal(!!auth_status, false, "user not yet authenticated");
-      network.checkUserRegistration("registered@testuser.com", function(status) {
-        equal(status, "complete");
-        network.checkAuth(function(auth_status) {
-          equal(auth_status, "password", "user authenticated after checkUserRegistration returns complete");
-          start();
-        }, testHelpers.unexpectedFailure);
-      }, testHelpers.unexpectedFailure);
-    }, testHelpers.unexpectedFailure);
-  });
+  asyncTest("checkUserRegistration returns complete - complete status, user is logged in", testVerificationComplete.curry("checkUserRegistration"));
 
   asyncTest("checkUserRegistration with XHR failure", function() {
     failureCheck(network.checkUserRegistration, "registered@testuser.com");

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -320,13 +320,14 @@
     );
   });
 
-  asyncTest("waitForUserValidation with `complete` response", function() {
+  asyncTest("waitForUserValidation with complete from backend, user not authed - `mustAuth` response", function() {
     storage.setReturnTo(testOrigin);
 
+    xhr.setContextInfo("auth_level", false);
     xhr.useResult("complete");
 
     lib.waitForUserValidation("registered@testuser.com", function(status) {
-      equal(status, "complete", "complete response expected");
+      equal(status, "mustAuth", "mustAuth response expected");
 
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
       start();
@@ -844,8 +845,22 @@
   });
 
 
- asyncTest("waitForEmailValidation `complete` response", function() {
+ asyncTest("waitForEmailValidation with `complete` backend response, user authenticated to assertion level - expect 'mustAuth'", function() {
     storage.setReturnTo(testOrigin);
+    xhr.setContextInfo("auth_level", "assertion");
+
+    xhr.useResult("complete");
+    lib.waitForEmailValidation("registered@testuser.com", function(status) {
+      ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
+      equal(status, "mustAuth", "mustAuth response expected");
+      start();
+    }, testHelpers.unexpectedXHRFailure);
+  });
+
+
+ asyncTest("waitForEmailValidation with `complete` backend response, user authenticated to password level - expect 'complete'", function() {
+    storage.setReturnTo(testOrigin);
+    xhr.setContextInfo("auth_level", "password");
 
     xhr.useResult("complete");
     lib.waitForEmailValidation("registered@testuser.com", function(status) {

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -329,6 +329,8 @@
     lib.waitForUserValidation("registered@testuser.com", function(status) {
       equal(status, "mustAuth", "mustAuth response expected");
 
+      testHelpers.testEmailMarkedVerified("registered@testuser.com");
+
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
       start();
     }, testHelpers.unexpectedXHRFailure);
@@ -341,6 +343,8 @@
 
     lib.waitForUserValidation("registered@testuser.com", function(status) {
       equal(status, "mustAuth", "mustAuth response expected");
+
+      testHelpers.testEmailMarkedVerified("registered@testuser.com");
 
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
       start();
@@ -852,6 +856,7 @@
     xhr.useResult("complete");
     lib.waitForEmailValidation("registered@testuser.com", function(status) {
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
+      testHelpers.testEmailMarkedVerified("registered@testuser.com");
       equal(status, "mustAuth", "mustAuth response expected");
       start();
     }, testHelpers.unexpectedXHRFailure);
@@ -865,6 +870,7 @@
     xhr.useResult("complete");
     lib.waitForEmailValidation("registered@testuser.com", function(status) {
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
+      testHelpers.testEmailMarkedVerified("registered@testuser.com");
       equal(status, "complete", "complete response expected");
       start();
     }, testHelpers.unexpectedXHRFailure);
@@ -876,6 +882,7 @@
 
     lib.waitForEmailValidation("registered@testuser.com", function(status) {
       ok(!storage.getReturnTo(), "staged on behalf of is cleared when validation completes");
+      testHelpers.testEmailMarkedVerified("registered@testuser.com");
       equal(status, "mustAuth", "mustAuth response expected");
       start();
     }, testHelpers.unexpectedXHRFailure);

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -568,6 +568,33 @@
     mediator.publish("window_unload");
   });
 
+  function testAuthenticateSpecifiedEmail(specified, expected) {
+    var options = {
+      email: TEST_EMAIL,
+      complete: function() {
+        testActionStarted("doAuthenticateWithRequiredEmail", {
+          cancelable: expected
+        });
+        start();
+      }
+    };
+
+    if (typeof specified !== "undefined") options.cancelable = specified;
+
+    mediator.publish("authenticate_specified_email", options);
+  }
+
+  asyncTest("authenticate_specified_email with false specified - call doAuthenticateWithRequiredEmail using specified cancelable", function() {
+    testAuthenticateSpecifiedEmail(false, false);
+  });
+
+  asyncTest("authenticate_specified_email with true specified - call doAuthenticateWithRequiredEmail using specified cancelable", function() {
+    testAuthenticateSpecifiedEmail(true, true);
+  });
+
+  asyncTest("authenticate_specified_email without cancelable - call doAuthenticateWithRequiredEmail, cancelable defaults to true", function() {
+    testAuthenticateSpecifiedEmail(undefined, true);
+  });
 
 
 }());

--- a/resources/static/test/cases/dialog/js/modules/check_registration.js
+++ b/resources/static/test/cases/dialog/js/modules/check_registration.js
@@ -44,8 +44,8 @@
 
   function testVerifiedUserEvent(event_name, message, password) {
     createController("waitForUserValidation", event_name, false, password);
-    register(event_name, function() {
-      ok(true, message);
+    register(event_name, function(msg, info) {
+      equal(info.mustAuth, false, "user does not need to verify");
       start();
     });
     controller.startCheck();
@@ -54,39 +54,22 @@
   function testMustAuthUserEvent(event_name, message) {
     createController("waitForUserValidation", event_name);
     register(event_name, function(msg, info) {
-      // we want the email, type and known all sent back to the caller so that
-      // this information does not need to be queried again.
-      ok(true, message);
-      equal(info.email, "registered@testuser.com", "correct email");
+      equal(info.mustAuth, true, "user needs to verify");
       start();
     });
     controller.startCheck();
   }
 
-  asyncTest("user validation with mustAuth result - callback with email, type and known set to true", function() {
+  asyncTest("user validation with mustAuth result - userVerified with mustAuth: true", function() {
     xhr.useResult("mustAuth");
-    testMustAuthUserEvent("authenticate_specified_email", "user must authenticate");
+    testMustAuthUserEvent("user_verified");
   });
 
-  asyncTest("user validation with pending->complete with auth_level = assertion, no authentication info given - authenticate_specified_email triggered", function() {
+  asyncTest("user validation with pending->complete with auth_level = assertion, no authentication info given - user_verified with mustAuth triggered", function() {
     user.init({ pollDuration: 100 });
     xhr.useResult("pending");
     xhr.setContextInfo("auth_level", "assertion");
-    testMustAuthUserEvent("authenticate_specified_email", "user must authenticate");
-
-    // use setTimeout to simulate a delay in the user opening the email.
-    setTimeout(function() {
-      xhr.useResult("complete");
-    }, 50);
-  });
-
-
-  asyncTest("user validation with pending->complete with auth_level = assertion, authentication info given - user_verified triggered", function() {
-    user.init({ pollDuration: 100 });
-    xhr.useResult("pending");
-    xhr.setContextInfo("auth_level", "password");
-
-    testVerifiedUserEvent("user_verified", "user verified after authenticating", "password");
+    testMustAuthUserEvent("user_verified");
 
     // use setTimeout to simulate a delay in the user opening the email.
     setTimeout(function() {
@@ -99,7 +82,7 @@
     xhr.useResult("pending");
     xhr.setContextInfo("auth_level", "password");
 
-    testVerifiedUserEvent("user_verified", "User verified");
+    testVerifiedUserEvent("user_verified");
 
     // use setTimeout to simulate a delay in the user opening the email.
     setTimeout(function() {

--- a/resources/static/test/cases/dialog/js/modules/check_registration.js
+++ b/resources/static/test/cases/dialog/js/modules/check_registration.js
@@ -8,15 +8,17 @@
 
   var controller,
       bid = BrowserID,
+      user = bid.User,
       xhr = bid.Mocks.xhr,
       network = bid.Network,
       testHelpers = bid.TestHelpers,
       register = testHelpers.register;
 
-  function createController(verifier, message, required) {
+  function createController(verifier, message, required, password) {
     controller = bid.Modules.CheckRegistration.create();
     controller.start({
       email: "registered@testuser.com",
+      password: password,
       verifier: verifier,
       verificationMessage: message,
       required: required,
@@ -40,8 +42,8 @@
     }
   });
 
-  function testVerifiedUserEvent(event_name, message) {
-    createController("waitForUserValidation", event_name);
+  function testVerifiedUserEvent(event_name, message, password) {
+    createController("waitForUserValidation", event_name, false, password);
     register(event_name, function() {
       ok(true, message);
       start();
@@ -49,28 +51,60 @@
     controller.startCheck();
   }
 
-  asyncTest("user validation with mustAuth result - callback with email, type and known set to true", function() {
-    xhr.useResult("mustAuth");
-    createController("waitForUserValidation");
-    register("authenticate", function(msg, info) {
+  function testMustAuthUserEvent(event_name, message) {
+    createController("waitForUserValidation", event_name);
+    register(event_name, function(msg, info) {
       // we want the email, type and known all sent back to the caller so that
       // this information does not need to be queried again.
+      ok(true, message);
       equal(info.email, "registered@testuser.com", "correct email");
-      ok(info.type, "type sent with info");
-      ok(info.known, "email is known");
       start();
     });
     controller.startCheck();
+  }
+
+  asyncTest("user validation with mustAuth result - callback with email, type and known set to true", function() {
+    xhr.useResult("mustAuth");
+    testMustAuthUserEvent("authenticate_specified_email", "user must authenticate");
   });
 
-  asyncTest("user validation with pending->complete result ~3 seconds", function() {
+  asyncTest("user validation with pending->complete with auth_level = assertion, no authentication info given - authenticate_specified_email triggered", function() {
+    user.init({ pollTimeout: 100 });
     xhr.useResult("pending");
+    xhr.setContextInfo("auth_level", "assertion");
+    testMustAuthUserEvent("authenticate_specified_email", "user must authenticate");
 
-    testVerifiedUserEvent("user_verified", "User verified");
     // use setTimeout to simulate a delay in the user opening the email.
     setTimeout(function() {
       xhr.useResult("complete");
-    }, 500);
+    }, 50);
+  });
+
+
+  asyncTest("user validation with pending->complete with auth_level = assertion, authentication info given - user_verified triggered", function() {
+    user.init({ pollTimeout: 100 });
+    xhr.useResult("pending");
+    xhr.setContextInfo("auth_level", "password");
+
+    testVerifiedUserEvent("user_verified", "user verified after authenticating", "password");
+
+    // use setTimeout to simulate a delay in the user opening the email.
+    setTimeout(function() {
+      xhr.useResult("complete");
+    }, 50);
+  });
+
+  asyncTest("user validation with pending->complete with auth_level = password - user_verified triggered", function() {
+    user.init({ pollTimeout: 100 });
+    xhr.useResult("pending");
+    xhr.setContextInfo("auth_level", "password");
+
+    testVerifiedUserEvent("user_verified", "User verified");
+
+    // use setTimeout to simulate a delay in the user opening the email.
+    setTimeout(function() {
+      xhr.useResult("complete");
+    }, 50);
   });
 
   asyncTest("user validation with XHR error - show error message", function() {

--- a/resources/static/test/cases/dialog/js/modules/check_registration.js
+++ b/resources/static/test/cases/dialog/js/modules/check_registration.js
@@ -69,7 +69,7 @@
   });
 
   asyncTest("user validation with pending->complete with auth_level = assertion, no authentication info given - authenticate_specified_email triggered", function() {
-    user.init({ pollTimeout: 100 });
+    user.init({ pollDuration: 100 });
     xhr.useResult("pending");
     xhr.setContextInfo("auth_level", "assertion");
     testMustAuthUserEvent("authenticate_specified_email", "user must authenticate");
@@ -82,7 +82,7 @@
 
 
   asyncTest("user validation with pending->complete with auth_level = assertion, authentication info given - user_verified triggered", function() {
-    user.init({ pollTimeout: 100 });
+    user.init({ pollDuration: 100 });
     xhr.useResult("pending");
     xhr.setContextInfo("auth_level", "password");
 
@@ -95,7 +95,7 @@
   });
 
   asyncTest("user validation with pending->complete with auth_level = password - user_verified triggered", function() {
-    user.init({ pollTimeout: 100 });
+    user.init({ pollDuration: 100 });
     xhr.useResult("pending");
     xhr.setContextInfo("auth_level", "password");
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -1,5 +1,5 @@
-/*jshint browsers: true laxbreak: true, expr: true */
-/*global BrowserID: true, ok: true, equal: true, start: true */
+/*jshint browser: true laxbreak: true, expr: true */
+/*global BrowserID: true, ok: true, equal: true, start: true, deepEqual: true, notEqual: true */
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -287,6 +287,12 @@ BrowserID.TestHelpers = (function() {
 
     testRPTosPPNotShown: function(msg) {
       TestHelpers.testNotHasClass("body", "rptospp", msg || "RP TOS/PP not shown");
+    },
+
+    testEmailMarkedVerified: function(email, msg) {
+      var emailInfo = storage.getEmail(email);
+      equal(emailInfo && emailInfo.verified, true,
+        "verified bit set for " + email);
     }
   };
 

--- a/tests/forgotten-pass-test.js
+++ b/tests/forgotten-pass-test.js
@@ -232,6 +232,7 @@ suite.addBatch({
       assert.equal(r.code, 200);
       var body = JSON.parse(r.body);
       assert.strictEqual(body.success, true);
+      assert.strictEqual(body.must_auth, false);
     }
   }
 });

--- a/tests/lib/wsapi.js
+++ b/tests/lib/wsapi.js
@@ -43,3 +43,12 @@ exports.getCSRF = function() {
   }
   return null;
 };
+
+// allows for multiple clients
+exports.setContext = function (cxt) {
+  context = cxt;
+};
+
+exports.getContext = function () {
+  return context;
+};


### PR DESCRIPTION
This includes @zaach's PR for #2104 and mine for #2088

There could stand to be some polish.

This flow needs tested:

Create an account with a primary. 
Add a secondary, verify on alt browser.  
Log out.  
Sign in with primary.  
Add new secondary email.  Verify in alt browser.
At this point, the user should have to enter their password

When the user is forced to enter their password, there is a cancel button in the screen that should probably not be there.
