### PR TITLE
Change loggedInEmail to loggedInUser in the example RP

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -153,7 +153,7 @@ function checkAssertion(assertion) {
 };
 
 navigator.id.watch({
-  loggedInEmail: (storage.loggedInUser === 'null') ? null : storage.loggedInUser,
+  loggedInUser: (storage.loggedInUser === 'null') ? null : storage.loggedInUser,
   onready: function () {
     loggit("onready");
     var txt = serial++ + ' navigator.id ready at ' + (new Date).toString();


### PR DESCRIPTION
To test:
- Make sure the example RP still works.
- Make sure the console message that says "loggedInEmail has been deprectated" is no longer seen.

issue #2227
