### PR TITLE
Fix issues with internal.get API

### DIFF
--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -67,7 +67,10 @@
       callback && callback(assertion || null);
     }
 
-    options = options || {};
+    // Make our own copy, since we assign properties to it.
+    // There was an error doing that in B2G, since we got a
+    // WrappsJSObject.
+    options = _.extend({}, options);
 
     var silent = !!options.silent;
     if(silent) {

--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -85,16 +85,24 @@
     else {
       // Use the standard dialog facilities to get the assertion, pass the
       // options block directly to the dialog.
-      var controller = moduleManager.getRunningModule("dialog");
-      if(controller) {
-        options.rp_api = "internal";
-        controller.get(origin, options, complete, complete);
-      }
-      else {
-        complete();
-      }
+      options.rp_api = "internal";
+      get(origin, options, complete);
     }
   };
+
+  function get(origin, options, complete) {
+    var args = arguments;
+    var controller;
+    try {
+      controller = moduleManager.getRunningModule("dialog");
+    } catch (noModule) {
+      return setTimeout(function _get_wait() {
+        get.apply(null, args);
+      }, 50);
+    }
+
+    controller.get(origin, options, complete, complete);
+  }
 
   /*
    * Get an assertion without user interaction - internal use


### PR DESCRIPTION
1. On a slower domain, like an awsbox, there was a timing issue. They didn't know when it was safe to call `internal.get`, since the `dialog` was not ready until after the `session_context` returned from the cookie check.
2. B2G was passing in a `WrappedJSObect` for options, which we then tried to append some properties to as defaults. This caused permission errors, so now we create a local copy using `_.extend()`.

@shane-tomlinson Feel free to tell me that the polling is dirty (it feels a bit dirty), but these commits are currently on https://b2g.personatest.org and working for them.

fixes #2580
