### PR TITLE
Fix the password being hidden if the user tabbed into the email field without typing any key besides tab.

### DIFF
--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -21,8 +21,7 @@ BrowserID.signIn = (function() {
       verifyEmail,
       verifyURL,
       addressInfo,
-      sc,
-      lastEmail;
+      sc;
 
   function userAuthenticated() {
     pageHelpers.clearStoredEmail();
@@ -168,16 +167,17 @@ BrowserID.signIn = (function() {
 
   function onEmailChange(event) {
     /*jshint validthis: true*/
+    var self=this;
 
     // this is basically a state reset.
     var email = dom.getInner("#email");
-    if(email !== lastEmail) {
+    if(email !== self.lastEmail) {
       dom.removeClass("body", "primary");
       dom.removeClass("body", "known_secondary");
       dom.removeClass("body", "unknown_secondary");
       dom.slideUp(".password_entry, .vpassword_entry, .verify_primary");
-      this.submit = emailSubmit;
-      lastEmail = email;
+      self.submit = emailSubmit;
+      self.lastEmail = email;
     }
   }
 
@@ -189,6 +189,11 @@ BrowserID.signIn = (function() {
       if(options && options.winchan) winchan = options.winchan;
 
       pageHelpers.setupEmail();
+
+      // set up the initial lastEmail so that if the user tabs into the email
+      // field, the password field does not close. See issue #2353.
+      // https://github.com/mozilla/browserid/issues/2353
+      self.lastEmail = dom.getInner("#email");
 
       self.click("#authWithPrimary", authWithPrimary);
       self.bind("#email", "change", onEmailChange);

--- a/resources/static/test/cases/pages/js/signin.js
+++ b/resources/static/test/cases/pages/js/signin.js
@@ -23,6 +23,8 @@
       winchan;
 
   function createController(options) {
+    if (controller) controller.destroy();
+
     winchan = new WinChanMock();
 
     var winMock = new WindowMock();
@@ -101,6 +103,15 @@
         testHasClass("body", "known_secondary", "known_secondary class added to body");
         testDocumentNotRedirected(docMock);
         equal($("#title").html(), "Sign In", "title correctly set");
+
+        // Make sure a tab keyup into the email field does not close the
+        // password field. This simulates a keyup happening into the email
+        // field, which if the user had not yet typed anything into the email
+        // field but the field was filled in because of the stored email, the
+        // password field would be hidden. See issue #2353
+        var e = jQuery.Event("keyup", { keyCode: 9 });
+        $("#email").trigger(e);
+        testHasClass("body", "known_secondary", "known_secondary class still on body");
 
         start();
       }


### PR DESCRIPTION
Steps to test:

1) Open up the /signin page
2) Enter a known secondary email address
3) Reload the page
4) Tab around page until focus lands in email field.
5) If the password field stays displayed, things work as they should.

issue #2353
