### PR TITLE
adds ability to adjust KPI rate base on User Agent

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -143,6 +143,11 @@ var conf = module.exports = convict({
     format: 'string = "http://localhost/wsapi/interaction_data"',
     env: 'KPI_BACKEND_DB_URL'
   },
+  kpi_backend_sample_rate_per_agent: {
+    doc: "A mapping of User Agent matches that have different rates than standard.",
+    format: 'object { } * = {}',
+    env: 'KPI_SAMPLE_AGENTS' // JSON text, i.e. { "Firefox OS": 0.7 }
+  },
   bcrypt_work_factor: {
     doc: "How expensive should we make password checks (to mitigate brute force attacks) ?  Each increment is 2x the cost.",
     format: 'integer{6,20} = 12',

--- a/lib/http_forward.js
+++ b/lib/http_forward.js
@@ -41,6 +41,7 @@ exports.forward = function(dest, req, res, cb) {
     port: u.port,
     path: u.path,
     method: req.method,
+    headers: req.headers,
     agent: false
   }, function(pres) {
 

--- a/lib/wsapi/session_context.js
+++ b/lib/wsapi/session_context.js
@@ -24,6 +24,21 @@ exports.i18n = false;
 const domainKeyCreationDate = secrets.publicKeyCreationDate();
 logger.debug("domain key was created at " + domainKeyCreationDate + " (certs issued prior to this are bogus)");
 
+function dataSampleRate(req) {
+  var ua = req.headers['user-agent'];
+  var rate = config.get('kpi_backend_sample_rate');
+  var per_agent_map = config.get('kpi_backend_sample_rate_per_agent');
+
+  for (var agent in per_agent_map) {
+    if (ua.match(agent)) {
+      rate = per_agent_map[agent];
+      break;
+    }
+  }
+
+  return rate;
+}
+
 exports.process = function(req, res) {
   if (typeof req.session == 'undefined') {
     req.session = {};
@@ -47,7 +62,7 @@ exports.process = function(req, res) {
       auth_level: auth_level,
       domain_key_creation_time: domainKeyCreationDate.getTime(),
       random_seed: crypto.randomBytes(32).toString('base64'),
-      data_sample_rate: config.get('kpi_backend_sample_rate')
+      data_sample_rate: dataSampleRate(req)
     };
     if (config.get('enable_code_version')) {
       respObj.code_version = version();


### PR DESCRIPTION
In config, we can do something like this:

``` js
"kpi_backend_sample_rate_per_agent": {
  "Firefox/19.0": 0.4
}
```

To check the UA string for Firefox 19, and give it a 40 percent rate.

/cc @jedp, since you filed the initial bug

fixes #1931
