### PR TITLE
Usability updates to the signin and signup pages.

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -462,7 +462,7 @@ button.delete:active {
   margin-bottom: 10px;
 }
 
-.siteinfo, #congrats, .password_entry, #verify_password, .enter_password .hint, #unknown_secondary, .verify_primary .forminputs {
+.siteinfo, #congrats, .password_entry, #verify_password, .enter_password .hint, .verify_primary .forminputs {
   display: none;
 }
 
@@ -478,8 +478,7 @@ button.delete:active {
   font-size: 13px;
 }
 
-.enter_password .password_entry, .enter_verify_password #verify_password, .known_secondary .password_entry,
-.unknown_secondary #unknown_secondary, .verify_primary #verify_primary {
+.enter_password .password_entry, .enter_verify_password #verify_password, .known_secondary .password_entry, .verify_primary #verify_primary {
   display: block;
 }
 

--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -149,6 +149,10 @@ BrowserID.signIn = (function() {
       self.bind("#email", "change", onEmailChange);
       self.bind("#email", "keyup", onEmailChange);
 
+      // a redirect to the signup page using the link needs to clear the stored
+      // email address or else the user may be redirected here.
+      self.bind(".redirect", "click", pageHelpers.clearStoredEmail);
+
       sc.start.call(self, options);
 
       // If there is an email already set up in pageHelpers.setupEmail, see if

--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -16,15 +16,12 @@ BrowserID.signIn = (function() {
       tooltip = bid.Tooltip,
       doc = document,
       winchan = window.WinChan,
+      complete = helpers.complete,
       verifyEmail,
       verifyURL,
       addressInfo,
       sc,
       lastEmail;
-
-  function complete(oncomplete, status) {
-    oncomplete && oncomplete(status);
-  }
 
   function provisionPrimaryUser(email, info, callback) {
     // primary user who is authenticated with the primary.
@@ -44,6 +41,7 @@ BrowserID.signIn = (function() {
   }
 
   function emailSubmit(oncomplete) {
+    /*jshint validthis: true*/
     var self=this,
         email = helpers.getAndValidateEmail("#email");
 
@@ -60,8 +58,7 @@ BrowserID.signIn = (function() {
             self.submit = passwordSubmit;
           }
           else {
-            dom.setInner("#unknown_email", email);
-            dom.addClass("body", "unknown_secondary");
+            doc.location = "/signup";
           }
 
           complete(oncomplete);
@@ -126,6 +123,8 @@ BrowserID.signIn = (function() {
   }
 
   function onEmailChange(event) {
+    /*jshint validthis: true*/
+
     // this is basically a state reset.
     var email = dom.getInner("#email");
     if(email !== lastEmail) {
@@ -151,6 +150,16 @@ BrowserID.signIn = (function() {
       self.bind("#email", "keyup", onEmailChange);
 
       sc.start.call(self, options);
+
+      // If there is an email already set up in pageHelpers.setupEmail, see if
+      // the email address is a primary, secondary, known or unknown.  Redirect
+      // if needed.
+      if (dom.getInner("#email")) {
+        self.submit(options.ready);
+      }
+      else {
+        complete(options.ready);
+      }
     },
     submit: emailSubmit
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -330,6 +330,15 @@ BrowserID.TestHelpers = (function() {
       var emailInfo = storage.getEmail(email);
       equal(emailInfo && emailInfo.verified, true,
         "verified bit set for " + email);
+    },
+
+    testDocumentRedirected: function(doc, expectedHref, msg) {
+      equal(doc.location, expectedHref, msg || "document redirected to " + expectedHref);
+    },
+
+    testDocumentNotRedirected: function(doc, msg) {
+      equal(doc.location.href, document.location.href, msg || "document not redirected");
+
     }
   };
 

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -8,14 +8,6 @@
         <form id="signUpForm" class="cf authform" novalidate>
             <h1><%- gettext('Sign In') %></h1>
 
-            <ul class="notifications">
-                <li class="notification" id="unknown_secondary">
-                  <%- format(gettext('<strong %(emailId)>Email</strong> is not registered. Would you like to <a %(signUpLink)>sign up</a> instead?'),
-                             { emailId: 'id="unknown_email"', signUpLink: 'class="action" href="/signup"' }) %>
-                </li>
-
-            </ul>
-
             <ul class="inputs">
                 <li>
                     <label for="email"><%- gettext('Email Address') %></label>

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -43,7 +43,7 @@
             <div class="submit cf forminputs">
                 <button tabindex="5"><%- gettext('Sign In') %></button>
                 <div class="remember cf">
-                    <a class="action" href="/signup"><%- gettext('New to Persona? Sign up today.') %></a>
+                    <a class="action redirect" href="/signup"><%- gettext('New to Persona? Sign up today.') %></a>
                 </div>
             </div>
 

--- a/resources/views/signup.ejs
+++ b/resources/views/signup.ejs
@@ -77,7 +77,7 @@
             <div class="submit cf forminputs">
                 <p class="cf">
                   <button><%- gettext('Verify Email') %></button>
-                  <a class="action remember" href="/signin" tabindex="2"><%- gettext('Existing account? Sign in.') %></a>
+                  <a class="action remember redirect" href="/signin" tabindex="2"><%- gettext('Existing account? Sign in.') %></a>
                 </p>
 
                 <p class="tospp">


### PR DESCRIPTION
In the signin page:
- If the user arrives with or enters an unknown secondary email, redirect them to the /signup page.
- If the user arrives with or enters a known secondary email in storage, show the password field.

In the signup page:
- If the user arrives with or enters an unknown secondary email, show the password fields.
- If the user arrives with or enters a known secondary email, redirect them to the /signup page.

The page load could use some work, but I am going for an incremental improvement here.

issue #2120
