### PR TITLE
Remove withContext from the cookie check to speed up dialog startup.

### DIFF
--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -700,36 +700,32 @@ BrowserID.Network = (function() {
      * @method cookiesEnabled
      */
     cookiesEnabled: function(onComplete, onFailure) {
-      // Make sure we get context first or else we will needlessly send
-      // a cookie to the server.
-      withContext(function() {
-        var enabled;
-        try {
-          // NOTE - The Android 3.3 and 4.0 default browsers will still pass
-          // this check.  This causes the Android browsers to only display the
-          // cookies diabled error screen only after the user has entered and
-          // submitted input.
-          // http://stackoverflow.com/questions/8509387/android-browser-not-respecting-cookies-disabled
+      var enabled;
+      try {
+        // NOTE - The Android 3.3 and 4.0 default browsers will still pass
+        // this check.  This causes the Android browsers to only display the
+        // cookies diabled error screen only after the user has entered and
+        // submitted input.
+        // http://stackoverflow.com/questions/8509387/android-browser-not-respecting-cookies-disabled
 
-          document.cookie = "__cookiesEnabledCheck=1";
-          enabled = document.cookie.indexOf("__cookiesEnabledCheck") > -1;
+        document.cookie = "__cookiesEnabledCheck=1";
+        enabled = document.cookie.indexOf("__cookiesEnabledCheck") > -1;
 
-          // expire the cookie NOW by setting its expires date to yesterday.
-          var expires = new Date();
-          expires.setDate(expires.getDate() - 1);
-          document.cookie = "__cookiesEnabledCheck=; expires=" + expires.toGMTString();
-        } catch(e) {
-          enabled = false;
-        }
+        // expire the cookie NOW by setting its expires date to yesterday.
+        var expires = new Date();
+        expires.setDate(expires.getDate() - 1);
+        document.cookie = "__cookiesEnabledCheck=; expires=" + expires.toGMTString();
+      } catch(e) {
+        enabled = false;
+      }
 
-        // BEGIN TESTING API
-        if (typeof Network.cookiesEnabledOverride === "boolean") {
-          enabled = Network.cookiesEnabledOverride;
-        }
-        // END TESTING API
+      // BEGIN TESTING API
+      if (typeof Network.cookiesEnabledOverride === "boolean") {
+        enabled = Network.cookiesEnabledOverride;
+      }
+      // END TESTING API
 
-        complete(onComplete, enabled);
-      }, onFailure);
+      complete(onComplete, enabled);
     },
 
     /**

--- a/resources/static/test/cases/common/js/modules/cookie_check.js
+++ b/resources/static/test/cases/common/js/modules/cookie_check.js
@@ -5,7 +5,7 @@
   "use strict";
 
   var bid = BrowserID,
-      transport = bid.Mocks.xhr,
+      network = bid.Network,
       testHelpers = bid.TestHelpers,
       controller;
 
@@ -26,19 +26,24 @@
     }
   });
 
-  asyncTest("create controller with XHR error during cookie check", function() {
-    transport.useResult("contextAjaxError");
+  asyncTest("create controller cookies disabled - ready returns with false status", function() {
+    network.init({
+      cookiesEnabledOverride: false
+    });
 
     createController({
-      ready: function() {
-        testHelpers.checkNetworkError();
+      ready: function(status) {
+        equal(status, false, "cookies are disabled, false status");
+        testHelpers.testErrorVisible();
         start();
       }
     });
   });
 
   asyncTest("create controller with cookies enabled - ready returns with true status", function() {
-    transport.setContextInfo("cookies_enabled", true);
+    network.init({
+      cookiesEnabledOverride: true
+    });
 
     createController({
       ready: function(status) {

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -63,10 +63,9 @@ BrowserID.TestHelpers = (function() {
 
       transport.setDelay(0);
       transport.setContextInfo("auth_level", undefined);
-      transport.setContextInfo("cookies_enabled", true);
       transport.useResult("valid");
 
-      network.init({ forceCookieStatus: undefined });
+      network.init({ cookiesEnabledOverride: true });
       clearStorage();
 
       $("body").stop().show();


### PR DESCRIPTION
withContext will be still called when an XHR request needs the context.

Updated the unit tests to make use of network.init({ cookiesEnabledOverride: xxx }); instead of transport.setContextInfo("cookies_enabled", xxx); The context info's cookies_enabled field was never actually checked anywhere.

issue #2604

Link to issue #2580 and PR #2584
