### PR TITLE
Move tooltips to where they are less obtrusive.

### DIFF
--- a/resources/static/dialog/views/authenticate.ejs
+++ b/resources/static/dialog/views/authenticate.ejs
@@ -25,6 +25,10 @@
               <div id="could_not_add" class="tooltip" for="email">
                 <%= gettext('We just sent an email to that address! If you really want to send another, wait a minute or two and try again.') %>
               </div>
+
+              <div id="cannot_authenticate" class="tooltip" for="email">
+                <%= gettext('This email address and password do not match.') %>
+              </div>
           </li>
 
 
@@ -42,9 +46,6 @@
                 <%= gettext('The password field is required.') %>
               </div>
 
-              <div id="cannot_authenticate" class="tooltip" for="password">
-                <%= gettext('This email address and password do not match.') %>
-              </div>
           </li>
 
       </ul>

--- a/resources/static/dialog/views/set_password.ejs
+++ b/resources/static/dialog/views/set_password.ejs
@@ -35,6 +35,10 @@
               <div id="could_not_add" class="tooltip" for="password">
                 <%= gettext('We just sent an email to that address! If you really want to send another, wait a minute or two and try again.') %>
               </div>
+
+              <div class="tooltip" id="passwords_no_match" for="password">
+                <%= gettext('These passwords don\'t match!') %>
+              </div>
           </li>
 
           <li>
@@ -45,9 +49,6 @@
                 <%= gettext('Verification password is required.') %>
               </div>
 
-              <div class="tooltip" id="passwords_no_match" for="vpassword">
-                <%= gettext('These passwords don\'t match!') %>
-              </div>
           </li>
 
       </ul>

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -39,6 +39,11 @@
                       <%- gettext('We just sent an email to that address! If you really want to send another, wait a minute or two and try again.') %>
                     </div>
 
+                    <div id="cannot_authenticate" class="tooltip" for="email">
+                      <%- gettext('This email address and password do not match.') %>
+                    </div>
+
+
                 </li>
 
                 <li class="password_entry vpassword_entry">
@@ -51,14 +56,13 @@
                       <%- gettext('The password field is required.') %>
                     </div>
 
-                    <div id="cannot_authenticate" class="tooltip" for="password">
-                      <%- gettext('This email address and password do not match.') %>
-                    </div>
-
                     <div class="tooltip" id="password_length" for="password">
                         <%- gettext('Password must be between 8 and 80 characters long.') %>
                     </div>
 
+                    <div class="tooltip" id="passwords_no_match" for="password">
+                      <%- gettext('These passwords don\'t match!') %>
+                    </div>
                 </li>
 
                 <li class="vpassword_entry">
@@ -69,9 +73,6 @@
                       <%- gettext('Verification password is required.') %>
                     </div>
 
-                    <div class="tooltip" id="passwords_no_match" for="vpassword">
-                      <%- gettext('These passwords don\'t match!') %>
-                    </div>
 
                 </li>
             </ul>


### PR DESCRIPTION
- Move the "passwords do not match" on the set password screen above the first password.
- Move the "this email address and password do not match" above the email field.

issue #2106
issue #2113
