### PR TITLE
don't set process.env.SUPPORTS_SIGNALS = false

### DIFF
--- a/scripts/run_locally.js
+++ b/scripts/run_locally.js
@@ -89,7 +89,6 @@ if (!(SIGNALS_PROP in process.env)) {
     process.removeListener('SIGINT', signals_test);
     process.env[SIGNALS_PROP] = true;
   } catch (noSignals) {
-    process.env[SIGNALS_PROP] = false;
   }
 }
 
@@ -155,4 +154,5 @@ if (process.env[SIGNALS_PROP]) {
     console.log('\nSIGINT recieved! trying to shut down gracefully...');
     Object.keys(daemons).forEach(function (k) { daemons[k].kill('SIGINT'); });
   });
+  
 }


### PR DESCRIPTION
process.env converts all values set into strings,
so its better to just not set it.
