### PR TITLE
Retain site<->email associations until a user either explicitly logs out or a new user logs in.

### DIFF
--- a/resources/static/common/js/modules/development.js
+++ b/resources/static/common/js/modules/development.js
@@ -12,6 +12,7 @@ BrowserID.Modules.Development = (function() {
       renderer = bid.Renderer,
       storage = bid.Storage,
       network = bid.Network,
+      xhr = bid.XHR,
       clickCount = 0;
 
 
@@ -29,6 +30,7 @@ BrowserID.Modules.Development = (function() {
         this.click("#clearLocalStorage", clearLocalStorage);
         this.click("#clearEmailsForSites", clearEmailsForSites);
         this.click("#forceIsThisYourComputer", forceIsThisYourComputer);
+        this.click("#expireSession", expireSession);
         this.click("#closeDevelopment", close);
       }
 
@@ -81,6 +83,12 @@ BrowserID.Modules.Development = (function() {
 
   function forceIsThisYourComputer() {
     storage.usersComputer.forceAsk(network.userid());
+  }
+
+  function expireSession() {
+    xhr.post({
+      url: "/wsapi/logout"
+    });
   }
 
   function close() {

--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -49,6 +49,7 @@ BrowserID.Storage = (function() {
     storage.removeItem("emails");
     storage.removeItem("siteInfo");
     storage.removeItem("managePage");
+    storage.removeItem("loggedIn");
     // Ensure there are default values after they are removed.  This is
     // necessary so that IE8's localStorage synchronization issues do not
     // surface.  In IE8, if the dialog page is open when the verification page
@@ -136,6 +137,15 @@ BrowserID.Storage = (function() {
         }
       }
       storage.siteInfo = JSON.stringify(siteInfo);
+
+      // remove any logged in sites associated with this address.
+      var loggedInInfo = JSON.parse(storage.loggedIn || "{}");
+      for(var site in loggedInInfo) {
+        if(loggedInInfo[site] === email) {
+          delete loggedInInfo[site];
+        }
+      }
+      storage.loggedIn = JSON.stringify(loggedInInfo);
     }
     else {
       throw "unknown email address";
@@ -153,6 +163,13 @@ BrowserID.Storage = (function() {
     else {
       throw "unknown email address";
     }
+  }
+
+  function invalidateAllEmails() {
+    var emails = getEmails();
+    _.each(emails, function(emailInfo, emailAddress) {
+      invalidateEmail(emailAddress);
+    });
   }
 
   function setReturnTo(returnToURL) {
@@ -485,8 +502,8 @@ BrowserID.Storage = (function() {
      */
     getEmail: getEmail,
     /**
-     * Remove an email address, its key pairs, and any sites associated with
-     * email address.
+     * Remove an email address, its key pairs, and any loggedIn sites, and any
+     * sites associated with email address.
      * @throws "unknown email address" if email address is not known.
      * @method removeEmail
      */
@@ -497,6 +514,12 @@ BrowserID.Storage = (function() {
      * @method invalidateEmail
      */
     invalidateEmail: invalidateEmail,
+
+    /**
+     * Remove the key information for all email addresses.
+     * @method invalidateAllEmails
+     */
+    invalidateAllEmails: invalidateAllEmails,
 
     site: {
       /**

--- a/resources/static/dialog/views/development.ejs
+++ b/resources/static/dialog/views/development.ejs
@@ -6,6 +6,7 @@
     <li><a id="clearLocalStorage" href="/">Clear localStorage</a></li>
     <li><a id="clearEmailsForSites" href="/">Clear Site&lt;-&gt;Emails</a></li>
     <li><a id="forceIsThisYourComputer" href="/">Force "Is This Your Computer"</a></li>
+    <li><a id="expireSession" href="/">Expire Session</a></li>
     <li><a id="closeDevelopment" href="/">Close</a></li>
 </ul>
 

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -7,6 +7,8 @@
   var bid = BrowserID,
       storage = bid.Storage,
       testHelpers = bid.TestHelpers,
+      createValidatedEmail = testHelpers.createValidatedEmail,
+      testEmailInvalidated = testHelpers.testEmailInvalidated,
       TEST_ORIGIN = "http://test.domain";
 
   module("common/js/storage", {
@@ -18,13 +20,6 @@
       storage.clear();
     }
   });
-
-  function testInvalidatedEmail(address) {
-    var id = storage.getEmail(address);
-    ok(id && !("priv" in id), "private key was removed");
-    ok(id && !("pub" in id), "public key was removed");
-    ok(id && !("cert" in id), "cert was removed");
-  }
 
   test("getEmails, getEmailCount with no emails", function() {
     var emails = storage.getEmails();
@@ -96,10 +91,9 @@
   });
 
   test("invalidateEmail with valid email address", function() {
-    storage.addEmail("testuser@testuser.com", {priv: "key", pub: "pub", cert: "cert"});
-
+    createValidatedEmail("testuser@testuser.com");
     storage.invalidateEmail("testuser@testuser.com");
-    testInvalidatedEmail("testuser@testuser.com");
+    testEmailInvalidated("testuser@testuser.com");
   });
 
   test("invalidateEmail with invalid email address", function() {
@@ -117,13 +111,13 @@
     var emails = ["testuser@testuser.com", "testuser2@testuser.com"];
 
     _.each(emails, function(address) {
-      storage.addPrimaryEmail(address, {priv: "key", pub: "pub", cert: "cert"});
+      createValidatedEmail(address);
     });
 
     storage.invalidateAllEmails();
 
     _.each(emails, function(address) {
-      testInvalidatedEmail(address);
+      testEmailInvalidated(address);
     });
   });
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -343,7 +343,21 @@ BrowserID.TestHelpers = (function() {
     testDocumentNotRedirected: function(doc, msg) {
       equal(doc.location.href, document.location.href, msg || "document not redirected");
 
+    },
+
+    createValidatedEmail: function(address, type) {
+      storage.addEmail(address, {priv: "key", pub: "pub", cert: "cert", type: type || "secondary"});
+
+    },
+
+    testEmailInvalidated: function(address) {
+      var id = storage.getEmail(address);
+      ok(id && !("priv" in id), address + ": private key was removed");
+      ok(id && !("pub" in id), address + ": public key was removed");
+      ok(id && !("cert" in id), address + ": cert was removed");
     }
+
+
   };
 
   return TestHelpers;


### PR DESCRIPTION
- On user.logoutUser, remove all emails, loggedIn emails, and site<->email associations.
- When a user's session expires, invalidate all certs (remove keys) but do not remove the email address.
- Depend on checkAuthenticationAndSync to remove any old email addresses and site associations for users who log out.

issue #1500
