### PR TITLE
Make sure navigator.id.get can be called with no options.

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1188,6 +1188,7 @@
       // get an assertion
       get: function(callback, passedOptions) {
         var opts = {};
+        passedOptions = passedOptions || {};
         opts.privacyPolicy =  passedOptions.privacyPolicy || undefined;
         opts.termsOfService = passedOptions.termsOfService || undefined;
         opts.privacyURL = passedOptions.privacyURL || undefined;


### PR DESCRIPTION
This fixes both navigator.id.get called with no options and navigator.id.getVerifiedEmail, which is still officially supported.

issue #2215
