### PR TITLE
removing gobbledygook symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /resources/static/production
 /resources/static/i18n
 /resources/static/common/js/lib/bidbundle.js
+/resources/static/common/js/lib/gobbledygook.js
 /resources/static/dialog/views/site
 .DS_Store
 Thumbs.db

--- a/resources/static/common/js/lib/gobbledygook.js
+++ b/resources/static/common/js/lib/gobbledygook.js
@@ -1,1 +1,0 @@
-../../../../../node_modules/gobbledygook/gobbledygook.js

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,3 +1,4 @@
+"use strict";
 // make symlinks
 var fs = require('fs');
 var path = require('path');
@@ -28,6 +29,7 @@ function copy(src, dest) {
 }
 
 copy('../node_modules/jwcrypto/bidbundle.js', '../resources/static/common/js/lib/bidbundle.js');
+copy('../node_modules/gobbledygook/gobbledygook.js', '../resources/static/common/js/lib/gobbledygook.js');
 
 
 // generate ephemeral keys


### PR DESCRIPTION
symlink no worky on Windows, so make a copy
at postinstall instead
