### PR TITLE
Fix IE failing when authenticating with IdP from main site's /signin

### DIFF
--- a/resources/static/auth_with_idp/main.js
+++ b/resources/static/auth_with_idp/main.js
@@ -7,10 +7,6 @@ var wc = WinChan.onOpen(function(origin, args, cb) {
   else {
     var fullURL = args;
 
-    // store information in window.name to indicate that
-    // we redirect here
-    window.name = 'auth_with_primary';
-
     wc.detach();
     window.location = fullURL;
   }

--- a/resources/static/authentication_api.js
+++ b/resources/static/authentication_api.js
@@ -32,6 +32,10 @@
       setTimeout(function() { cb(email); }, 0);
     };
 
+    // window.name is set when the dialog window is opened. window.name must be
+    // set from window.open and cannot be set from within the dialog or else
+    // it is lost in IE whenever the page redirects to the IdP.
+    // See issue #2287 - https://github.com/mozilla/browserid/issues/2287
     navigator.id.completeAuthentication = function(cb) {
       if (window.name == 'auth_with_primary')
         window.location = 'https://login.persona.org/authenticate_with_primary#complete';

--- a/resources/static/common/js/lib/winchan.js
+++ b/resources/static/common/js/lib/winchan.js
@@ -95,6 +95,7 @@
         if (err) setTimeout(function() { cb(err); }, 0);
 
         // supply default options
+        if (!opts.window_name) opts.window_name = null;
         if (!opts.window_features || isFennec()) opts.window_features = undefined;
 
         // opts.params may be undefined
@@ -124,7 +125,7 @@
           messageTarget = iframe.contentWindow;
         }
 
-        var w = window.open(opts.url, null, opts.window_features);
+        var w = window.open(opts.url, opts.window_name, opts.window_features);
 
         if (!messageTarget) messageTarget = w;
 

--- a/resources/static/pages/js/page_helpers.js
+++ b/resources/static/pages/js/page_helpers.js
@@ -128,6 +128,12 @@ BrowserID.PageHelpers = (function() {
       // This is the relay that will be used when the IdP redirects to sign_in_complete
       relay_url: "https://login.persona.org/relay",
       window_features: "width=700,height=375",
+      // Set the window name from window.open or else IE resets the name to
+      // null whenever the user is redirected to the IdP. Without window.name,
+      // the IdP tries to redirect back to the normal BrowserID dialog and an
+      // exception is thrown.
+      // See issue #2287 - https://github.com/mozilla/browserid/issues/2287
+      window_name: "auth_with_primary",
       params: helpers.toURL(baseURL, {email: email})
     }, function(error, result) {
       // We have to force a reset of the primary caches because the user's


### PR DESCRIPTION
- window.name is used to keep track of where to redirect the user once authentication with the IdP is complete. IE was losing window.name when redirected to the IdP because it was set from within the dialog.
- Set the window.name to auth_with_primary when window.open is called.
- Update WinChan to use the version that allows the setting of window.name

issue #2287
