### PR TITLE
Add clear localstorage step to change password test to ensure specific w...

### DIFF
--- a/automation-tests/123done/tests/test_change_password.py
+++ b/automation-tests/123done/tests/test_change_password.py
@@ -44,6 +44,7 @@ class TestChangePassword:
         account_manager.click_password_done()
 
         account_manager.click_sign_out()
+        mozwebqa.selenium.execute_script('localStorage.clear()')
 
         home_pg.go_to_home_page()
 


### PR DESCRIPTION
This step is to clear the browserid artefacts from the localstorage and ensure that for the second login step we will not hit the 'is this your computer' workflow.

This will stabilise slow IE tests that were falling into the 'is this your computer' workflow and failing.
