### PR TITLE
Add note-to-ourselves re: onready's deprecation

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1040,6 +1040,7 @@
               commChan.call({
                 method: 'loaded',
                 success: function(){
+                  // NOTE: Do not modify without reading GH-2017
                   if (observers.ready) observers.ready();
                 }, error: function() {
                 }
@@ -1114,6 +1115,7 @@
 
       observers.login = options.onlogin || null;
       observers.logout = options.onlogout || null;
+      // NOTE: Do not modify without reading GH-2017
       observers.ready = options.onready || null;
 
       // back compat support for loggedInEmail


### PR DESCRIPTION
onready is in a weird state of limbo: we know we're going to deprecate it, we
know what we're going to replace it with, and we know we want to discourage its
use for the moment, but we haven't actually planned, implemented, or announced
its replacement.

We haven't announced its deprecation, either.

Adding two small comments in-code to ensure that we don't inadvertantly remove
this without giving RPs proper notice. After all, if onready stops firing, we
seriously break sites that rely on it.

See GH-2017 for more info.
