### PR TITLE
Bug #2307: don't expire existing sessions when adding a secondary address

### DIFF
--- a/lib/db/json.js
+++ b/lib/db/json.js
@@ -310,7 +310,7 @@ exports.completeConfirmEmail = function(secret, cb) {
           exports.emailToUID(o.email, function(err, uid) {
             if(err) return cb(err, o.email, o.existing_user);
 
-            exports.updatePassword(uid, hash, true, function(err) {
+            exports.updatePassword(uid, hash, false, function(err) {
               cb(err || null, o.email, o.existing_user);
             });
           });

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -397,7 +397,7 @@ exports.completeConfirmEmail = function(secret, cb) {
     // we're adding or reverifying an email address to an existing user account.  add appropriate
     // entries into email table.
     if (o.passwd) {
-      exports.updatePassword(o.existing_user, o.passwd, true, function(err) {
+      exports.updatePassword(o.existing_user, o.passwd, false, function(err) {
         if (err) return cb('could not set user\'s password');
         addEmailToUser(o.existing_user, o.email, 'secondary', cb);
       });


### PR DESCRIPTION
If a persona.org account is initially created with a "primary"
address (meaning an address served by a participating IdP, so
persona.org is given an assertion from that IdP as proof of ownership),
the new account will not have a password associated with it. If you then
add a "secondary" address (meaning an address _not_ served by a
participating IdP, requiring an email challenge to prove ownership), you
will have to set up a password when you add the secondary. The
establishment of this password should _not_ invalidate any sessions that
were set up earlier.

In Bug #2307, this manifested as the first browser (in which the
add-secondary-email operation was started, so it had the old session and
was waiting for the operation to complete, polling
/wsapi/email_addition_status all the while) receiving a "400
Unauthorized" error when the email challenge link was opened in a second
browser (which thus got a new session).

The test for this effect lives in tests/primary-then-secondary-test.js,
which need the same 2-second delay as password-update-test.js (to make
sure that the modified lastPasswordReset time was actually different
than the previous value, so the session really would be expired).
