### PR TITLE
longer timeout for sauce jobs

### DIFF
--- a/scripts/run_selenium_test
+++ b/scripts/run_selenium_test
@@ -26,6 +26,7 @@ var globalPythonArgs = {
   "-m": "py.test",
   "--credentials": path.join(testPath, "credentials.yaml"),
   "--saucelabs": path.join(testPath, "sauce.yaml"),
+  "--webqatimeout": 90,
   "--destructive": null
 };
 


### PR DESCRIPTION
i have tested that a longer timeout makes browserid (bidpom) tests less flakey
i have not tested the change to this script, since i have neither node nor apt-get installed, and it's late at night.
i think you should try it.
