### PR TITLE
change loggedInUser to == instead of ===

### DIFF
--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -58,7 +58,7 @@
         // the resources or cost required to generate an assertion
         if (assertion) chan.notify({ method: 'login', params: assertion });
         loggedInUser = email;
-      } else if (loggedInUser !== null) {
+      } else if (loggedInUser != null) {
         // only send logout events when loggedInUser is not null, which is an
         // indicator that the site thinks the user is logged out
         chan.notify({ method: 'logout' });


### PR DESCRIPTION
loggedInUser starts as undefined, and later can become a real value, or be set explicitly to null. So, when checking if there is a loggedInUser, we must allow either undefined or null to match.

This would trigger an initial onlogout event, immediately, since it's first set to undefined, and then checked for null.

Unless this as by design? If so, we should add to the comment that this has been considered.
