### PR TITLE
update jwcrypto dependency to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "express": "2.5.0",
         "gobbledygook": "0.0.3", 
         "mustache": "0.3.1-dev",
-        "jwcrypto": "https://github.com/mozilla/jwcrypto/tarball/2012-07-new-data-formats",
+        "jwcrypto": "0.4.0",
         "mysql": "0.9.5",
         "nodemailer": "0.3.21",
         "mkdirp": "0.3.0",


### PR DESCRIPTION
I grepped through the browserid code (as of 0366b9f) and verified that
all calls to cert.sign() have been updated to match the new API in
jwcrypto-0.4.0 .

The use of jwcrypto-0.4.0 allows browserid code to handle the new key
format and certificate format in version="2012.08.15". It won't create
new-format keys or certs yet: that will require a new jwcrypto release,
as well as changes in browserid to detect when it is safe to use the new
format (we must either wait for all deployed IdP primaries, browser
implementations, and verifiers to handle the new format, or implement
feature-advertisements and negotiation tools to selectively enable it).

The cert.sign() API calls were actually upgraded to the new API in
commit 67e54de3, when pull-request #2133 was landed. The branch was not
quite ready at that time, as it was using a named branch of jwcrypto
instead of the final 0.4.0 release. This commit effectively finishes off
that branch.
