### PR TITLE
fixupAbsolutePath: filter out scheme-relative URLs

### DIFF
--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -83,7 +83,7 @@ BrowserID.Modules.Dialog = (function() {
     if (typeof(url) !== "string")
       throw "urls must be strings: (" + url + ")";
     if (/^http(s)?:\/\//.test(url)) u = URLParse(url);
-    else if (/^\//.test(url)) u = URLParse(origin + url);
+    else if (/^\/[^\/]/.test(url)) u = URLParse(origin + url);
     else throw "relative urls not allowed: (" + url + ")";
     // encodeURI limits our return value to [a-z0-9:/?%], excluding <script>
     var encodedURI = encodeURI(u.validate().normalize().toString());
@@ -105,7 +105,8 @@ BrowserID.Modules.Dialog = (function() {
   }
 
   function fixupAbsolutePath(origin_url, path) {
-    if (/^\//.test(path))  return fixupURL(origin_url, path);
+    // Ensure URL is an absolute path (not a relative path or a scheme-relative URL)
+    if (/^\/[^\/]/.test(path))  return fixupURL(origin_url, path);
 
     throw "must be an absolute path: (" + path + ")";
   }

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -614,6 +614,23 @@
     });
   });
 
+  asyncTest("get with a scheme-relative siteLogo URL - not allowed", function() {
+    createController({
+      ready: function() {
+        mediator.subscribe("start", function(msg, info) {
+          ok(false, "start should not have been called");
+        });
+
+        var retval = controller.get(HTTPS_TEST_DOMAIN, {
+          siteLogo: "//example.com/image.png"
+        });
+
+        equal(retval, "must be an absolute path: (//example.com/image.png)", "expected error");
+        testErrorVisible();
+        start();
+      }
+    });
+  });
 
   asyncTest("get with returnTo with https - not allowed", function() {
     createController({
@@ -629,6 +646,24 @@
         });
 
         equal(retval, "must be an absolute path: (" + URL + ")", "expected error");
+        testErrorVisible();
+        start();
+      }
+    });
+  });
+
+  asyncTest("get with a scheme-relative returnTo URL - not allowed", function() {
+    createController({
+      ready: function() {
+        mediator.subscribe("start", function(msg, info) {
+          ok(false, "unexpected start");
+        });
+
+        var retval = controller.get(HTTP_TEST_DOMAIN, {
+          returnTo: '//example.com/return'
+        });
+
+        equal(retval, "must be an absolute path: (//example.com/return)", "expected error");
         testErrorVisible();
         start();
       }


### PR DESCRIPTION
The [current check](https://github.com/mozilla/browserid/blob/dev/resources/static/dialog/js/modules/dialog.js#L108) to ensure that only absolute paths are accepted fails to take into account scheme-relative URLs like `//foo.com`.

These URLs end up in `fixupURL` and [get the origin prepended to them](https://github.com/mozilla/browserid/blob/dev/resources/static/dialog/js/modules/dialog.js#L86) to something like `https://origin.example.com//foo.com`, which is invalid but still follows our same-origin restrictions.

So the solution is to require that the character after the leading slash be anything but a slash.
