### PR TITLE
Complete registration test fix

### DIFF
--- a/automation-tests/123done/tests/test_change_password.py
+++ b/automation-tests/123done/tests/test_change_password.py
@@ -27,9 +27,8 @@ class TestChangePassword:
         email = inbox.find_by_index(0)
 
         # Load the BrowserID link from the email in the browser
-        mozwebqa.selenium.get(email.verify_user_link)
         from browserid.pages.complete_registration import CompleteRegistration
-        CompleteRegistration(mozwebqa.selenium, mozwebqa.timeout)
+        CompleteRegistration(mozwebqa.selenium, email.verify_user_link)
 
         mozwebqa.selenium.get(mozwebqa.server_base_url)
         from browserid.pages.account_manager import AccountManager

--- a/automation-tests/123done/tests/test_change_password.py
+++ b/automation-tests/123done/tests/test_change_password.py
@@ -28,7 +28,7 @@ class TestChangePassword:
 
         # Load the BrowserID link from the email in the browser
         from browserid.pages.complete_registration import CompleteRegistration
-        CompleteRegistration(mozwebqa.selenium, email.verify_user_link)
+        CompleteRegistration(mozwebqa, email.verify_user_link)
 
         mozwebqa.selenium.get(mozwebqa.server_base_url)
         from browserid.pages.account_manager import AccountManager

--- a/automation-tests/123done/tests/test_new_user.py
+++ b/automation-tests/123done/tests/test_new_user.py
@@ -28,7 +28,7 @@ class TestNewAccount:
 
         # Load the BrowserID link from the email in the browser
         from browserid.pages.complete_registration import CompleteRegistration
-        complete_registration = CompleteRegistration(mozwebqa.selenium, email.verify_user_link)
+        complete_registration = CompleteRegistration(mozwebqa, email.verify_user_link)
 
         home_pg.go_to_home_page()
         Assert.equal(home_pg.logged_in_user_email, user['email'])

--- a/automation-tests/123done/tests/test_new_user.py
+++ b/automation-tests/123done/tests/test_new_user.py
@@ -27,13 +27,8 @@ class TestNewAccount:
         email = inbox.find_by_index(0)
 
         # Load the BrowserID link from the email in the browser
-        mozwebqa.selenium.get(email.verify_user_link)
         from browserid.pages.complete_registration import CompleteRegistration
-        complete_registration = CompleteRegistration(mozwebqa.selenium, mozwebqa.timeout)
-
-        # Check the message on the registration page reflects a successful registration!
-        Assert.contains("Thank you for signing up with Persona.", complete_registration.thank_you)
+        complete_registration = CompleteRegistration(mozwebqa.selenium, email.verify_user_link)
 
         home_pg.go_to_home_page()
-
         Assert.equal(home_pg.logged_in_user_email, user['email'])

--- a/automation-tests/browserid/pages/complete_registration.py
+++ b/automation-tests/browserid/pages/complete_registration.py
@@ -25,7 +25,7 @@ class CompleteRegistration(Base):
         - url - the confirmation url from the email
         - expect - redirect/success/reset/verify (default redirect)
         """
-        Base.__init__(self, mozwebqa)
+        Base.__init__(self, mozwebqa.selenium, mozwebqa.timeout)
         print "the url" + url
         self.selenium.get(url)
 

--- a/automation-tests/browserid/pages/complete_registration.py
+++ b/automation-tests/browserid/pages/complete_registration.py
@@ -12,20 +12,39 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 class CompleteRegistration(Base):
 
+    _page_title = 'Mozilla Persona: Complete Registration'
     _email_locator = (By.ID, 'email')
     _password_locator = (By.ID, 'password')
     _finish_locator = (By.CSS_SELECTOR, 'div.submit > button')
     _thank_you_locator = (By.ID, 'congrats')
 
-    def __init__(self, selenium, timeout, expect='success'):
-        Base.__init__(self, selenium, timeout)
+    def __init__(self, mozwebqa, url, expect='redirect'):
+        """
+        class init method
+        :Args:
+        - url - the confirmation url from the email
+        - expect - redirect/success/reset/verify (default redirect)
+        """
+        Base.__init__(self, mozwebqa)
+        print "the url" + url
+        self.selenium.get(url)
 
-        if expect == 'success':
+        if expect == 'redirect':
             WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: s.find_element(*self._thank_you_locator).is_displayed())
+                lambda s: s.title != self._page_title,
+                "Complete Registration page did not redirect")
+        elif expect == 'success':
+            WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: 'Thank you' in s.find_element(*self._thank_you_locator).text,
+                "Complete Registration did not succeed")
+        elif expect == 'reset':
+            WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: 'verified' in s.find_element(*self._thank_you_locator).text,
+                "Complete Registration did not succeed")
         elif expect == 'verify':
             WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: s.find_element(*self._password_locator).is_displayed())
+                lambda s: s.find_element(*self._password_locator).is_displayed(),
+                "password field did not become visible")
         else:
             raise Exception('Unknown expect value: %s' % expect)
 

--- a/automation-tests/run_saucelabs
+++ b/automation-tests/run_saucelabs
@@ -42,6 +42,7 @@ var globalPythonArgs = {
   "--saucelabs": sauceYAMLPath,
   "--webqatimeout": 90,
   "--destructive": null,
+  "-n": 5,
   "-q": null,
   '--capabilities': JSON.stringify({ "avoid-proxy":"true"})
 };


### PR DESCRIPTION
This should fix the most prominent failure in our unit tests which arises on many of our VMS, usually the slower ones.  

The problem was that we were trying to test the registration landing page when verifying an email that was staged via 123done.  Because the landing page redirects after ~5 seconds, we were doing a WebDriverWait with a non-automic test case.  That test case would often (reproducibly > 50% of the time on osx/ffx saucelabs vm) fetch an element before page redirect, and try to extract the textual contents of that element after page redirect.

Now we wait for the redirect to occur which alleviates the timing issues.  

In order to fix this I selectively merged some of @klrmn's fixes to the complete_registration bit of bidpom.  

While some tests might be broken by this bidpom change, all we care about right now is 123done tests.
