### PR TITLE
If there is no saved site info in localStorage, redirect to the management page after verification is complete.

### DIFF
--- a/resources/static/pages/js/verify_secondary_address.js
+++ b/resources/static/pages/js/verify_secondary_address.js
@@ -31,11 +31,12 @@ BrowserID.verifySecondaryAddress = (function() {
 
   function showRegistrationInfo(info) {
     dom.setInner("#email", info.email);
+    dom.setInner(".website", redirectTo);
+
+    if (uiTimeoutID) uiTimeoutID = clearTimeout(uiTimeoutID);
+    updateRedirectTimeout();
 
     if (info.returnTo) {
-      dom.setInner(".website", info.returnTo);
-      if (uiTimeoutID) uiTimeoutID = clearTimeout(uiTimeoutID);
-      updateRedirectTimeout();
       dom.show(".siteinfo");
     }
   }
@@ -70,22 +71,17 @@ BrowserID.verifySecondaryAddress = (function() {
 
         if (verified) {
           pageHelpers.replaceFormWithNotice("#congrats", function() {
-            if (redirectTo) {
-              // set the loggedIn status for the site.  This allows us to get
-              // a silent assertion without relying on the dialog to set the
-              // loggedIn status for the domain.  This is useful when the user
-              // closes the dialog OR if redirection happens before the dialog
-              // has had a chance to finish its business.
-              storage.setLoggedIn(URLParse(redirectTo).originOnly(), email);
+            // set the loggedIn status for the site.  This allows us to get
+            // a silent assertion without relying on the dialog to set the
+            // loggedIn status for the domain.  This is useful when the user
+            // closes the dialog OR if redirection happens before the dialog
+            // has had a chance to finish its business.
+            storage.setLoggedIn(URLParse(redirectTo).originOnly(), email);
 
-              countdownTimeout(function() {
-                doc.location.href = redirectTo;
-                complete(oncomplete, verified);
-              });
-            }
-            else {
+            countdownTimeout(function() {
+              doc.location = redirectTo;
               complete(oncomplete, verified);
-            }
+            });
           });
         }
         else {
@@ -111,7 +107,7 @@ BrowserID.verifySecondaryAddress = (function() {
     var self=this;
     user.tokenInfo(token, function(info) {
       if (info) {
-        redirectTo = info.returnTo;
+        redirectTo = info.returnTo || "https://login.persona.org/";
         email = info.email;
         showRegistrationInfo(info);
         mustAuth = info.must_auth;

--- a/resources/static/test/cases/pages/js/verify_secondary_address.js
+++ b/resources/static/test/cases/pages/js/verify_secondary_address.js
@@ -15,6 +15,9 @@
       testHelpers = bid.TestHelpers,
       testHasClass = testHelpers.testHasClass,
       testVisible = testHelpers.testVisible,
+      testNotVisible = testHelpers.testNotVisible,
+      testElementTextEquals = testHelpers.testElementTextEquals,
+      testDocumentRedirected = testHelpers.testDocumentRedirected,
       validToken = true,
       controller,
       config = {
@@ -77,25 +80,28 @@
     equal(error, "missing config option: token", "correct error thrown");
   });
 
-  asyncTest("valid token, no password necessary - verify user and show site info", function() {
+  asyncTest("valid token, no password necessary - verify user and show site info, user is redirected to saved URL", function() {
     var returnTo = "https://test.domain/path";
     storage.setReturnTo(returnTo);
 
     createController(config, function() {
       testVisible("#congrats");
       testHasClass("body", "complete");
-      equal($(".website").eq(0).text(), returnTo, "website is updated");
-      equal(doc.location.href, returnTo, "redirection occurred to correct URL");
+      testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
+      testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
       equal(storage.getLoggedIn("https://test.domain"), "testuser@testuser.com", "logged in status set");
       start();
     });
   });
 
-  asyncTest("valid token, no password necessary, no saved site info - verify user but do not show site info", function() {
+  asyncTest("valid token, no password necessary, no saved site info - verify user, user is redirected to login.persona.org", function() {
+    var returnTo = "https://login.persona.org/";
+
     createController(config, function() {
       testEmail();
-      equal($(".siteinfo").is(":visible"), false, "siteinfo is not visible without having it");
-      equal($(".siteinfo .website").text(), "", "origin is not updated");
+      testNotVisible(".siteinfo", "siteinfo is not visible without having it");
+      testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
+      testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
       start();
     });
   });

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -330,6 +330,11 @@ BrowserID.TestHelpers = (function() {
       }
     },
 
+    testElementTextEquals: function(selector, expected, msg) {
+      equal($(selector).eq(0).text(), expected, msg || (selector + " text is: " + expected));
+
+    },
+
     testEmailMarkedVerified: function(email, msg) {
       var emailInfo = storage.getEmail(email);
       equal(emailInfo && emailInfo.verified, true,

--- a/resources/views/confirm.ejs
+++ b/resources/views/confirm.ejs
@@ -42,11 +42,11 @@
               <%- gettext('<strong class="email">Your address</strong> has been verified!') %>
             </p>
 
-            <p class="siteinfo">
+            <p>
               <%- format(gettext('Your new address is set up and ready to go. You will be redirected to %s'), ["<strong class='website'></strong>"]) %>
             </p>
 
-            <p id="redirection" class="siteinfo">
+            <p id="redirection">
               <%- format(gettext("Redirecting in %s seconds"), ["<span id='redirectTimeout'></span>" ]) %>
             </p>
         </div>

--- a/resources/views/verify_email_address.ejs
+++ b/resources/views/verify_email_address.ejs
@@ -41,11 +41,11 @@
             <p><%- gettext('Thank you for signing up with <strong>Persona</strong>. You can now use your Persona account to <em>Sign In</em> or <em>Sign Up</em> to websites all across the web!') %>
             </p>
 
-            <p class="siteinfo">
+            <p>
               <%- format(gettext('Your new address is set up and ready to go. You will be redirected to %s'), ["<strong class='website'></strong>"]) %>
             </p>
 
-            <p id="redirection" class="siteinfo">
+            <p id="redirection">
               <%- format(gettext("Redirecting in %s seconds"), ["<span id='redirectTimeout'></span>" ]) %>
             </p>
         </div>


### PR DESCRIPTION
This makes it so the user is always redirected _somewhere_ after verification.
- If the user is verifying in the same browser as they started and started at an RP, the user will be redirected to the RP.
- If the user is verifying in the same browser as they started and started at Persona, the user will be redirected to Persona's management page.
- If the user is verifying in a different browser than they started at, the user will be redirected to Persona's management page.

issue #2388
