### PR TITLE
Fix IE8 showing the red line on the signin page.

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-noscript {
+#noscript-warning {
+  position: absolute;
   position: fixed;
   display: block;
   background-color: #ef1010;

--- a/resources/views/partial/noscript-warning.ejs
+++ b/resources/views/partial/noscript-warning.ejs
@@ -1,0 +1,9 @@
+<noscript>
+  <!-- IE8 has a rendering bug with noscript tags, content must be placed
+       inside of another element to be styled -->
+  <p id="noscript-warning">
+    <%- gettext('We\'re sorry, Persona requires that Javascript is enabled.') %>
+  </p>
+</noscript>
+
+

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -113,7 +113,5 @@
     </div>
 </div>
 
-<noscript>
-  <%- gettext('We\'re sorry, Persona requires that Javascript is enabled.') %>
-</noscript>
+<%- partial('partial/noscript-warning') %>
 


### PR DESCRIPTION
IE8 has a rendering bug with the noscript tag, see http://stackoverflow.com/questions/2912175/noscript-tag-appears-even-if-javascript-is-turned-on-in-ie8

Placing the noscript contents inside of another tag that can be styled correctly in IE8

issue #1566
