### PR TITLE
Give the Persona window the name __persona_dialog when opening. 

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -814,79 +814,11 @@
               }
             }
           };
-        },
-        onOpen: function(cb) {
-          var o = "*";
-          var msgTarget = isIE ? findRelay() : window.opener;
-          if (!msgTarget) throw "can't find relay frame";
-          function doPost(msg) {
-            msg = JSON.stringify(msg);
-            if (isIE) msgTarget.doPost(msg, o);
-            else msgTarget.postMessage(msg, o);
-          }
-
-          function onMessage(e) {
-            // only one message gets through
-            removeListener(window, 'message', onMessage);
-            var d;
-            o = e.origin;
-            try {
-              d = JSON.parse(e.data);
-            } catch(err) { }
-            if (cb) {
-              // this setTimeout is critically important for IE8 -
-              // in ie8 sometimes addListener for 'message' can synchronously
-              // cause your callback to be invoked.  awesome.
-              setTimeout(function() {
-                cb(o, d.d, function(r) {
-                  cb = undefined;
-                  doPost({a: 'response', d: r});
-                });
-              }, 0);
-            }
-          }
-
-          function onDie(e) {
-            if (e.data === CLOSE_CMD) {
-              try { window.close(); } catch (o_O) {}
-            }
-          }
-          addListener(isIE ? msgTarget : window, 'message', onMessage);
-          addListener(isIE ? msgTarget : window, 'message', onDie);
-
-          // we cannot post to our parent that we're ready before the iframe
-          // is loaded. (IE specific possible failure)
-          try {
-            doPost({a: "ready"});
-          } catch(e) {
-            // this code should never be exectued outside IE
-            addListener(msgTarget, 'load', function(e) {
-              doPost({a: "ready"});
-            });
-          }
-
-          // if window is unloaded and the client hasn't called cb, it's an error
-          var onUnload = function() {
-            removeListener(isIE ? msgTarget : window, 'message', onDie);
-            if (cb) doPost({ a: 'error', d: 'client closed window' });
-            cb = undefined;
-            // explicitly close the window, in case the client is trying to reload or nav
-            try { window.close(); } catch (e) { }
-          };
-          addListener(window, 'unload', onUnload);
-          return {
-            detach: function() {
-              removeListener(window, 'unload', onUnload);
-            }
-          };
         }
       };
     } else {
       return {
         open: function(url, winopts, arg, cb) {
-          setTimeout(function() { cb("unsupported browser"); }, 0);
-        },
-        onOpen: function(cb) {
           setTimeout(function() { cb("unsupported browser"); }, 0);
         }
       };

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -626,6 +626,8 @@
   })();
 
   // local embedded copy of winchan: http://github.com/lloyd/winchan
+  // BEGIN WINCHAN
+
   ;WinChan = (function() {
     var RELAY_FRAME_NAME = "__winchan_relay_frame";
     var CLOSE_CMD = "die";
@@ -723,6 +725,7 @@
           if (err) setTimeout(function() { cb(err); }, 0);
 
           // supply default options
+          if (!opts.window_name) opts.window_name = null;
           if (!opts.window_features || isFennec()) opts.window_features = undefined;
 
           // opts.params may be undefined
@@ -752,7 +755,7 @@
             messageTarget = iframe.contentWindow;
           }
 
-          var w = window.open(opts.url, null, opts.window_features);
+          var w = window.open(opts.url, opts.window_name, opts.window_features);
 
           if (!messageTarget) messageTarget = w;
 
@@ -811,16 +814,88 @@
               }
             }
           };
+        },
+        onOpen: function(cb) {
+          var o = "*";
+          var msgTarget = isIE ? findRelay() : window.opener;
+          if (!msgTarget) throw "can't find relay frame";
+          function doPost(msg) {
+            msg = JSON.stringify(msg);
+            if (isIE) msgTarget.doPost(msg, o);
+            else msgTarget.postMessage(msg, o);
+          }
+
+          function onMessage(e) {
+            // only one message gets through
+            removeListener(window, 'message', onMessage);
+            var d;
+            o = e.origin;
+            try {
+              d = JSON.parse(e.data);
+            } catch(err) { }
+            if (cb) {
+              // this setTimeout is critically important for IE8 -
+              // in ie8 sometimes addListener for 'message' can synchronously
+              // cause your callback to be invoked.  awesome.
+              setTimeout(function() {
+                cb(o, d.d, function(r) {
+                  cb = undefined;
+                  doPost({a: 'response', d: r});
+                });
+              }, 0);
+            }
+          }
+
+          function onDie(e) {
+            if (e.data === CLOSE_CMD) {
+              try { window.close(); } catch (o_O) {}
+            }
+          }
+          addListener(isIE ? msgTarget : window, 'message', onMessage);
+          addListener(isIE ? msgTarget : window, 'message', onDie);
+
+          // we cannot post to our parent that we're ready before the iframe
+          // is loaded. (IE specific possible failure)
+          try {
+            doPost({a: "ready"});
+          } catch(e) {
+            // this code should never be exectued outside IE
+            addListener(msgTarget, 'load', function(e) {
+              doPost({a: "ready"});
+            });
+          }
+
+          // if window is unloaded and the client hasn't called cb, it's an error
+          var onUnload = function() {
+            removeListener(isIE ? msgTarget : window, 'message', onDie);
+            if (cb) doPost({ a: 'error', d: 'client closed window' });
+            cb = undefined;
+            // explicitly close the window, in case the client is trying to reload or nav
+            try { window.close(); } catch (e) { }
+          };
+          addListener(window, 'unload', onUnload);
+          return {
+            detach: function() {
+              removeListener(window, 'unload', onUnload);
+            }
+          };
         }
       };
     } else {
       return {
         open: function(url, winopts, arg, cb) {
           setTimeout(function() { cb("unsupported browser"); }, 0);
+        },
+        onOpen: function(cb) {
+          setTimeout(function() { cb("unsupported browser"); }, 0);
         }
       };
     }
   })();
+
+
+
+  // END WINCHAN
 
   var BrowserSupport = (function() {
     var win = window,
@@ -1112,6 +1187,7 @@
         url: ipServer + '/sign_in',
         relay_url: ipServer + '/relay',
         window_features: windowOpenOpts,
+        window_name: '__persona_dialog',
         params: {
           method: "get",
           params: options


### PR DESCRIPTION
@benadida, @lloyd - Would you two give this a review?

Useful for Selenium tests which need an easy mechanism to get a reference to the window being tested.  Once Selenium has a reference to the window, it's name can be changed.

Include the new WinChan which allows window.name to be set.  Setting the name of the dialog to __persona_dialog on load.

This does not appear to interfere with primary signin where it changes the window.name to "auth_with_primary"

/cc @davehunt 

issue #1023
