### PR TITLE
always set currentHint to null at startup

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -179,6 +179,7 @@ BrowserID.Modules.Authenticate = (function() {
         email: lastEmail
       });
 
+      currentHint = null;
       dom.hide(".returning,.start");
 
       // We have to show the TOS/PP agreements to *all* users here. Users who


### PR DESCRIPTION
`currentHint` was getting set to `returning`, and when it came back from Forgot Password, it would try to show `returning` again, but that would be prevented since `shotHint` thought it was already shown.

fixes #2132
