### PR TITLE
many updates to run.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Thumbs.db
 /automation-tests/credentials.yaml
 /automation-tests/sauce.yaml
 automation-tests/persona_server/results/*
+/automation-tests/chromedriver.log

--- a/automation-tests/README.md
+++ b/automation-tests/README.md
@@ -1,7 +1,7 @@
 getting started
 ===============
 
-# I'm super impatient. Let's get going in 10 sec or less.
+# I'm super impatient. Let's get going in 10 sec or less. (But I don't run Windows)
 
 TL;DR: just execute ```./run.py``` from inside the automation-tests directory.
 
@@ -15,7 +15,7 @@ If you want to run that single test against your ephemeral instance called 'foo'
 
 If you want to run all the tests, create a dummy user, put its info in credentials.yaml, then do ```run.py --all``` to run all the tests, including 123done and myfavoritebeer tests.
 
-If you want to run all the tests against all the browsers, using sauce labs credentials, then do ```run.py --everywhere```.
+If you want to run all the tests against all the browsers, using any browsers the script can find locally, then do ```run.py --everywhere```.
 
 # I've got time. Tell me more!
 
@@ -23,7 +23,7 @@ OK, sure...
 
 ## how to run selenium tests inside the automation-tests directory against ephemeral, stage, or prod environments
 
-Node bindings aren't as mature as python for Selenium 2 API (webdriver), so we're using python bindings instead. This requires some python-centric setup, but it shouldn't take more than 15 minutes or so to get up and running.
+Node bindings aren't as mature as python for Selenium 2 API (webdriver), so we're using python bindings instead. This requires some python-centric setup, but it shouldn't take more than 15 minutes or so to get up and running, unless you're running Windows. See the bottom of this page for Windows setup instructions.
 
 These tests currently only hit myfavoritebeers and 123done domains. For example, to test an ephemeral install named foo.personatest.org, you can pass 'foo.123done.org' into the py.test baseurl parameter (this is covered again in the examples section).
 
@@ -113,4 +113,13 @@ TODO: some idioms from the existing test code to help people quickly express "fi
 Refer to [mozilla's pytest_mozwebqa](https://github.com/davehunt/pytest-mozwebqa#writing-tests-for-pytest_mozwebqa) documentation on writing tests for the time being.
 
 A note about upstreaming bidpom changes: this codebase contains [mozilla's bidpom](https://github.com/mozilla/bidpom) as [git-subtree](https://github.com/apenwarr/git-subtree/blob/master/git-subtree.txt). This allows us to pull in changes from upstream, while easily tracking the bidpom code to branches. It's unlikely that we'll need to push or pull to upstream frequently, but for details on doing so, see also apenwarr's [blog post](http://apenwarr.ca/log/?m=200904#30).
+
+## Setting up Python in a Windows Environment
+
+Note: this post talks about python 2.5, but you need to install 2.6 or 2.7, and not 3.x.
+
+http://blog.sadphaeton.com/2009/01/20/python-development-windows-part-1installing-python.html
+http://blog.sadphaeton.com/2009/01/20/python-development-windows-part-2-installing-easyinstallcould-be-easier.html
+
+Alternately, think about running under cygwin instead.
 

--- a/automation-tests/browserid/pages/account_manager.py
+++ b/automation-tests/browserid/pages/account_manager.py
@@ -28,6 +28,8 @@ class AccountManager(Base):
 
     @property
     def signed_in(self):
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: s.execute_script('return jQuery.active == 0'))
         return 'not_authenticated' not in self.selenium.find_element(By.TAG_NAME, 'body').get_attribute('class')
 
     @property

--- a/automation-tests/run.py
+++ b/automation-tests/run.py
@@ -10,8 +10,12 @@ import sys
 # used to check for existence of virtualenv and pip.
 # lifted from: http://stackoverflow.com/questions/377017
 def which(program):
+    if platform.system() == 'Windows':
+        program += '.exe'
+
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
     fpath, fname = os.path.split(program)
     if fpath:
         if is_exe(program):

--- a/automation-tests/run.py
+++ b/automation-tests/run.py
@@ -46,22 +46,12 @@ def main():
                       ' not the full domain name ("foo.123done.org")')
     parser.add_option('--everywhere', '-e', dest='run_everywhere', action='store_true',
                       help='like --all, but run all tests on all supported' +
-                           ' browsers using sauce labs credentials either' +
-                           ' specified in sauce.yaml or in environment' +
-                           ' variables PERSONA_SAUCE_USER, PERSONA_SAUCE_PASSWORD,' +
-                           ' and PERSONA_SAUCE_APIKEY.')
+                           ' browsers available locally.')
     options, arguments = parser.parse_args()
 
-    # you can't specify both --all and --everywhere
-    if options.run_everywhere and options.run_all:
-            sys.stderr.write("either use --all or --everywhere, not both")
-            exit(1)
-
     # 1. check that python is the right version 
-    # TODO: would 2.6 actually work?
-    # it worked for Leah with 2.6, but i didn't necessarily test all the options
-    if sys.version_info < (2,7,0):
-        sys.stderr.write('python 2.7 or later is required to run the tests\n')
+    if sys.version_info < (2,6,0):
+        sys.stderr.write('python 2.6 or later is required to run the tests\n')
         exit(1)
 
     # 2. check that virtualenv and pip exist. if not, bail.
@@ -121,7 +111,7 @@ def main():
         # XXX check to see if opera is installed locally
 
     for browser in browsers:
-        if options.run_everywhere or options.run_all:
+        if options.run_all:
             no_proxy_json = '--capabilities={\"avoid-proxy\":true}'
             subprocess.call(env_py + ' -m py.test --destructive' +
                 ' --credentials=credentials.yaml ' + browser[0] + 

--- a/automation-tests/run.py
+++ b/automation-tests/run.py
@@ -154,7 +154,7 @@ def main():
             ('--platform=VISTA --browsername=chrome  --capabilities=' + no_proxy_json + ' ', 'vista_chrome'),
             ('--platform=VISTA --browsername=firefox --browserver=13  --capabilities=' + no_proxy_json + ' ', 'vista_firefox_13'),
             ('--platform=VISTA --browsername="internet explorer" --browserver=9 ', 'vista_ie_9'),
-            ('--platform=XP    --browsername="internet explorer" --browserver=8 ' 'xp_ie_8'),
+            ('--platform=XP    --browsername="internet explorer" --browserver=8 ', 'xp_ie_8'),
         ]
         sauce = '--saucelabs=sauce.yaml '
     else:


### PR DESCRIPTION
- tell selenium not to use proxy
- reduce restriction to python 2.6
- write out a credentials.yaml file if it doesn't exist
- do not use sauce
- save results to different folders so you end up with all of them rather than just the most recently finished
- make -e run both FF and Chrome
- make 'which' work on windows

Tested on OSX and WinXP
