### PR TITLE
Add VerificationURL and RelyingParty to verification email headers

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -30,24 +30,24 @@ if (smtp_params && smtp_params.host) {
 
 const TEMPLATE_PATH = path.join(__dirname, "static", "email_templates");
 
-// the underbar decorator to allow getext to extract strings 
+// the underbar decorator to allow getext to extract strings
 function _(str) { return str; }
 
 // a map of all the different emails we send
 const templates = {
   "new": {
     landing: 'verify_email_address',
-    subject: _("Confirm email address for Persona"), 
+    subject: _("Confirm email address for Persona"),
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'new.ejs')),
   },
   "reset": {
     landing: 'reset_password',
-    subject: _("Reset Persona password"), 
+    subject: _("Reset Persona password"),
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'reset.ejs')),
   },
   "confirm": {
     landing: 'confirm',
-    subject: _("Confirm email address for Persona"), 
+    subject: _("Confirm email address for Persona"),
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.ejs')),
   }
 };
@@ -56,7 +56,7 @@ const templates = {
 Object.keys(templates).forEach(function(type) {
   templates[type].template = ejs.compile(templates[type].template.toString());
 });
-    
+
 
 var interceptor = undefined;
 
@@ -100,6 +100,10 @@ function doSend(email_type, email, site, secret, langContext) {
       sender: "Persona <no-reply@persona.org>",
       to: email,
       subject: GETTEXT(email_params.subject),
+      headers: {
+        'X-BrowserID-VerificationURL': public_url,
+        'X-BrowserID-RelyingParty': site
+      },
       body: email_params.template({
         link: public_url,
         site: site,


### PR DESCRIPTION
While emails are on everybody's mind ...

Issue #1639

Adds X- headers containing verification url and RP in order to make automated handing easier and less susceptible to breakage if email templates or URL patterns change.

This would be used by https://github.com/lloyd/personatestuser.org
