### PR TITLE
Adding a deprecation warning for navigator.id.getVerifiedEmail

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1230,6 +1230,7 @@
       },
       // backwards compatibility with old API
       getVerifiedEmail: function(callback) {
+        warn("navigator.id.getVerifiedEmail has been deprecated");
         checkCompat(true);
         navigator.id.get(callback);
       },


### PR DESCRIPTION
issue #1990
