### PR TITLE
upgrade to jwcrypto 0.4.2 which fixes windows and properly installs bigi...

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "express": "2.5.0",
         "gobbledygook": "0.0.3",
         "mustache": "0.3.1-dev",
-        "jwcrypto": "0.4.1",
+        "jwcrypto": "0.4.2",
         "mysql": "0.9.5",
         "nodemailer": "0.3.21",
         "mkdirp": "0.3.0",


### PR DESCRIPTION
...nt into envs where it is supported

issue #2226
