### PR TITLE
fixes for testsetup, etc.

### DIFF
--- a/automation-tests/lib/restmail.js
+++ b/automation-tests/lib/restmail.js
@@ -13,6 +13,9 @@ exports.randomEmail = function(chars, domain) {
     str += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
   }
 
+  // Until GH-2551 is fixed, use lowercase alphanum for email
+  str = str.toLowerCase();
+
   return str + '@' + (domain ? domain : 'restmail.net');
 };
 

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -1,8 +1,9 @@
 const
 personatestuser = require('../lib/personatestuser.js'),
-restmail = require('../lib/restmail.js');
+restmail = require('../lib/restmail.js'),
 saucePlatforms = require('./sauce-platforms.js'),
-wd = require('wd');
+wd = require('wd'),
+_ = require('underscore');
 
 require('./wd-extensions.js');
 
@@ -20,11 +21,10 @@ var testSetup = {};
 //  - desiredCapabilities (see json wire protocol for list of capabilities)
 // env var equivalents are PERSONA_BROWSER and PERSONA_BROWSER_CAPABILITIES
 testSetup.startup = function(opts) {
-
+  opts = opts || {};
   _setSessionOpts(opts);
 
-  var opts = opts || {},
-    sauceUser = opts.sauceUser || process.env['PERSONA_SAUCE_USER'],
+  var sauceUser = opts.sauceUser || process.env['PERSONA_SAUCE_USER'],
     sauceApiKey = opts.sauceApiKey || process.env['PERSONA_SAUCE_APIKEY'],
     browser;
 
@@ -49,36 +49,27 @@ testSetup.browsers = []
 // these session opts aren't needed until the user requests a session via newSession()
 // but we harvest them from the command line at startup time
 function _setSessionOpts(opts) {
-  var sessionOpts = {},
-    opts = opts || {};
+  opts = opts || {};
+  var sessionOpts = {};
 
   // check for typos: throw error if requestedPlatform not found in list of supported sauce platforms
   var requestedPlatform = opts.platform || process.env['PERSONA_BROWSER'];
   if (requestedPlatform && !saucePlatforms.platforms[requestedPlatform]) {
-    cb(new Error('requested platform ' + requestedPlatform + ' not found in list of available platforms'))
+    throw new Error('requested platform ' + requestedPlatform + 
+                    ' not found in list of available platforms');
   }
-  var platform = requestedPlatform ? saucePlatforms.platforms[requestedPlatform] : '';
+  var platform = requestedPlatform ? saucePlatforms.platforms[requestedPlatform] : {};
 
   // add platform, browserName, version to session opts
-  for (var opt in platform) { sessionOpts[opt] = platform[opt] }
+  sessionOpts = _.extend(sessionOpts, platform);
 
   // pull the default desired capabilities out of the sauce-platforms file
   // overwrite if specified by user
   var desiredCapabilities = opts.desiredCapabilities || process.env['PERSONA_BROWSER_CAPABILITIES'] || {};
-  for (var opt in saucePlatforms.defaultCapabilities) { sessionOpts[opt] = saucePlatforms.defaultCapabilities[opt] }
-  for (var opt in desiredCapabilities) { sessionOpts[opt] = desiredCapabilities[opt] }
+  sessionOpts = _.extend(sessionOpts, saucePlatforms.defaultCapabilities);
+  sessionOpts = _.extend(sessionOpts, desiredCapabilities);
 
   testSetup.sessionOpts = sessionOpts;
-}
-
-// override testSetup.sessionOpts with opts, if set
-testSetup.mergeOpts = function(opts) {
-  var capabilities = {};
-  if (opts) {
-    for (var o in testSetup.sessionOpts) { capabilities[o] = testSetup.sessionOpts[o]; }
-    for (var o in opts) { capabilities[o] = opts[o]; }
-  }
-  return capabilities;
 }
 
 // opts could be of the form:

--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -34,8 +34,12 @@ wd.prototype.waitForDisplayed = function(opts, cb) {
 };
  
 // allocate a new browser session and sets implicit wait timeout
-wd.prototype.newSession = function(cb, opts) {
-  browser = this;
+wd.prototype.newSession = function(opts, cb) {
+  var browser = this;
+  if (typeof opts === 'function') {
+    cb = opts;
+    opts = {};
+  }
 
   browser.init(opts, function(err) {
     if (err) return cb(err);
@@ -58,6 +62,8 @@ wd.prototype.newSession = function(cb, opts) {
 wd.prototype.waitForWindow = function(opts, cb) {
   if (typeof opts == 'string') opts = { name: opts };
   if (!opts.name) throw "waitForWindow missing window `name`";
+  var browser = this;
+
   setTimeouts(opts);
   utils.waitFor(opts.poll, opts.timeout, function(done) {
     browser.window(opts.name, function(err) {

--- a/automation-tests/package.json
+++ b/automation-tests/package.json
@@ -7,6 +7,7 @@
     "vows": "*",
     "wd": "*",
     "request": "*",
-    "optimist": "*"
+    "optimist": "*",
+    "underscore": "*"
   }
 }

--- a/automation-tests/tests/change-password-test.js
+++ b/automation-tests/tests/change-password-test.js
@@ -23,7 +23,8 @@ var testSetup = require('../lib/test-setup.js'),
   testUser;
 
 vowsHarness({
-  "create a new selenium session": function(done) { browser.newSession(testSetup.sessionOpts, done);
+  "create a new selenium session": function(done) {
+    browser.newSession(testSetup.sessionOpts, done);
   },
   "create a new personatestuser": function(done) {
     personatestuser.getVerifiedUser(function(err, user, blob) {

--- a/automation-tests/tests/new-user/new-user-primary-test.js
+++ b/automation-tests/tests/new-user/new-user-primary-test.js
@@ -30,6 +30,7 @@ function dialogEyedeemeFlow(b, email, cb) {
     .wtype(CSS['dialog'].emailInput, email)
     .wclick(CSS['dialog'].newEmailNextButton)
     .wclick(CSS['dialog'].verifyWithPrimaryButton)
+    .wclick(CSS['dialog'].verifyWithPrimaryButton) //XXX Why do we need to click twice?
     .wtype(CSS['eyedee.me'].newPassword, email.split('@')[0])
     .wclick(CSS['eyedee.me'].createAccountButton, cb);
 }


### PR DESCRIPTION
- fix the backward order of arguments to wd.prototype.newSession. (We weren't
  actually running any browser but the default FF/Vista one as a result. Now
  that we are trying to run Windows, we don't seem to be able to. But that's
  next to fix.)
- fix some accidental globals and shadows
- use underscore.extend to reduce boilerplate
- remove unused testSetup.mergeOpts method
- node-inspector doesn't like one-liner functions
