### PR TITLE
Sanity checks for the deprecated tosURL and privacyURL

### DIFF
--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -174,9 +174,12 @@ BrowserID.Modules.Dialog = (function() {
           helpers.log("requiredEmail has been deprecated");
         }
 
-        // support old parameter names...
-        if (paramsFromRP.tosURL) paramsFromRP.termsOfService = paramsFromRP.tosURL;
-        if (paramsFromRP.privacyURL) paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
+        // support old parameter names if new parameter names not defined.
+        if (paramsFromRP.tosURL && !paramsFromRP.termsOfService)
+          paramsFromRP.termsOfService = paramsFromRP.tosURL;
+
+        if (paramsFromRP.privacyURL && !paramsFromRP.privacyPolicy)
+          paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
 
         if (paramsFromRP.termsOfService && paramsFromRP.privacyPolicy) {
           params.termsOfService = fixupURL(origin_url, paramsFromRP.termsOfService);

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1080,20 +1080,7 @@
       _open_hidden_iframe();
 
       // back compat support for loggedInEmail
-      if (typeof options.loggedInEmail !== 'undefined' &&
-          typeof options.loggedInUser !== 'undefined') {
-        throw "you cannot supply *both* loggedInEmail and loggedInUser";
-      }
-      else if(typeof options.loggedInEmail !== 'undefined') {
-        try {
-          console.log("loggedInEmail has been deprecated");
-        } catch(e) {
-          /* ignore error */
-        }
-
-        options.loggedInUser = options.loggedInEmail;
-        delete options.loggedInEmail;
-      }
+      checkRenamed(options, "loggedInEmail", "loggedInUser");
 
       // check that the commChan was properly initialized before interacting with it.
       // on unsupported browsers commChan might still be undefined, in which case
@@ -1107,9 +1094,9 @@
     }
 
     function internalRequest(options) {
-      if (options.requiredEmail) {
-        warn("requiredEmail has been deprecated");
-      }
+      checkDeprecated(options, "requiredEmail");
+      checkRenamed(options, "tosURL", "termsOfService");
+      checkRenamed(options, "privacyURL", "privacyPolicy");
 
       if (options.termsOfService && !options.privacyPolicy) {
         warn("termsOfService ignored unless privacyPolicy also defined");

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -347,7 +347,7 @@
   });
 
 
-  asyncTest("get with valid absolute termsOfService & privacyPolicy - go to start", function() {
+  function testValidTermsOfServicePrivacyPolicy(options, expected) {
     createController({
       ready: function() {
         var startInfo;
@@ -355,70 +355,60 @@
           startInfo = info;
         });
 
-        var retval = controller.get(HTTP_TEST_DOMAIN, {
-          termsOfService: "/tos.html",
-          privacyPolicy: "/privacy.html"
-        });
-
-        testHelpers.testObjectValuesEqual(startInfo, {
-          termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
-          privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
-        });
+        var retval = controller.get(HTTP_TEST_DOMAIN, options);
+        testHelpers.testObjectValuesEqual(startInfo, expected);
 
         equal(typeof retval, "undefined", "no error expected");
         testErrorNotVisible();
         start();
       }
     });
+  }
+
+  asyncTest("get with valid absolute termsOfService & privacyPolicy - go to start", function() {
+    testValidTermsOfServicePrivacyPolicy({
+      termsOfService: "/tos.html",
+      privacyPolicy: "/privacy.html"
+    },
+    {
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+    });
   });
 
   asyncTest("get with valid fully qualified http termsOfService & privacyPolicy - go to start", function() {
-    createController({
-      ready: function() {
-        var startInfo;
-        mediator.subscribe("start", function(msg, info) {
-          startInfo = info;
-        });
-
-        var retval = controller.get(HTTP_TEST_DOMAIN, {
-          termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
-          privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
-        });
-
-        testHelpers.testObjectValuesEqual(startInfo, {
-          termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
-          privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
-        });
-
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
+    testValidTermsOfServicePrivacyPolicy({
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+    },
+    {
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
     });
   });
 
 
   asyncTest("get with valid fully qualified https termsOfService & privacyPolicy - go to start", function() {
-    createController({
-      ready: function() {
-        var startInfo;
-        mediator.subscribe("start", function(msg, info) {
-          startInfo = info;
-        });
+    testValidTermsOfServicePrivacyPolicy({
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    },
+    {
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    });
+  });
 
-        var retval = controller.get(HTTP_TEST_DOMAIN, {
-          termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
-          privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
-        });
-
-        testHelpers.testObjectValuesEqual(startInfo, {
-          termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
-          privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
+  asyncTest("get with valid termsOfService, tosURL & privacyPolicy, privacyURL - use termsOfService and privacyPolicy", function() {
+    testValidTermsOfServicePrivacyPolicy({
+      termsOfService: "/tos.html",
+      tosURL: "/tos_deprecated.html",
+      privacyPolicy: "/privacy.html",
+      privacyURL: "/privacy_deprecated.html"
+    },
+    {
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
     });
   });
 


### PR DESCRIPTION
- Use termsOfService over tosURL
- Ensure only one of termsOfService or tosURL is defined
- Use privacyPolicy over privacyURL
- Ensure only one of privacyPolicy or privacyURL is defined

@lloyd - I feel like the exceptions that are thrown when both termsOfService and tosURL/privacyPolicy and privacyURL should be done in dialog.js.  This would ensure that native callers of the dialog code are acting as we expect as well.

I placed these in include.js for now because watch has a similar check for loggedInEmail

issue #1659
