### PR TITLE
Fix the email not being saved when the user goes from /signin to /forgot via the "forgot your password?" link.

### DIFF
--- a/resources/static/pages/js/forgot.js
+++ b/resources/static/pages/js/forgot.js
@@ -53,11 +53,10 @@ BrowserID.forgot = (function() {
   }
 
   function redirectIfNeeded(doc, ready) {
-    // email addresses are stored if the user is coming from the signin or
-    // signup page.  If no email address is stored, the user browsed here
-    // directly.  If the user browsed here directly, kick them back to the
-    // sign in page.
-    var email = pageHelpers.getStoredEmail();
+    // email addresses are stored if the user is coming from the signin page.
+    // If no email address is stored, the user browsed here directly.  If
+    // the user browsed here directly, kick them back to the signin page.
+    var email = pageHelpers.setupEmail();
     if (!email) {
       doc.location.href = "/signin";
       complete(ready);
@@ -86,8 +85,6 @@ BrowserID.forgot = (function() {
       // the content.
       redirectIfNeeded(doc, function() {
         dom.focus("form input[autofocus]");
-
-        pageHelpers.setupEmail();
 
         self.bind("form", "submit", cancelEvent(submit));
         self.click("#back", back);

--- a/resources/static/pages/js/page_helpers.js
+++ b/resources/static/pages/js/page_helpers.js
@@ -28,7 +28,7 @@ BrowserID.PageHelpers = (function() {
     return storage.signInEmail.get() || "";
   }
 
-  function onEmailChange(event) {
+  function storeCurrentEmail(event) {
     var email = dom.getInner("#email");
     setStoredEmail(email);
   }
@@ -44,8 +44,7 @@ BrowserID.PageHelpers = (function() {
       if ($("#password").length) $("#password").focus();
     }
 
-    dom.bindEvent("#email", "change", onEmailChange);
-    dom.bindEvent("#email", "keyup", onEmailChange);
+    return email;
   }
 
   function getParameterByName( name ) {
@@ -154,6 +153,7 @@ BrowserID.PageHelpers = (function() {
     setStoredEmail: setStoredEmail,
     clearStoredEmail: clearStoredEmail,
     getStoredEmail: getStoredEmail,
+    storeCurrentEmail: storeCurrentEmail,
     getParameterByName: getParameterByName,
     /**
      * shows a failure screen immediately

--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -191,7 +191,7 @@ BrowserID.signIn = (function() {
       self.click("#authWithPrimary", authWithPrimary);
       self.bind("#email", "change", onEmailChange);
       self.bind("#email", "keyup", onEmailChange);
-      self.bind(".store_email", "click", pageHelpers.storeCurrentEmail);
+      self.bind(".forgot", "click", pageHelpers.storeCurrentEmail);
 
       sc.start.call(self, options);
 

--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -188,18 +188,17 @@ BrowserID.signIn = (function() {
       if(options && options.document) doc = options.document;
       if(options && options.winchan) winchan = options.winchan;
 
-      pageHelpers.setupEmail();
-
       self.click("#authWithPrimary", authWithPrimary);
       self.bind("#email", "change", onEmailChange);
       self.bind("#email", "keyup", onEmailChange);
+      self.bind(".store_email", "click", pageHelpers.storeCurrentEmail);
 
       sc.start.call(self, options);
 
       // If there is an email already set up in pageHelpers.setupEmail, see if
       // the email address is a primary, secondary, known or unknown.  Redirect
       // if needed.
-      if (dom.getInner("#email")) {
+      if (pageHelpers.setupEmail()) {
         self.submit(options.ready);
       }
       else {

--- a/resources/static/test/cases/pages/js/page_helpers.js
+++ b/resources/static/test/cases/pages/js/page_helpers.js
@@ -43,22 +43,11 @@
     equal(pageHelpers.getStoredEmail(), "testuser@testuser.com", "getStoredEmail works correctly");
   });
 
-  test("a key press in the email address field saves it", function() {
-    $("#email").val("");
-
-    pageHelpers.setStoredEmail("testuser@testuser.co");
-    pageHelpers.setupEmail();
-
-    // The fake jQuery event does not actually cause the letter to be added, we
-    // have to do that manually.
+  test("storeCurrentEmail saves the address currently stored in #email", function() {
+    pageHelpers.clearStoredEmail();
     $("#email").val("testuser@testuser.com");
-
-    var e = jQuery.Event("keyup");
-    e.which = 77; //choose the one you want
-    e.keyCode = 77;
-    $("#email").trigger(e);
-
-    equal(pageHelpers.getStoredEmail(), "testuser@testuser.com", "hitting a key updates the stored email");
+    pageHelpers.storeCurrentEmail();
+    equal(pageHelpers.getStoredEmail(), "testuser@testuser.com", "storeCurrentEmail stores the current email");
   });
 
   test("clearStoredEmail clears the email address from storage", function() {

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -42,7 +42,7 @@
                 </li>
 
                 <li class="password_entry vpassword_entry">
-                    <a class="forgot right store_email" href="/forgot"><%- gettext('forgot your password?') %></a>
+                    <a class="forgot right" href="/forgot"><%- gettext('forgot your password?') %></a>
                     <label for="password" class="password_entry"><%- gettext('Password') %></label>
                     <label for="password" class="vpassword_entry"><%- gettext('Your email address is new to us. Please create a password to use with Persona.') %></label>
                     <input id="password" placeholder="<%- gettext('password') %>" type="password" maxlength="80">

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -42,7 +42,7 @@
                 </li>
 
                 <li class="password_entry vpassword_entry">
-                    <a class="forgot right" href="/forgot"><%- gettext('forgot your password?') %></a>
+                    <a class="forgot right store_email" href="/forgot"><%- gettext('forgot your password?') %></a>
                     <label for="password" class="password_entry"><%- gettext('Password') %></label>
                     <label for="password" class="vpassword_entry"><%- gettext('Your email address is new to us. Please create a password to use with Persona.') %></label>
                     <input id="password" placeholder="<%- gettext('password') %>" type="password" maxlength="80">


### PR DESCRIPTION
- Clean up behaviors when going between /signin and /forgot.
- Emails only need to be stored when toggling between /signin and /forgot. Instead of saving the email every time the user types a charcter, save the email when the user goes from /signin to /forgot via the "forgot your password?" link. Let the browser take care of auto-fill.
- pageHelpers.setupEmail now returns an email if it is available.
#2179
