### PR TITLE
attempt to fix window switch / close errors

### DIFF
--- a/automation-tests/browserid/pages/sign_in.py
+++ b/automation-tests/browserid/pages/sign_in.py
@@ -35,6 +35,9 @@ class SignIn(Base):
     def __init__(self, selenium, timeout, expect='new'):
         Base.__init__(self, selenium, timeout)
 
+        # wait for second window to open
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: s.window_handles > 1)
         selenium.switch_to_window('__persona_dialog')
 
         if expect == 'new':
@@ -50,7 +53,11 @@ class SignIn(Base):
             raise Exception('Unknown expect value: %s' % expect)
 
     def close_window(self):
-        self.selenium.close()
+        try:  # race condition with window closing by itself
+            self.selenium.close()
+        except:
+            # if it fails, the framework will capture a screenshot
+            pass
 
     @property
     def signed_in_email(self):


### PR DESCRIPTION
this has been tested against WinXP IE8, but will have to be merged to find out whether it reduces the number of failures on ci

3 occasions of 2 sporadic failures in ci logs as of 5pm friday

seen at
https://ci.mozilla.org/view/Persona/job/identity.browserid.dev.windows.xp.ie.8/1315/testReport/junit/123done.tests.test_new_user/TestNewAccount/test_can_create_new_user_account

self = <browserid.pages.sign_in.SignIn object at 0x188cf10>

```
def close_window(self):
```

> ```
>   self.selenium.close()
> ```

browserid/pages/sign_in.py:53:

E       WebDriverException: Message: u'ERROR Internal Server Error'

---

seen at
https://ci.mozilla.org/view/Persona/job/identity.browserid.dev.windows.7.ie.9/1324/testReport/junit/123done.tests.test_sign_in/TestSignIn/test_that_user_can_sign_in/

https://ci.mozilla.org/view/Persona/job/identity.browserid.dev.windows.7.ie.9/1313/testReport/junit/123done.tests.test_change_password/TestChangePassword/test_can_change_user_password/

self = <browserid.pages.sign_in.SignIn object at 0x2a3ff10>
selenium = <selenium.webdriver.remote.webdriver.WebDriver object at
0x29b9bd0>
timeout = 90, expect = 'new'

```
def __init__(self, selenium, timeout, expect='new'):
    Base.__init__(self, selenium, timeout)
```

> ```
>   selenium.switch_to_window('__persona_dialog')
> ```

browserid/pages/sign_in.py:38:

E       NoSuchWindowException: Message: u"No window found
