### PR TITLE
update version.js to run asynchronously and eliminate race conditions in code

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -53,14 +53,13 @@ function renderCachableView(req, res, template, options) {
 
   options.enable_development_menu = config.get('enable_development_menu');
 
-  // The real version number is not ready until sometime after initial load,
-  // until it is ready a fake randomly generated string is used. Go get
-  // the real SHA whenever it is actually needed so that the randomly
-  // generated SHA is not returned to the user.
-  options.commit = version();
+  // Get the SHA associated with this code.
+  version(function(commit) {
+    options.commit = commit;
 
-  res.local('util', util);
-  res.render(template, options);
+    res.local('util', util);
+    res.render(template, options);
+  });
 }
 
 exports.setup = function(app) {

--- a/lib/version.js
+++ b/lib/version.js
@@ -32,11 +32,10 @@ function setSHA(s) {
 if (config.get('env') === 'production') {
   try {
     var contents = fs.readFileSync(path.join(__dirname, '..', 'resources', 'static', 'ver.txt'));
-    sha = contents.toString().split(' ')[0];
-    if (sha.length !== 7) throw "bad sha in ver.txt";
-    setSHA(sha);
+    var reportedSHA = contents.toString().split(' ')[0];
+    if (reportedSHA.length !== 7) throw "bad sha in ver.txt";
+    setSHA(reportedSHA);
   } catch(e) {
-    sha = undefined;
     logger.debug('cannot read code version from ver.txt: ' + e);
   }
 }

--- a/lib/version.js
+++ b/lib/version.js
@@ -15,7 +15,17 @@ spawn = require('child_process').spawn,
 secrets = require('./secrets.js'),
 config = require('./configuration');
 
+// the discovered SHA of the software
 var sha;
+
+// a list of functions that are waiting for the sha to be populated
+var waitingForSha = [];
+
+function setSHA(s) {
+  sha = s;
+  waitingForSha.forEach(function(f) { f(sha); });
+  waitingForSha = [];
+}
 
 // first try ver.txt which by convention is placed in repo root at
 // deployment time
@@ -24,6 +34,7 @@ if (config.get('env') === 'production') {
     var contents = fs.readFileSync(path.join(__dirname, '..', 'resources', 'static', 'ver.txt'));
     sha = contents.toString().split(' ')[0];
     if (sha.length !== 7) throw "bad sha in ver.txt";
+    setSHA(sha);
   } catch(e) {
     sha = undefined;
     logger.debug('cannot read code version from ver.txt: ' + e);
@@ -31,12 +42,13 @@ if (config.get('env') === 'production') {
 }
 
 // now set the SHA to either the read SHA or a random string
-module.exports = function() { return sha; };
+module.exports = function(cb) {
+  if (sha) cb(sha);
+  else waitingForSha.push(cb);
+};
 
 // if ver.txt discovery failed, try using git to get the sha.
 if (!sha) {
-  sha = secrets.weakGenerate(7);
-
   // next try using git
   var p = spawn('git', [ 'log', '--pretty=%h', '-1' ]);
   var buf = "";
@@ -46,10 +58,15 @@ if (!sha) {
   p.stdout.on('end', function() {
     var gitsha = buf.toString().trim();
     if (gitsha && gitsha.length === 7) {
-      sha = gitsha;
-      logger.info('code version (via git) is: ' + module.exports());
+      module.exports(function(theSha) {
+        logger.warn('code version (via git)' + theSha);
+      });
+      setSHA(gitsha);
     } else {
-      logger.warn('code version (randomly generated) is: ' + module.exports());
+      module.exports(function(theSha) {
+        logger.warn('code version (randomly generated) is: ' + theSha);
+      });
+      setSHA(secrets.weakGenerate(7));
     }
   });
 } else {

--- a/lib/wsapi/session_context.js
+++ b/lib/wsapi/session_context.js
@@ -55,7 +55,7 @@ exports.process = function(req, res) {
   var has_password = false;
   var authenticated = false;
 
-  function sendResponse() {
+  function sendResponse(sha) {
     var respObj = {
       csrf_token: req.session.csrf,
       server_time: (new Date()).getTime(),
@@ -67,7 +67,7 @@ exports.process = function(req, res) {
       data_sample_rate: dataSampleRate(req)
     };
     if (config.get('enable_code_version')) {
-      respObj.code_version = version();
+      respObj.code_version = sha;
     }
     if (req.session && req.session.userid) {
       respObj.userid = req.session.userid;
@@ -80,7 +80,7 @@ exports.process = function(req, res) {
   // then we should purge the stored cookie
   if (!wsapi.isAuthed(req, 'assertion')) {
     logger.debug("user is not authenticated");
-    sendResponse();
+    version(sendResponse);
   } else {
     db.userKnown(req.session.userid, function (err, known, hasPassword) {
       if (err) {
@@ -94,7 +94,7 @@ exports.process = function(req, res) {
         has_password = hasPassword;
         authenticated = true;
       }
-      sendResponse();
+      version(sendResponse);
     });
   }
 };

--- a/tests/software-version-test.js
+++ b/tests/software-version-test.js
@@ -19,7 +19,7 @@ suite.options.error = false;
 
 suite.addBatch({
   "version": {
-    topic: function() { return version(); },
+    topic: function() { version(this.callback); },
     "works": function(r) {
       assert.isString(r);
       assert.equal(r.length, 7);


### PR DESCRIPTION
The way that `version.js`, a tiny library to determine the currently running code version, worked made it impossible to reliably determine the software version at startup.  Because it would return a bogus (randomly generated) version until the `git` program could return the actual version, client code would have to wait.  

This improvement makes it possible to write a command line program (or server) that gets the version without any setTimeouts as soon as it is available.

This is motivated by the automation testing work that's ongoing.
