### PR TITLE
can configure kpi datastore url with env var

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -138,7 +138,11 @@ var conf = module.exports = convict({
     format: 'number = 0.0',
     env: 'KPI_BACKEND_SAMPLE_RATE'
   },
-  kpi_backend_db_url: 'string = "http://localhost/wsapi/interaction_data"',
+  kpi_backend_db_url: {
+    doc: "URL of KPiggyBank service to send Key Performance Indicator data to",
+    format: 'string = "http://localhost/wsapi/interaction_data"',
+    env: 'KPI_BACKEND_DB_URL'
+  },
   bcrypt_work_factor: {
     doc: "How expensive should we make password checks (to mitigate brute force attacks) ?  Each increment is 2x the cost.",
     format: 'integer{6,20} = 12',


### PR DESCRIPTION
Just to let you run [kpiggybank](https://github.com/jedp/kpiggybank) locally and have browserid send kpi data to it:

```
KPI_BACKEND_DB_URL=http://localhost:3000/wsapi/interaction_data npm start
```
