### PR TITLE
only set 'proxy = { proxyType: 'direct' }' for Opera. IE doesn't like it. And add a 'persona' tag to the job

### DIFF
--- a/automation-tests/lib/sauce-platforms.js
+++ b/automation-tests/lib/sauce-platforms.js
@@ -38,8 +38,7 @@ const platforms = {
 
 const defaultCapabilities = {
   avoidProxy: true,
-  proxy: { proxyType: 'direct' } //TODO reportedly works for opera; investigate
-}
+};
 
 exports.platforms = platforms;
 exports.defaultCapabilities = defaultCapabilities;

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -71,6 +71,17 @@ function _setSessionOpts(opts) {
   _.extend(sessionOpts, saucePlatforms.defaultCapabilities);
   _.extend(sessionOpts, desiredCapabilities);
 
+  if (sessionOpts.browserName === 'opera' && !sessionOpts.proxy) {
+    // TODO reportedly works for opera; investigate
+    sessionOpts.proxy = { proxyType: 'direct' };
+  }
+
+  // Ensure there is a tag for 'persona'
+  sessionOpts.tags = sessionOpts.tags || [];
+  if (sessionOpts.tags.indexOf('persona') === -1) {
+    sessionOpts.tags.push('persona');
+  }
+
   testSetup.sessionOpts = sessionOpts;
 }
 


### PR DESCRIPTION
only set 'proxy = { proxyType: 'direct' }' for Opera. IE doesn't like it. And add a 'persona' tag to the job
