### PR TITLE
Fix the user going back to the "enter email" state if they select an email using auto-complete and then type CTRL-C on the email address.

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -126,8 +126,10 @@ BrowserID.Modules.Authenticate = (function() {
 
   function enterEmailState() {
     /*jshint validthis: true*/
+    var self=this;
     if (!dom.is("#email", ":disabled")) {
-      this.submit = checkEmail;
+      self.publish("enter_email");
+      self.submit = checkEmail;
       showHint("start");
     }
   }
@@ -157,7 +159,7 @@ BrowserID.Modules.Authenticate = (function() {
     }
   }
 
-  function emailKeyUp() {
+  function emailChange() {
     /*jshint validthis: true*/
     var newEmail = dom.getInner("#email");
     if (newEmail !== lastEmail) {
@@ -191,7 +193,10 @@ BrowserID.Modules.Authenticate = (function() {
         dialogHelpers.showRPTosPP.call(self);
       }
 
-      self.bind("#email", "keyup", emailKeyUp);
+      self.bind("#email", "keyup", emailChange);
+      // Adding the change event causes the email to be checked whenever an
+      // element blurs but it has been updated via autofill.  See issue #406
+      self.bind("#email", "change", emailChange);
       self.click("#forgotPassword", forgotPassword);
 
       Module.sc.start.call(self, options);

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -126,7 +126,7 @@
       // The first time the password is shown, change the email address.  The
       // second time the password is shown, make sure the password was cleared.
 
-      if(enterPasswordCount == 0) {
+      if(enterPasswordCount === 0) {
         // simulate the user changing the email address.  This should clear the
         // password.
         $("#password").val("password");
@@ -143,6 +143,40 @@
     });
 
     controller.checkEmail();
+  });
+
+  asyncTest("do not clear password if user selects an email address using autofill, then presses a key that does not change the address (CTRL-C for instance)", function() {
+    xhr.useResult("known_secondary");
+
+    // This test is for issue #406
+
+    // First, see the staps after this handler.
+
+    mediator.subscribe("enter_password", function() {
+      // The user is now looking at the password field and they decide to copy
+      // from the email field by hitting CTRL-C.
+      //
+      // Simulates the user hitting a key that does not change the
+      // input.  The user should NOT go back to the "enter_email" state at this
+      // point.
+      var enterEmailCount = 0;
+      mediator.subscribe("enter_email", function() {
+        enterEmailCount++;
+      });
+      $("#email").keyup();
+
+      equal(enterEmailCount, 0, "enter_email not called after submit if keyup did not change email field");
+      start();
+    });
+
+    // Simulates the user selecting testuser@testuser.com from the
+    // autocomplete menu.
+    $("#email").val("registered@testuser.com");
+    $("#email").change();
+
+    // Simulate the user hitting the "next" button.  Once the address is
+    // verified, the enter_password message will be triggered.
+    controller.submit();
   });
 
   asyncTest("checkEmail with email that has IdP support - 'primary_user' message", function() {


### PR DESCRIPTION
issue #406
