### PR TITLE
Added CEF logging at key points alongside our app logger

### DIFF
--- a/lib/cef_logger.js
+++ b/lib/cef_logger.js
@@ -1,0 +1,169 @@
+/**
+ * A thin abstraction layer over the cef library
+ *
+ * This is deliberately not a part of the logging.js library because
+ * we want CEF logging calls to stand out separately in the code.
+ *
+ * See the cef module's README.md file for more information.
+ */
+
+const cef = require('cef');
+
+const STACK_FRAME_RE = new RegExp(/at ((\S+)\s)?\(?([^:]+):(\d+):(\d+)/);
+const THIS_FILE = __filename.split('/')[__filename.split('/').length - 1];
+
+var Logger = function(config) {
+  this.cef = cef.getInstance(config);
+
+  // used by _getCallerSignature to provide a unique signature for
+  // callers by module, function, and line number.
+  this._moduleIndex = {};
+  this._functionIndex = {};
+  return this;
+};
+
+/**
+ * The CEF logger supports eight logging severities.  In practice, we
+ * use only four:
+ *
+ *   emergency: Completely out of whack. Someone needs to look at
+ *              this. Harm to the application, user account, or system
+ *              security could have taken place.
+ *
+ *   alert:     Suspicious activity or application has non-validated
+ *              user input. Impact is not known.
+ *
+ *   warn:      Normal security application stuff, login failures,
+ *              password changes.
+ *
+ *   info:      Normal app activity. Logins and various kinds of
+ *              transactions.
+ */
+
+Logger.prototype = {
+
+  /**
+   * Return the function name, module, line, and column of the code
+   * that called into this logger.  Utility function for _emit().
+   */
+  _getCaller: function() {
+    var err = new Error();
+    Error.captureStackTrace(err);
+
+    // Throw away the first line of the trace
+    var frames = err.stack.split('\n').slice(1);
+
+    // Find the first line in the stack that doesn't name this module.
+    var callerInfo = null;
+    for (var i = 0; i < frames.length; i++) {
+      if (frames[i].indexOf(THIS_FILE) === -1) {
+        callerInfo = STACK_FRAME_RE.exec(frames[i]);
+        break;
+      }
+    }
+
+    if (callerInfo) {
+      return {
+        function: callerInfo[2] || null,
+        module: callerInfo[3] || null,
+        line: callerInfo[4] || null,
+        column: callerInfo[5] || null
+      };
+    }
+    return null;
+  },
+
+  /**
+   * _emit() - an private method to map the logging methods below
+   * to the cef logger methods.
+   */
+  _emit: function(severity, signature, name, extensions) {
+    extensions = extensions || {};
+    var options = {
+      signature: signature,
+      name: name,
+      extensions: extensions || {}
+    };
+    this.cef[severity](options);
+  },
+
+  /**
+   * The following logging functions take these arguments:
+   *
+   * @param signature
+   *        (integer)    A short string describing the part of the
+   *                     application that is being logged.  Used by
+   *                     ArcSight for correlation.  Yes, this is
+   *                     annoying and awkward to have to enter.
+   *
+   * @param name
+   *        (string)     A human-readable description.  This is your log
+   *                     message.
+   *
+   * @param extensions
+   *        (object)     A dictionary of special key/value pairs designated
+   *                     by the CEF standard or by ArcSight.  You're
+   *                     most likely to care about the ones provided by
+   *                     the cef helper function,
+   *                     extensionsFromHTTPRequest(req).
+   */
+
+  emergency: function(signature, name, extensions) {
+    this._emit('emergency', signature, name, extensions);
+  },
+
+  alert: function(signature, name, extensions) {
+    this._emit('alert', signature, name, extensions);
+  },
+
+  warn: function(signature, name, extensions) {
+    this._emit('warn', signature, name, extensions);
+  },
+
+  info: function(signature, name, extensions) {
+    this._emit('info', signature, name, extensions);
+  }
+};
+
+/**
+ * getInstance()     get a singleton instance of the logger with the
+ *                   config specified in our configuration.js file.
+ */
+var instances = {};
+var getInstance = module.exports.getInstance = function getInstance(config) {
+  // maybe override app config
+  config = config || require('./configuration').get('cef');
+
+  // make an instance key for this config
+  var configKey = [];
+  Object.keys(config).sort().forEach(function(key) {
+    configKey.push(key + '=' + config[key]);
+  });
+  // stringify the array
+  configKey = configKey.join(',');
+
+  if (!instances[configKey]) {
+    instances[configKey] = new Logger(config);
+  }
+
+  return instances[configKey];
+};
+
+/**
+ * combineHTTPEnvWithParams - utility to merge output of
+ * cef.extensionsFromHTTPRequest with additional params
+ *
+ * @param request
+ *        (object)    The http request object
+ *
+ * @param extensions
+ *        (object)    Optional extra cef extension dictionary
+ */
+module.exports.mergeWithHttpEnv = function mergeWithHttpEnv(req, params) {
+  params = params || {};
+  var env = cef.extensionsFromHTTPRequest(req);
+  Object.keys(params).forEach(function(key) {
+    env[key] = params[key];
+  });
+  return env;
+};

--- a/lib/cef_logger.js
+++ b/lib/cef_logger.js
@@ -7,10 +7,41 @@
  * See the cef module's README.md file for more information.
  */
 
-const cef = require('cef');
+const path = require('path'),
+      cef = require('cef'),
+      http = require('http');
 
 const STACK_FRAME_RE = new RegExp(/at ((\S+)\s)?\(?([^:]+):(\d+):(\d+)/);
-const THIS_FILE = __filename.split('/')[__filename.split('/').length - 1];
+const THIS_FILE = path.basename(__filename);
+
+function copyIntoObject(to, from) {
+  Object.keys(from).forEach(function(key) {
+    to[key] = from[key];
+  });
+}
+
+/**
+ * mergeObjects - utility function for logging methods below.
+ * It combines a list of objects into a single CEF extension
+ * dictionary.
+ *
+ * Presently, objects can be either an http request or a
+ * plain ol' dictionary.
+ */
+function mergeObjects(objList) {
+  var obj = {};
+  for (var i = 0; i < objList.length; i++) {
+    // http request objects: extract relevant objects
+    if (objList[i] instanceof http.IncomingMessage) {
+      copyIntoObject(obj, cef.extensionsFromHTTPRequest(objList[i]));
+    }
+    // Assume everything else is just valid cef extensions
+    else {
+      copyIntoObject(obj, objList[i]);
+    }
+  }
+  return obj;
+}
 
 var Logger = function(config) {
   this.cef = cef.getInstance(config);
@@ -84,7 +115,7 @@ Logger.prototype = {
       name: name,
       extensions: extensions || {}
     };
-    this.cef[severity](options);
+    return this.cef[severity](options);
   },
 
   /**
@@ -100,28 +131,34 @@ Logger.prototype = {
    *        (string)     A human-readable description.  This is your log
    *                     message.
    *
-   * @param extensions
-   *        (object)     A dictionary of special key/value pairs designated
-   *                     by the CEF standard or by ArcSight.  You're
-   *                     most likely to care about the ones provided by
-   *                     the cef helper function,
-   *                     extensionsFromHTTPRequest(req).
+   * @param etc ...
+   *        (objects)    A set of positional arguments containing key/value
+   *                     pairs to be logged as extensions.  You can pass
+   *                     dictionaries of valid CEF keys or http request
+   *                     objects.  The latter will be converted into valid
+   *                     CEF keys.  These arguments will all be mashed into
+   *                     a single dictionary of CEF extensions.  Arguments
+   *                     will be processed in the order they are given.
    */
 
-  emergency: function(signature, name, extensions) {
-    this._emit('emergency', signature, name, extensions);
+  emergency: function(signature, name, etc) {
+    var extensions = mergeObjects(Array.prototype.slice.call(arguments, 2));
+    return this._emit('emergency', signature, name, extensions);
   },
 
-  alert: function(signature, name, extensions) {
-    this._emit('alert', signature, name, extensions);
+  alert: function(signature, name, etc) {
+    var extensions = mergeObjects(Array.prototype.slice.call(arguments, 2));
+    return this._emit('alert', signature, name, extensions);
   },
 
-  warn: function(signature, name, extensions) {
-    this._emit('warn', signature, name, extensions);
+  warn: function(signature, name, etc) {
+    var extensions = mergeObjects(Array.prototype.slice.call(arguments, 2));
+    return this._emit('warn', signature, name, extensions);
   },
 
-  info: function(signature, name, extensions) {
-    this._emit('info', signature, name, extensions);
+  info: function(signature, name, etc) {
+    var extensions = mergeObjects(Array.prototype.slice.call(arguments, 2));
+    return this._emit('info', signature, name, extensions);
   }
 };
 
@@ -147,23 +184,4 @@ var getInstance = module.exports.getInstance = function getInstance(config) {
   }
 
   return instances[configKey];
-};
-
-/**
- * combineHTTPEnvWithParams - utility to merge output of
- * cef.extensionsFromHTTPRequest with additional params
- *
- * @param request
- *        (object)    The http request object
- *
- * @param extensions
- *        (object)    Optional extra cef extension dictionary
- */
-module.exports.mergeWithHttpEnv = function mergeWithHttpEnv(req, params) {
-  params = params || {};
-  var env = cef.extensionsFromHTTPRequest(req);
-  Object.keys(params).forEach(function(key) {
-    env[key] = params[key];
-  });
-  return env;
 };

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -133,6 +133,22 @@ var conf = module.exports = convict({
     host: "string?",
     port: "integer{1,65535}?"
   },
+  cef: {
+    vendor: 'string = "Mozilla"',
+    product: 'string = "browserid"',
+    version: 'string = "0.1"',
+    syslog_tag: 'string = "browserid"',
+    syslog_host: {
+      doc: 'Host where syslog service is listening',
+      format: 'string = "127.0.0.1"',
+      env: 'CEF_SYSLOG_HOST'
+    },
+    syslog_port: {
+      doc: 'Port on which syslog service will receive UDP messages',
+      format: 'integer = 514',
+      env: 'CEF_SYSLOG_PORT'
+    },
+  },
   kpi_backend_sample_rate: {
     doc: "Float between 0 and 1 inclusive, for the % of user flows that should send back KPI JSON blobs. Example: 0.5 would be 50% traffic.",
     format: 'number = 0.0',

--- a/lib/wsapi.js
+++ b/lib/wsapi.js
@@ -108,6 +108,8 @@ function langContext(req) {
 }
 
 function databaseDown(res, err) {
+  // For CEF, this is logged by the caller so params from the http
+  // request can be recorded.
   logger.warn('database is down, cannot process request: ' + err);
   httputils.serviceUnavailable(res, "database unavailable");
 }

--- a/lib/wsapi/account_cancel.js
+++ b/lib/wsapi/account_cancel.js
@@ -6,8 +6,7 @@ const
 db = require('../db.js'),
 wsapi = require('../wsapi'),
 logger = require('../logging.js').logger,
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -18,11 +17,11 @@ exports.process = function(req, res) {
   db.cancelAccount(req.session.userid, function(error) {
     if (error) {
       cef_logger.alert("ACCOUNT_CANCEL", "Error canceling account",
-                      mergeEnv(req, {duser: req.session.userid, msg: error}));
+                      req, {duser: req.session.userid, msg: error});
       wsapi.databaseDown(res, error);
     } else {
       cef_logger.warn("ACCOUNT_CANCEL", "Canceled user account",
-                      mergeEnv(req, {duser: req.session.userid}));
+                      req, {duser: req.session.userid});
       res.json({ success: true });
     }});
 };

--- a/lib/wsapi/account_cancel.js
+++ b/lib/wsapi/account_cancel.js
@@ -5,7 +5,9 @@
 const
 db = require('../db.js'),
 wsapi = require('../wsapi'),
-logger = require('../logging.js').logger;
+logger = require('../logging.js').logger,
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -15,8 +17,12 @@ exports.i18n = false;
 exports.process = function(req, res) {
   db.cancelAccount(req.session.userid, function(error) {
     if (error) {
+      cef_logger.alert("ACCOUNT_CANCEL", "Error canceling account",
+                      mergeEnv(req, {duser: req.session.userid, msg: error}));
       wsapi.databaseDown(res, error);
     } else {
+      cef_logger.warn("ACCOUNT_CANCEL", "Canceled user account",
+                      mergeEnv(req, {duser: req.session.userid}));
       res.json({ success: true });
     }});
 };

--- a/lib/wsapi/add_email_with_assertion.js
+++ b/lib/wsapi/add_email_with_assertion.js
@@ -10,7 +10,9 @@ logger = require('../logging.js').logger,
 querystring = require('querystring'),
 primary = require('../primary.js'),
 http = require('http'),
-https = require('https');
+https = require('https'),
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -27,6 +29,8 @@ exports.process = function(req, res) {
   // first let's verify that the assertion is valid
   primary.verifyAssertion(req.params.assertion, function(err, email) {
     if (err) {
+      cef_logger.warn("ASSERTION_ERROR", "Cannot verify assertion",
+                     mergeEnv(req, {duser: email, msg: err}));
       return res.json({
         success: false,
         reason: err.toString()
@@ -38,6 +42,8 @@ exports.process = function(req, res) {
     // that email to their account, removing it from others accounts if required.
     db.addPrimaryEmailToAccount(req.session.userid, email, function(err) {
       if (err) {
+        cef_logger.alert("ADD_EMAIL", "Failed to add primary email to account",
+                        mergeEnv(req, {duser: email, msg: err}));
         logger.warn('cannot add primary email "' + email + '" to acct with uid "'
                     + req.session.userid + '": ' + err);
         return wsapi.databaseDown(res, err);

--- a/lib/wsapi/add_email_with_assertion.js
+++ b/lib/wsapi/add_email_with_assertion.js
@@ -11,8 +11,7 @@ querystring = require('querystring'),
 primary = require('../primary.js'),
 http = require('http'),
 https = require('https'),
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -30,7 +29,7 @@ exports.process = function(req, res) {
   primary.verifyAssertion(req.params.assertion, function(err, email) {
     if (err) {
       cef_logger.warn("ASSERTION_ERROR", "Cannot verify assertion",
-                     mergeEnv(req, {duser: email, msg: err}));
+                     req, {duser: email, msg: err});
       return res.json({
         success: false,
         reason: err.toString()
@@ -43,7 +42,7 @@ exports.process = function(req, res) {
     db.addPrimaryEmailToAccount(req.session.userid, email, function(err) {
       if (err) {
         cef_logger.alert("ADD_EMAIL", "Failed to add primary email to account",
-                        mergeEnv(req, {duser: email, msg: err}));
+                        req, {duser: email, msg: err});
         logger.warn('cannot add primary email "' + email + '" to acct with uid "'
                     + req.session.userid + '": ' + err);
         return wsapi.databaseDown(res, err);

--- a/lib/wsapi/authenticate_user.js
+++ b/lib/wsapi/authenticate_user.js
@@ -13,8 +13,7 @@ https = require('https'),
 querystring = require('querystring'),
 statsd = require('../statsd'),
 config = require('../configuration'),
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 exports.method = 'post';
 exports.writes_db = false;
@@ -30,7 +29,7 @@ exports.process = function(req, res) {
   function fail(reason) {
     var r = { success: false };
     if (reason) r.reason = reason;
-    cef_logger.warn("AUTH_FAILURE", "User authentication failed", mergeEnv(req, {msg:reason}));
+    cef_logger.warn("AUTH_FAILURE", "User authentication failed", req, {msg:reason});
     logger.debug('authentication fails for user: ' + req.params.email + (reason ? (' - ' + reason) : ""));
     return res.json(r);
   }
@@ -56,17 +55,16 @@ exports.process = function(req, res) {
 
         if (err) {
           if (err.indexOf('exceeded') != -1) {
-            cef_logger.alert("LOAD_HIGH", "Load exceeded on auth request", mergeEnv(req));
+            cef_logger.alert("LOAD_HIGH", "Load exceeded on auth request", req);
             logger.warn("max load hit, failing on auth request with 503: " + err);
             res.status(503);
             return fail("server is too busy");
           }
-          cef_logger.alert("BCRYPT_ERROR", "Internal error on bcrypt.compare",
-                           mergeEnv(req, {msg: err}));
+          cef_logger.alert("BCRYPT_ERROR", "Internal error on bcrypt.compare", req, {msg: err});
           logger.error("error comparing passwords with bcrypt: " + err);
           return fail("internal password check error");
         } else if (!success) {
-          cef_logger.warn("AUTH_FAILURE", "Password mismatch", mergeEnv(req));
+          cef_logger.warn("AUTH_FAILURE", "Password mismatch", req);
           return fail("password mismatch for user: " + req.params.email);
         } else {
           if (!req.session) req.session = {};
@@ -80,7 +78,7 @@ exports.process = function(req, res) {
           // if the work factor has changed, update the hash here.  issue #204
           // NOTE: this runs asynchronously and will not delay the response
           if (config.get('bcrypt_work_factor') != bcrypt.get_rounds(hash)) {
-            cef_logger.warn("AUTH_UPDATE", "Updated password for user", mergeEnv(req, {suser:uid}));
+            cef_logger.warn("AUTH_UPDATE", "Updated password for user", req, {suser:uid});
             logger.info("updating bcrypted password for user " + uid);
 
             // this request must be forwarded to dbwriter, and we'll use the
@@ -108,7 +106,7 @@ exports.process = function(req, res) {
               pres.on('end', function() {
                 if (pres.statusCode !== 200) {
                   cef_logger.alert("DB_FAILURE", "Cannot update password rounds; dbwriter error",
-                                  mergeEnv(req, {suser: uid, msg: pres.statusCode}));
+                                  req, {suser: uid, msg: pres.statusCode});
                   logger.error("failed to update bcrypt rounds of password for " + uid +
                                " dbwriter returns " + pres.statusCode);
                 } else {
@@ -120,7 +118,7 @@ exports.process = function(req, res) {
               });
             }).on('error', function(e) {
               cef_logger.alert("AUTH_FAILURE", "Error updating password rounds",
-                              mergeEnv(req, {suser: uid, msg: e}));
+                              req, {suser: uid, msg: e});
               logger.error("failed to update bcrypt rounds of password for " + uid + ": " + e);
             });
 

--- a/lib/wsapi/authenticate_user.js
+++ b/lib/wsapi/authenticate_user.js
@@ -12,7 +12,9 @@ http = require('http'),
 https = require('https'),
 querystring = require('querystring'),
 statsd = require('../statsd'),
-config = require('../configuration');
+config = require('../configuration'),
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 exports.method = 'post';
 exports.writes_db = false;
@@ -28,6 +30,7 @@ exports.process = function(req, res) {
   function fail(reason) {
     var r = { success: false };
     if (reason) r.reason = reason;
+    cef_logger.warn("AUTH_FAILURE", "User authentication failed", mergeEnv(req, {msg:reason}));
     logger.debug('authentication fails for user: ' + req.params.email + (reason ? (' - ' + reason) : ""));
     return res.json(r);
   }
@@ -53,13 +56,17 @@ exports.process = function(req, res) {
 
         if (err) {
           if (err.indexOf('exceeded') != -1) {
+            cef_logger.alert("LOAD_HIGH", "Load exceeded on auth request", mergeEnv(req));
             logger.warn("max load hit, failing on auth request with 503: " + err);
             res.status(503);
             return fail("server is too busy");
           }
+          cef_logger.alert("BCRYPT_ERROR", "Internal error on bcrypt.compare",
+                           mergeEnv(req, {msg: err}));
           logger.error("error comparing passwords with bcrypt: " + err);
           return fail("internal password check error");
         } else if (!success) {
+          cef_logger.warn("AUTH_FAILURE", "Password mismatch", mergeEnv(req));
           return fail("password mismatch for user: " + req.params.email);
         } else {
           if (!req.session) req.session = {};
@@ -73,6 +80,7 @@ exports.process = function(req, res) {
           // if the work factor has changed, update the hash here.  issue #204
           // NOTE: this runs asynchronously and will not delay the response
           if (config.get('bcrypt_work_factor') != bcrypt.get_rounds(hash)) {
+            cef_logger.warn("AUTH_UPDATE", "Updated password for user", mergeEnv(req, {suser:uid}));
             logger.info("updating bcrypted password for user " + uid);
 
             // this request must be forwarded to dbwriter, and we'll use the
@@ -99,6 +107,8 @@ exports.process = function(req, res) {
             }, function(pres) {
               pres.on('end', function() {
                 if (pres.statusCode !== 200) {
+                  cef_logger.alert("DB_FAILURE", "Cannot update password rounds; dbwriter error",
+                                  mergeEnv(req, {suser: uid, msg: pres.statusCode}));
                   logger.error("failed to update bcrypt rounds of password for " + uid +
                                " dbwriter returns " + pres.statusCode);
                 } else {
@@ -109,6 +119,8 @@ exports.process = function(req, res) {
                 }
               });
             }).on('error', function(e) {
+              cef_logger.alert("AUTH_FAILURE", "Error updating password rounds",
+                              mergeEnv(req, {suser: uid, msg: e}));
               logger.error("failed to update bcrypt rounds of password for " + uid + ": " + e);
             });
 

--- a/lib/wsapi/have_email.js
+++ b/lib/wsapi/have_email.js
@@ -5,7 +5,9 @@
 const
 db = require('../db.js'),
 wsapi = require('../wsapi.js'),
-url = require('url');
+url = require('url'),
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 // return if an email is known to browserid
 
@@ -19,7 +21,11 @@ exports.args = {
 
 exports.process = function(req, res) {
   db.emailKnown(req.params.email, function(err, known) {
-    if (err) return wsapi.databaseDown(res, err);
+    if (err) {
+      return wsapi.databaseDown(res, err);
+      cef_logger.alert("DB_FAILURE", "emailKnown failed",
+                       mergeEnv(req, {duser: req.params.email, msg: err}));
+    }
     res.json({ email_known: known });
   });
 };

--- a/lib/wsapi/have_email.js
+++ b/lib/wsapi/have_email.js
@@ -6,8 +6,7 @@ const
 db = require('../db.js'),
 wsapi = require('../wsapi.js'),
 url = require('url'),
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 // return if an email is known to browserid
 
@@ -24,7 +23,7 @@ exports.process = function(req, res) {
     if (err) {
       return wsapi.databaseDown(res, err);
       cef_logger.alert("DB_FAILURE", "emailKnown failed",
-                       mergeEnv(req, {duser: req.params.email, msg: err}));
+                       req, {duser: req.params.email, msg: err});
     }
     res.json({ email_known: known });
   });

--- a/lib/wsapi/logout.js
+++ b/lib/wsapi/logout.js
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const
-wsapi = require('../wsapi.js');
+wsapi = require('../wsapi.js'),
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 exports.method = 'post';
 exports.writes_db = false;
@@ -12,5 +14,6 @@ exports.i18n = false;
 
 exports.process = function(req, res) {
   wsapi.clearAuthenticatedUser(req.session);
+  cef_logger.info("USER_LOGOUT", "User logout", mergeEnv(req));
   res.json({ success: true });
 };

--- a/lib/wsapi/logout.js
+++ b/lib/wsapi/logout.js
@@ -4,8 +4,7 @@
 
 const
 wsapi = require('../wsapi.js'),
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 exports.method = 'post';
 exports.writes_db = false;
@@ -14,6 +13,6 @@ exports.i18n = false;
 
 exports.process = function(req, res) {
   wsapi.clearAuthenticatedUser(req.session);
-  cef_logger.info("USER_LOGOUT", "User logout", mergeEnv(req));
+  cef_logger.info("USER_LOGOUT", "User logout", req);
   res.json({ success: true });
 };

--- a/lib/wsapi/remove_email.js
+++ b/lib/wsapi/remove_email.js
@@ -6,7 +6,9 @@ const
 db = require('../db.js'),
 wsapi = require('../wsapi'),
 httputils = require('../httputils'),
-logger = require('../logging.js').logger;
+logger = require('../logging.js').logger,
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -21,6 +23,8 @@ exports.process = function(req, res) {
 
   db.removeEmail(req.session.userid, email, function(error) {
     if (error) {
+      cef_logger.alert("REMOVE_EMAIL", "Error removing email",
+                      mergeEnv(req, {duser: req.session.userid, msg: error}));
       logger.warn("error removing email " + email);
       if (error === 'database connection unavailable') {
         wsapi.databaseDown(res, error);
@@ -28,6 +32,8 @@ exports.process = function(req, res) {
         httputils.badRequest(res, error.toString());
       }
     } else {
+      cef_logger.info("REMOVE_EMAIL", "Removed user email",
+                     mergeEnv(req, {duser: req.session.userid}));
       res.json({ success: true });
     }});
 };

--- a/lib/wsapi/remove_email.js
+++ b/lib/wsapi/remove_email.js
@@ -7,8 +7,7 @@ db = require('../db.js'),
 wsapi = require('../wsapi'),
 httputils = require('../httputils'),
 logger = require('../logging.js').logger,
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 exports.method = 'post';
 exports.writes_db = true;
@@ -24,7 +23,7 @@ exports.process = function(req, res) {
   db.removeEmail(req.session.userid, email, function(error) {
     if (error) {
       cef_logger.alert("REMOVE_EMAIL", "Error removing email",
-                      mergeEnv(req, {duser: req.session.userid, msg: error}));
+                      req, {duser: req.session.userid, msg: error});
       logger.warn("error removing email " + email);
       if (error === 'database connection unavailable') {
         wsapi.databaseDown(res, error);
@@ -33,7 +32,7 @@ exports.process = function(req, res) {
       }
     } else {
       cef_logger.info("REMOVE_EMAIL", "Removed user email",
-                     mergeEnv(req, {duser: req.session.userid}));
+                     req, {duser: req.session.userid});
       res.json({ success: true });
     }});
 };

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -9,8 +9,7 @@ httputils = require('../httputils'),
 logger = require('../logging.js').logger,
 email = require('../email.js'),
 config = require('../configuration'),
-cef_logger = require('../cef_logger').getInstance(),
-mergeEnv = require('../cef_logger').mergeWithHttpEnv;
+cef_logger = require('../cef_logger').getInstance();
 
 /* First half of account creation.  Stages a user account for creation.
  * this involves creating a secret url that must be delivered to the
@@ -36,7 +35,7 @@ exports.process = function(req, res) {
 
     if (last && (new Date() - last) < config.get('min_time_between_emails_ms')) {
       cef_logger.alert("EMAIL_LOAD", "Throttling email staging request",
-                      mergeEnv(req, {duser: req.params.email}));
+                      req, {duser: req.params.email});
       logger.warn('throttling request to stage email address ' + req.params.email + ', only ' +
                   ((new Date() - last) / 1000.0) + "s elapsed");
       return httputils.throttled(res, "Too many emails sent to that address, try again later.");
@@ -49,12 +48,11 @@ exports.process = function(req, res) {
     wsapi.bcryptPassword(req.params.pass, function (err, hash) {
       if (err) {
         if (err.indexOf('exceeded') != -1) {
-          cef_logger.alert("LOAD_HIGH", "Load exceeded on stage request", mergeEnv(req));
+          cef_logger.alert("LOAD_HIGH", "Load exceeded on stage request", req);
           logger.warn("max load hit, failing on auth request with 503: " + err);
           return httputils.serviceUnavailable(res, "server is too busy");
         }
-        cef_logger.alert("BCRYPT_ERROR", "Error bcrypting password",
-                         mergeEnv(req, {msg: err}));
+        cef_logger.alert("BCRYPT_ERROR", "Error bcrypting password", req, {msg: err});
         logger.error("can't bcrypt: " + err);
         return res.json({ success: false });
       }
@@ -64,8 +62,7 @@ exports.process = function(req, res) {
         // and given to the user), on failure it throws
         db.stageUser(req.params.email, hash, function(err, secret) {
           if (err) {
-            cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure",
-                       mergeEnv(req, {msg: err}));
+            cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure", req, {msg: err});
             return wsapi.databaseDown(res, err);
           }
 

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -8,7 +8,9 @@ wsapi = require('../wsapi.js'),
 httputils = require('../httputils'),
 logger = require('../logging.js').logger,
 email = require('../email.js'),
-config = require('../configuration');
+config = require('../configuration'),
+cef_logger = require('../cef_logger').getInstance(),
+mergeEnv = require('../cef_logger').mergeWithHttpEnv;
 
 /* First half of account creation.  Stages a user account for creation.
  * this involves creating a secret url that must be delivered to the
@@ -33,6 +35,8 @@ exports.process = function(req, res) {
     if (err) return wsapi.databaseDown(res, err);
 
     if (last && (new Date() - last) < config.get('min_time_between_emails_ms')) {
+      cef_logger.alert("EMAIL_LOAD", "Throttling email staging request",
+                      mergeEnv(req, {duser: req.params.email}));
       logger.warn('throttling request to stage email address ' + req.params.email + ', only ' +
                   ((new Date() - last) / 1000.0) + "s elapsed");
       return httputils.throttled(res, "Too many emails sent to that address, try again later.");
@@ -45,9 +49,12 @@ exports.process = function(req, res) {
     wsapi.bcryptPassword(req.params.pass, function (err, hash) {
       if (err) {
         if (err.indexOf('exceeded') != -1) {
+          cef_logger.alert("LOAD_HIGH", "Load exceeded on stage request", mergeEnv(req));
           logger.warn("max load hit, failing on auth request with 503: " + err);
           return httputils.serviceUnavailable(res, "server is too busy");
         }
+        cef_logger.alert("BCRYPT_ERROR", "Error bcrypting password",
+                         mergeEnv(req, {msg: err}));
         logger.error("can't bcrypt: " + err);
         return res.json({ success: false });
       }
@@ -56,7 +63,11 @@ exports.process = function(req, res) {
         // upon success, stage_user returns a secret (that'll get baked into a url
         // and given to the user), on failure it throws
         db.stageUser(req.params.email, hash, function(err, secret) {
-          if (err) return wsapi.databaseDown(res, err);
+          if (err) {
+            cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure",
+                       mergeEnv(req, {msg: err}));
+            return wsapi.databaseDown(res, err);
+          }
 
           // store the email being registered in the session data
           if (!req.session) req.session = {};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "JSONSelect": "0.4.0",
         "bcrypt": "0.4.1",
+        "cef": "0.3.2",
         "compute-cluster": "0.0.6",
         "connect": "1.7.2",
         "convict": "0.0.6",
@@ -16,7 +17,7 @@
         "ejs": "0.4.3",
         "etagify": "0.0.2",
         "express": "2.5.0",
-        "gobbledygook": "0.0.3", 
+        "gobbledygook": "0.0.3",
         "mustache": "0.3.1-dev",
         "jwcrypto": "0.3.2",
         "mysql": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "JSONSelect": "0.4.0",
         "bcrypt": "0.4.1",
-        "cef": "0.3.2",
+        "cef": "0.3.3",
         "compute-cluster": "0.0.6",
         "connect": "1.7.2",
         "convict": "0.0.6",

--- a/tests/add-email-with-assertion-test.js
+++ b/tests/add-email-with-assertion-test.js
@@ -172,7 +172,7 @@ suite.addBatch({
     "returns an object with what we'd expect": function(err, r) {
       var respObj = JSON.parse(r.body);
       var emails = Object.keys(respObj);
-      assert.strictEqual(emails.length, 2)
+      assert.strictEqual(emails.length, 2);
       assert.ok(emails.indexOf(TEST_EMAIL) != -1);
       assert.ok(emails.indexOf(TEST_FIRST_ACCT) != -1);
       assert.equal(respObj[TEST_EMAIL].type, "primary");

--- a/tests/cef-logging.js
+++ b/tests/cef-logging.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert'),
+    vows = require('vows'),
+    util = require('util'),
+    dgram = require('dgram'),
+    cef_logger = require('../lib/cef_logger');
+
+var mock_http_req = {
+  url: '/pie',
+  method: 'GET',
+  headers: {
+    'user-agent': 'Tiney fork 3.14',
+    'host': 'pie.io'
+  }
+};
+
+function produces(signature, message, expected_string, extensions) {
+  // Mock udp syslog service
+  var server = dgram.createSocket('udp4');
+
+  var context = {
+    topic: function() {
+      var method = this.context.name;
+
+      // Throw the server away when the first message is received.
+      // Return the message to the test context.
+      server.on('message', function(buf, rinfo) {
+        server.removeAllListeners();
+        server.close();
+        this.callback(null, buf.toString());
+      }.bind(this));
+
+      // When server is up, create a logger and send a message
+      server.on('listening', function() {
+        var syslog_port = server.address().port;
+        var config = {
+          vendor: 'Mozilla',
+          product: 'pie-taster',
+          version: '42',
+          syslog_port: syslog_port,
+          syslog_tag: 'flan',
+          syslog_facility: 'local4'
+        };
+        var logger = cef_logger.getInstance(config);
+        logger[method](signature, message, extensions);
+      });
+
+      server.bind(0);
+    }
+  };
+
+  context["produces the expected CEF string"] = function(message) {
+    assert(message.indexOf(expected_string) !== -1);
+  };
+
+  context["writes extensions to the log"] = function(message) {
+    Object.keys(extensions).forEach(function(key) {
+      assert(message.indexOf(util.format("%s=%s", key, extensions[key])) > -1);
+    });
+  };
+
+  return context;
+}
+
+var suite = vows.describe("CEF Logging")
+
+.addBatch({
+
+  // First test with nothing else mixed into the http env to prove that
+  // bare http env comes in as an object.
+  "info": produces("GET_PIE", "I like pie",
+                  "CEF:0|Mozilla|pie-taster|42|GET_PIE|I like pie|4",
+                  cef_logger.mergeWithHttpEnv(mock_http_req)),
+
+  // Blending other params in with http env ...
+  "warn": produces("PIE", "Supplies of pies in demise",
+                  "CEF:0|Mozilla|pie-taster|42|PIE|Supplies of pies in demise|6",
+                  cef_logger.mergeWithHttpEnv(mock_http_req, {msg: "37 remaining"})),
+
+  "alert": produces("PIE", "MOAR PIES!!!",
+                  "CEF:0|Mozilla|pie-taster|42|PIE|MOAR PIES!!!|9",
+                  {dhost: "my belly", msg: "supply all gone"}),
+
+  "emergency": produces("PIE_FAILURE", "Died of starvation",
+                  "CEF:0|Mozilla|pie-taster|42|PIE_FAILURE|Died of starvation|10",
+                  {end: Date.now()}),
+
+});
+
+if (process.argv[1] === __filename) {
+  suite.run();
+} else {
+  suite.export(module);
+}

--- a/tests/stalled-mysql-test.js
+++ b/tests/stalled-mysql-test.js
@@ -161,7 +161,7 @@ suite.addBatch({
 // is stalled
 addStallDriverBatch(false);
 
-var token = undefined;
+token = undefined;
 
 suite.addBatch({
   "ping": {


### PR DESCRIPTION
Issue #2131

CEF (common event format) logging will enable dev and security ops to use tools like ArcSight to more closely track security and system events.  

To facilitate this, I have put an external CEF logging module together: https://github.com/jedp/node-cef.  It sends log messages via UDP to a syslog service.  The service is configured in our `lib/configuration.js`.

In this pull request, I have tried to make a more friendly API for the CEF logger, and implemented logging at key locations identified in this security review: https://wiki.mozilla.org/Security/Reviews/Identity/browserid

@ygjb @lloyd @ozten can you help me answer the following questions?
- Have I adhered properly to the CEF spec and practices?
- Is the CEF section in `lib/configuration.js` adequate (particularly for udp syslog)?
- Could the `cef_logger` API be made less obtrusive and more developer-friendly?

Many thanks!
j
