### PR TITLE
Fix for IE8 not being able to complete user verification.

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -32,6 +32,10 @@ BrowserID.Storage = (function() {
       ONE_DAY_IN_MS = (1000 * 60 * 60 * 24),
       storage = BrowserID.getStorage();
 
+  // Set default values immediately so that IE8 localStorage synchronization
+  // issues do not become a factor. See issue #2206
+  setDefaultValues();
+
   // temporary, replace with helpers.log if storage uses elog long term...
   function elog (msg) {
     if (window.console && console.error) console.error(msg);
@@ -45,6 +49,12 @@ BrowserID.Storage = (function() {
     storage.removeItem("emails");
     storage.removeItem("siteInfo");
     storage.removeItem("managePage");
+    // Ensure there are default values after they are removed.  This is
+    // necessary so that IE8's localStorage synchronization issues do not
+    // surface.  In IE8, if the dialog page is open when the verification page
+    // loads and emails does not have a default value, the dialog cannot read
+    // or write to localStorage. The dialog See issues #1637 and #2206
+    setDefaultValues();
   }
 
   // initialize all localStorage values to default if they are unset.

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -71,12 +71,19 @@
   });
 
 
-  test("clear", function() {
+  test("clear - there should be default values", function() {
     storage.addEmail("testuser@testuser.com", {priv: "key"});
     storage.clear();
 
     var emails = storage.getEmails();
     equal(_.size(emails), 0, "object should have no items");
+
+    // all fields *MUST* have default values or else synchronization of
+    // localStorage in IE8 across multiple browsing contexts becomes a problem.
+    // See issue #2206 and #1637
+    notEqual(typeof localStorage.emails, "undefined", "emails is defined");
+    notEqual(typeof localStorage.siteInfo, "undefined", "siteInfo is defined");
+    notEqual(typeof localStorage.managePage, "undefined", "managePage is defined");
   });
 
   test("invalidateEmail with valid email address", function() {


### PR DESCRIPTION
in clear(), after calling localStorage.removeItem, call setDefaultValues to ensure the dialog has a set of values for each of its fields whenever the verification page loads.

issue #2206
