### PR TITLE
avoid running tests that require --email

### DIFF
--- a/automation-tests/browserid/tests/check_sign_in.py
+++ b/automation-tests/browserid/tests/check_sign_in.py
@@ -17,6 +17,8 @@ import restmail
 class TestSignIn(BaseTest):
 
     def test_sign_in_helper(self, mozwebqa):
+        if mozwebqa.email == None:
+            pytest.skip("no --email supplied")
         browser_id = BrowserID(mozwebqa.selenium, mozwebqa.timeout)
         browser_id.sign_in(mozwebqa.email, mozwebqa.password)
 
@@ -24,6 +26,8 @@ class TestSignIn(BaseTest):
             lambda s: s.find_element_by_id('loggedin').is_displayed())
 
     def test_sign_in(self, mozwebqa):
+        if mozwebqa.email == None:
+            pytest.skip("no --email supplied")
         from .. pages.sign_in import SignIn
         signin = SignIn(mozwebqa.selenium, mozwebqa.timeout, expect='new')
         signin.email = mozwebqa.email

--- a/automation-tests/run.py
+++ b/automation-tests/run.py
@@ -134,12 +134,15 @@ def main():
         if options.run_everywhere or options.run_all:
             subprocess.call(env_py + ' -m py.test --destructive ' +
                 '--credentials=credentials.yaml ' + sauce + browser + 
+                ' --webqatimeout=90 -m travis' +
                 ' --baseurl=http://' + host + '.123done.org -q browserid', shell=True)
             subprocess.call(env_py + ' -m py.test --destructive ' +
                 '--credentials=credentials.yaml ' + sauce + browser + 
+                ' --webqatimeout=90' +
                 ' --baseurl=http://' + host + '.123done.org -q 123done', shell=True)
             subprocess.call(env_py + ' -m py.test --destructive ' +
                 '--credentials=credentials.yaml ' + sauce + browser + 
+                ' --webqatimeout=90' +
                 ' --baseurl=http://' + host + '.myfavoritebeer.org -q myfavoritebeer', shell=True)
         # only run one test in the default case
         else:


### PR DESCRIPTION
avoiding them in two ways,
- -m travis
- skip if mozwebqa.email == None

also, longer timeouts
