### PR TITLE
catch winchan removeListener error in IE8

### DIFF
--- a/resources/static/common/js/lib/winchan.js
+++ b/resources/static/common/js/lib/winchan.js
@@ -236,7 +236,10 @@
 
         // if window is unloaded and the client hasn't called cb, it's an error
         var onUnload = function() {
-          removeListener(isIE ? msgTarget : window, 'message', onDie);
+          try {
+            // IE8 doesn't like this...
+            removeListener(isIE ? msgTarget : window, 'message', onDie);
+          } catch (ohWell) { }
           if (cb) doPost({ a: 'error', d: 'client closed window' });
           cb = undefined;
           // explicitly close the window, in case the client is trying to reload or nav


### PR DESCRIPTION
removeListener throws in IE8

pending on lloyd/winchan#27 getting merged in, this contains those changes.

would fix #2183
