### PR TITLE
update client-sessions for Windows

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -36,7 +36,7 @@
     "0.4.3": "e6819c8d5faa957f64f98f66a8506268c1d1f17d"
   },
   "client-sessions": {
-    "0.0.6": "8985fbeebfaf2da77bd23f1ff2e387f5f8abb059"
+    "0.0.9": "5dd2c770c53f5f203c1a60df4e29ab59dcc98674"
   },
   "coffee-script": {
     "1.3.3": "150d6b4cb522894369efed6a2101c20bc7f4a4f4"
@@ -159,7 +159,7 @@
     "0.9.5": "cc95e1c31d0653974d3fb3e9266ed466cd0f96b5"
   },
   "node-proxy": {
-    "0.5.2": "c22cc7ddf8c2af0bfa32fed30d3c533b216ef893"
+    "0.6.0": "41e64712dbd947aa9d9f466b5c0b5ee020bbcbbb"
   },
   "node-statsd": {
     "0.0.2": "*"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "connect": "1.7.2",
         "convict": "0.0.6",
         "cjson": "0.0.6",
-        "client-sessions": "0.0.6",
+        "client-sessions": "0.0.9",
         "connect-cachify": "0.0.10",
         "connect-cookie-session": "0.0.2",
         "connect-logger-statsd": "0.0.1",


### PR DESCRIPTION
this has a new version of node-proxy, that uses
node-gyp and can therefore compile on Windows

This addresses 1 part of #1769.
