### PR TITLE
Mark add-email test as expected to fail on IE9. Refs #2265, fixes #2269.

### DIFF
--- a/automation-tests/browserid/tests/check_add_email.py
+++ b/automation-tests/browserid/tests/check_add_email.py
@@ -17,6 +17,9 @@ import restmail
 class TestSignIn(BaseTest):
 
     @pytest.mark.travis
+    @pytest.mark.xfail("config.getvalue('browser_name') == 'internet explorer' \
+                       and int(config.getvalue('browser_version')) == 9", 
+                       reason='IE Local Storage https://github.com/mozilla/browserid/issues/2265')
     def test_add_email(self, mozwebqa):
         user = self.create_verified_user(mozwebqa.selenium, mozwebqa.timeout)
         user.additional_emails.append('%s_1@restmail.net' % user.id)


### PR DESCRIPTION
This change imported from defunct "upstream" repo mozilla/BrowserID-Tests 0e3b76

Once this change is merged over, we'll be up to date with BrowserID-Tests, so it can be obsoleted (and I'll add a note to its README to this effect); next, the tests will be migrated to ci.mozilla.org, and BrowserID-Tests will be deleted.

The essence of the change is that, for IE9, while #2265 is open, we expect a certain test (add secondary email) to fail. We express this by decorating the test with a pytest.xfail decorator.

This diff doesn't map directly over from the BrowserID-Tests repo because the affected test was moved into bidpom without the corresponding 123done test being deleted. I previously deleted that duplicate test (123done/test_add_another_email), so I added the annotation to the surviving version of the test (browserid/check_add_email).
