### PR TITLE
Make x_frame_options configurable.  Default to DENY.

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -87,7 +87,7 @@ if (config.get('scheme') == 'https') {
 // #4 - prevent framing of everything.  content underneath that needs to be
 // framed must explicitly remove the x-frame-options
 app.use(function(req, resp, next) {
-  resp.setHeader('x-frame-options', 'DENY');
+  resp.setHeader('x-frame-options', config.get('x_frame_options'));
   next();
 });
 

--- a/bin/dbwriter
+++ b/bin/dbwriter
@@ -69,7 +69,7 @@ if (config.get('scheme') == 'https') {
 // prevent framing of everything.  content underneath that needs to be
 // framed must explicitly remove the x-frame-options
 app.use(function(req, resp, next) {
-  resp.setHeader('x-frame-options', 'DENY');
+  resp.setHeader('x-frame-options', config.get('x_frame_options'));
   next();
 });
 

--- a/bin/static
+++ b/bin/static
@@ -69,7 +69,7 @@ if (statsd_config && statsd_config.enabled) {
 // #4 - prevent framing of everything.  content underneath that needs to be
 // framed must explicitly remove the x-frame-options
 app.use(function(req, resp, next) {
-  resp.setHeader('x-frame-options', 'DENY');
+  resp.setHeader('x-frame-options', config.get('x_frame_options'));
   next();
 });
 

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -232,6 +232,10 @@ var conf = module.exports = convict({
     doc: "A mapping of domain names to urls, which maps popular email services to shimmed IDP deployments.",
     format: 'object { } *?',
     env: 'PROXY_IDPS' // JSON text, i.e. {"yahoo.com":"yahoo.login.persona.org"}
+  },
+  x_frame_options: {
+    doc: "By default, do not allow BrowserID to be embedded in an IFRAME",
+    format: 'string = "DENY"'
   }
 });
 


### PR DESCRIPTION
- Useful for when running unit tests on testmob.org.  Unit tests and code need to be embedded in an iframe.

issue #2138
