### PR TITLE
Fix the unresponsive set password screen if the staging wsapi returned a throttled response.

### DIFF
--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -57,6 +57,13 @@ BrowserID.State = (function() {
       };
 
       self.stagedEmail = info.email;
+
+      // Keep these emails around until the user is actually staged.  If the
+      // staging request is throttled, the next time set_password is called,
+      // these variables are needed to know which staging function to call.
+      // See issue #2258.
+      self.newUserEmail = self.addEmailEmail = self.resetPasswordEmail = null;
+
       startAction(actionName, actionInfo);
     }
 
@@ -184,6 +191,7 @@ BrowserID.State = (function() {
       });
 
       startAction(false, "doSetPassword", info);
+      complete(info.complete);
     });
 
     handleState("password_set", function(msg, info) {
@@ -201,15 +209,12 @@ BrowserID.State = (function() {
       self.stagedPassword = info.password;
 
       if(self.newUserEmail) {
-        self.newUserEmail = null;
         startAction(false, "doStageUser", info);
       }
       else if(self.addEmailEmail) {
-        self.addEmailEmail = null;
         startAction(false, "doStageEmail", info);
       }
       else if(self.resetPasswordEmail) {
-        self.resetPasswordEmail = null;
         startAction(false, "doStageResetPassword", info);
       }
     });
@@ -427,6 +432,7 @@ BrowserID.State = (function() {
       // point, the email confirmation screen will be shown.
       self.resetPasswordEmail = info.email;
       startAction(false, "doResetPassword", info);
+      complete(info.complete);
     });
 
     handleState("reset_password_staged", handleEmailStaged.curry("doConfirmResetPassword"));

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -31,15 +31,35 @@
           this.info[key] = info;
         };
       }(key));
+      ActionsMock.prototype.reset = function() {
+        for(var key in ActionsMock.prototype) {
+          if(bid.Modules.Actions.prototype.hasOwnProperty(key)) {
+            delete this.called[key];
+            delete this.info[key];
+          }
+        }
+      };
     }
   }
 
   function testActionStarted(actionName, requiredOptions) {
-    ok(actions.called[actionName], actionName + "called");
+    ok(actions.called[actionName], actionName + " called");
     for(var key in requiredOptions) {
       equal(actions.info[actionName][key], requiredOptions[key],
           actionName + " called with " + key + "=" + requiredOptions[key]);
     }
+  }
+
+  function testStagingThrottledRetry(startMessage, expectedStagingAction) {
+    mediator.publish(startMessage, { email: TEST_EMAIL, complete: function() {
+        mediator.publish("password_set");
+        actions.reset();
+
+        mediator.publish("password_set");
+        testActionStarted(expectedStagingAction, { email: TEST_EMAIL });
+        start();
+      }
+    });
   }
 
   function testVerifyStagedAddress(startMessage, verifyScreenAction) {
@@ -149,6 +169,10 @@
     mediator.publish("password_set");
 
     equal(actions.info.doStageUser.email, TEST_EMAIL, "correct email sent to doStageUser");
+  });
+
+  asyncTest("multiple calls to password_set for new_user, simulate throttling - call doStageUser with correct email for each", function() {
+    testStagingThrottledRetry("new_user", "doStageUser");
   });
 
   test("password_set for add secondary email - call doStageEmail with correct email", function() {
@@ -293,6 +317,11 @@
     });
     testActionStarted("doResetPassword", { email: TEST_EMAIL, requiredEmail: true });
   });
+
+  asyncTest("multiple calls to password_set for forgot_password, simulate throttling - call doStageResetPassword with correct email for each", function() {
+    testStagingThrottledRetry("forgot_password", "doStageResetPassword");
+  });
+
 
   asyncTest("reset_password_staged to staged_address_confirmed - call doConfirmResetPassword then doEmailConfirmed", function() {
     testVerifyStagedAddress("reset_password_staged", "doConfirmResetPassword");
@@ -546,6 +575,10 @@
         start();
       }
     });
+  });
+
+  asyncTest("multiple calls to password_set for stage_email, simulate throttling - call doAddEmail with correct email for each", function() {
+    testStagingThrottledRetry("stage_email", "doStageEmail");
   });
 
   test("stage_reverify_email - call doStageReverifyEmail", function() {


### PR DESCRIPTION
issue #2258

To properly test:
- Make sure the user can still hit "enter" after a throttled response for staging a new account, forgot password, and add the first secondary email to a primary only account.

Conflicts:
    resources/static/test/cases/dialog/js/misc/state.js
