### PR TITLE
Hides edit_password_form from screen readers when visually hidden

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -311,6 +311,7 @@ button.delete:active {
 .showedit {
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
   opacity: 0;
+  visibility:hidden;
   -webkit-transition: all 500ms;
   -moz-transition: all 500ms;
   -ms-transition: all 500ms;
@@ -321,6 +322,7 @@ button.delete:active {
 .edit .showedit {
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
   opacity: 1;
+  visibility:visible;
 }
 
 #disclaimer {


### PR DESCRIPTION
When `opacity:0;` is used to hide elements AT still sees/read them, you need to use `visibility:hidden` OR `display:none;` to hide them for AT.
