### PR TITLE
Corrects the source order on the label/input password fields

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -304,10 +304,6 @@ button.delete:active {
   display: inline-block;
 }
 
-#edit_password input[type=password] {
-  width: 40%;
-}
-
 .showedit {
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
   opacity: 0;
@@ -321,6 +317,10 @@ button.delete:active {
 .edit .showedit {
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
   opacity: 1;
+}
+
+#changePassword{
+	margin-top:21px;
 }
 
 #disclaimer {

--- a/resources/views/index.ejs
+++ b/resources/views/index.ejs
@@ -60,14 +60,13 @@
                 <button class="done"><%- gettext('cancel') %></button>
               </header>
 
-              <div class="showedit">
-                <label for="old_password"><%- gettext('Old Password') %></label>
-                <label for="new_password"><%- gettext('New Password') %></label>
-              </div>
-
               <form id="edit_password_form" class="showedit">
-                <input type="password" id="old_password" name="old_password" maxlength="80"/>
-                <input type="password" id="new_password" name="new_password" maxlength="80"/>
+                <label for="old_password"><%- gettext('Old Password') %><br>
+                  <input type="password" id="old_password" name="old_password" maxlength="80"/>
+                </label>
+                <label for="new_password"><%- gettext('New Password') %><br>
+                  <input type="password" id="new_password" name="new_password" maxlength="80"/>
+                </label>
                 <button id="changePassword"><%- gettext('done') %></button>
 
                 <div class="tooltip" for="old_password" id="tooltipOldRequired"><%- gettext('Old password is required.') %></div>


### PR DESCRIPTION
The order of labels and input password fields are not optimal right now. If using a screenreader the output becomes

`label old password`
`label new password`
`input old password`
`input new password` 

which is confusing.

This pullrequest fixes so that the labels are more connected to the corresponding input field.
