### PR TITLE
update bcrypt to 0.7.1

### DIFF
--- a/lib/bcrypt-compute.js
+++ b/lib/bcrypt-compute.js
@@ -6,10 +6,10 @@ const bcrypt = require('bcrypt');
 
 process.on('message', function(m) {
   if (m.op === 'encrypt') {
-    var r = bcrypt.encrypt_sync(m.pass, bcrypt.gen_salt_sync(m.factor));
+    var r = bcrypt.hashSync(m.pass, bcrypt.genSaltSync(m.factor));
     process.send({r:r});
   } else if (m.op === 'compare') {
-    var r = bcrypt.compare_sync(m.pass, m.hash);
+    var r = bcrypt.compareSync(m.pass, m.hash);
     process.send({r:r});
   }
 });

--- a/lib/bcrypt.js
+++ b/lib/bcrypt.js
@@ -46,8 +46,8 @@ exports.compare = function(pass, hash, cb) {
   })
 };
 
-exports.get_rounds = function(hash) {
-  return bcrypt.get_rounds(hash);
+exports.get_rounds = exports.getRounds = function(hash) {
+  return bcrypt.getRounds(hash);
 };
 
 exports.shutdown = function() {

--- a/lib/wsapi/authenticate_user.js
+++ b/lib/wsapi/authenticate_user.js
@@ -72,7 +72,7 @@ exports.process = function(req, res) {
 
           // if the work factor has changed, update the hash here.  issue #204
           // NOTE: this runs asynchronously and will not delay the response
-          if (config.get('bcrypt_work_factor') != bcrypt.get_rounds(hash)) {
+          if (config.get('bcrypt_work_factor') != bcrypt.getRounds(hash)) {
             logger.info("updating bcrypted password for user " + uid);
 
             // this request must be forwarded to dbwriter, and we'll use the

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "dependencies": {
         "JSONSelect": "0.4.0",
-        "bcrypt": "0.4.1",
+        "bcrypt": "0.7.1",
         "compute-cluster": "0.0.6",
         "connect": "1.7.2",
         "convict": "0.0.6",


### PR DESCRIPTION
this adds Windows support to bcrypt, as long as you're
using nodejs >= 0.8.5

fixes deprecation warning since newer bcrypt has new API

one of the last pieces for #1769
