### PR TITLE
Fix typo in primary logging

### DIFF
--- a/lib/primary.js
+++ b/lib/primary.js
@@ -65,7 +65,7 @@ function parseWellKnownBody(body, domain, delegates, cb) {
         bail = true;
         return cb("Too many hops while delegating authority " + JSON.stringify(dels));
       }
-      logger.debug(domain + ' is delegating to' + v[k]);
+      logger.debug(domain + ' is delegating to ' + v[k]);
       // recurse into low level get /.well-known/browserid and parse again?
       // If everything goes well, finally call our original callback
       delegates[domain] = dels.length;


### PR DESCRIPTION
Before:

`browserid (64065): debug: hotmail.com is delegating tohttps://dev.bigtent.mozilla.org`

After:

`browserid (64065): debug: hotmail.com is delegating to https://dev.bigtent.mozilla.org`
