### PR TITLE
exclude .svn in addition to .git when building RPM

### DIFF
--- a/scripts/rpmbuild.sh
+++ b/scripts/rpmbuild.sh
@@ -12,7 +12,7 @@ cd $(dirname $0)/..    # top level of the checkout
 mkdir -p rpmbuild/SOURCES rpmbuild/SPECS rpmbuild/SOURCES
 rm -rf rpmbuild/RPMS rpmbuild/SOURCES/browserid
 
-tar --exclude rpmbuild --exclude .git \
+tar --exclude rpmbuild --exclude .git --exclude .svn \
     --exclude var -czf \
     $PWD/rpmbuild/SOURCES/browserid-server.tar.gz .
 


### PR DESCRIPTION
We noticed that while inspecting an RPM that there were /opt/browserid/locale/*/.svn/ directories. Exclude those from the RPM.
