### PR TITLE
Change the default language from en-US to en

### DIFF
--- a/config/aws.json
+++ b/config/aws.json
@@ -7,10 +7,10 @@
   "kpi_backend_sample_rate": 1.0,
   // for amazon deployments, enable it-CH which is the trigger language
   // for localization tests db-LB (which is a testing language where chars
-  // are inverted and reversed), and en-US.
+  // are inverted and reversed), and en.
   // This set can be overridden by adding more to config.json on the VM.
   "supported_languages": [
-    "en-US", "it-CH"
+    "en", "it-CH"
   ],
   "debug_lang": "it-CH",
   "var_path": "/home/app/var",

--- a/config/l10n-all.json
+++ b/config/l10n-all.json
@@ -1,6 +1,6 @@
 {
 "supported_languages": [
-    "af", "bg", "ca", "cs", "cy", "da", "db-LB", "de", "el", "en-US",
+    "af", "bg", "ca", "cs", "cy", "da", "db-LB", "de", "el", "en",
     "eo", "es", "et", "eu", "fi", "fr", "fy", "ga", "gd", "gl",
     "he", "hr", "hu", "id", "it", "ja", "ko", "lij", "lt", "ml",
     "nb-NO", "nl", "pa", "pl", "pt", "pt-BR", "rm", "ro", "ru", "si",

--- a/config/l10n-prod.json
+++ b/config/l10n-prod.json
@@ -1,6 +1,6 @@
 {
   "supported_languages": [
-    "af", "bg", "ca", "cs", "cy", "da", "de", "el", "en-US", "eo",
+    "af", "bg", "ca", "cs", "cy", "da", "de", "el", "en", "eo",
     "es", "et", "eu", "fi", "fr", "fy", "ga", "gd", "gl", "he",
     "hr", "hu", "id", "it", "ja", "ko", "lij", "lt", "nb-NO", "nl",
     "pa", "pl", "pt-BR", "rm", "ro", "ru", "sk", "sl", "son", "sq",

--- a/config/production.json
+++ b/config/production.json
@@ -21,7 +21,7 @@
   "max_compute_duration": 10,
   "disable_primary_support": false,
   "enable_code_version": false,
-  "default_lang": "en-US",
+  "default_lang": "en",
   // supported_languages should be overridded with what is appropriate for the
   // deployment.  That is environment dependent:
   //  * in l10 preview env it's all available locales
@@ -29,7 +29,7 @@
   //    testing locales:  "it-CH", "db-LB"
   //  * in production it's reviews locales that have been signed off
   "supported_languages": [
-    "en-US"
+    "en"
   ],
   "debug_lang": "it-CH",
   // locale directory should be overridden

--- a/docs/changes/1863.qa
+++ b/docs/changes/1863.qa
@@ -1,0 +1,4 @@
+The default language is now en instead of en-US. All en-* variants fall back to using en.
+
+Check:
+* If a user has two languages, en-gb and it-ch (in that order), user should see English translations.

--- a/docs/changes/1863.rp
+++ b/docs/changes/1863.rp
@@ -1,0 +1,2 @@
+The default language is now en instead of en-US. All en-* variants fall back to using en. If a user has two languages, en-gb and it-ch (in that order), user should see English translations.
+

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -185,11 +185,11 @@ var conf = module.exports = convict({
     port: 'integer{1,65535}?',
     host: 'string?'
   },
-  default_lang: 'string = "en-US"',
+  default_lang: 'string = "en"',
   debug_lang: 'string = "it-CH"',
   supported_languages: {
     doc: "List of languages this deployment should detect and display localized strings.",
-    format: 'array { string }* = [ "en-US", "it-CH" ]',
+    format: 'array { string }* = [ "en", "it-CH" ]',
     env: 'SUPPORTED_LANGUAGES'
   },
   disable_locale_check: {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -37,16 +37,16 @@ var translations = {};
  *
  * Usage:
   app.use(i18n.abide({
-    supported_languages: ['en-US', 'fr', 'pl'],
-    default_lang: 'en-US',
+    supported_languages: ['en', 'fr', 'pl'],
+    default_lang: 'en',
   }));
  *
  * Other valid options: gettext_alias, ngettext_alias
  */
 exports.abide = function (options) {
   if (! options.gettext_alias)          options.gettext_alias = 'gettext';
-  if (! options.supported_languages)    options.supported_languages = ['en-US'];
-  if (! options.default_lang)           options.default_lang = 'en-US';
+  if (! options.supported_languages)    options.supported_languages = ['en'];
+  if (! options.default_lang)           options.default_lang = 'en';
   if (! options.debug_lang)             options.debug_lang = 'it-CH';
   if (! options.disable_locale_check)   options.disable_locale_check = false;
   if (! options.translation_directory)  options.i18n_json_dir = 'l10n/';
@@ -152,7 +152,7 @@ function qualityCmp(a, b) {
  * }
  */
 var parseAcceptLanguage = exports.parseAcceptLanguage = function (header) {
-    // pl,fr-FR;q=0.3,en-US;q=0.1
+    // pl,fr-FR;q=0.3,en;q=0.1
     if (! header || ! header.split) {
       return [];
     }
@@ -194,7 +194,7 @@ var bestLanguage = exports.bestLanguage = function(languages, supported_language
 /**
  * Given a language code, return a locale code the OS understands.
  *
- * language: en-US
+ * language: en
  * locale:   en_US
  */
 var localeFrom = exports.localeFrom = function (language) {


### PR DESCRIPTION
This involves no changes for the localizers. 

The default language was set to "en" in all of the configuration files. All references to en-US were changed to "en" in supported languages.  en-\* languages will fall back to "en" if an exact match is not made. Unsupported languages fall back to "en" because it is the default language.

issue #1863
