### PR TITLE
make placeholder text in inputs lighter grey

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -141,6 +141,12 @@ input[type=password]:disabled {
     border-color: #b2b2b2;
 }
 
+input[type=text]:-moz-placeholder,
+input[type=email]:-moz-placeholder,
+input[type=password]:-moz-placeholder {
+   color:#aaa;
+}
+
 label {
   display: block;
 }


### PR DESCRIPTION
only Firefox seems to make the placeholder text
be the same color as the normal text, so this will
set the placeholder to a lighter grey

fixes #2187
