### PR TITLE
Add a timeout when trying to fetch a well-known. Fixes #2603.

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -225,8 +225,9 @@ var conf = module.exports = convict({
   process_type: 'string',
   email_to_console: 'boolean = false',
   declaration_of_support_timeout_ms: {
-    doc: "The amount of time we wait for a server to respond with a declaration of support, before concluding that they are not a primary.  Only relevant when our local proxy is in use, not in production or staging",
-    format: 'integer = 15000'
+    doc: "The amount of time we wait for a server to respond with a declaration of support, before concluding that they are not a primary. Needs to be shorter than the dialog's time_until_delay param to avoid xhr-delay UI.",
+    format: 'integer = 8000',
+    env: 'DECLARATION_OF_SUPPORT_TIMEOUT_MS'
   },
   enable_development_menu: {
     doc: "Whether or not the development menu can be accessed",

--- a/lib/primary.js
+++ b/lib/primary.js
@@ -13,6 +13,7 @@ logger = require('./logging.js').logger,
 urlparse = require('urlparse'),
 jwcrypto = require("jwcrypto"),
 config = require("./configuration.js"),
+primaryTimeout = config.get('declaration_of_support_timeout_ms'), 
 secrets = require("./secrets.js");
 
 // alg
@@ -206,7 +207,7 @@ var getWellKnown = function (domain, delegates, cb) {
     req.abort();
     logger.debug('timeout trying to load well-known for ' + domain + ': ' + e.toString());
     handleProxyIDP();
-  }, config.get('declaration_of_support_timeout_ms'));
+  }, primaryTimeout);
   req.on('response', function() { clearTimeout(reqTimeout) });
 
   req.on('error', function(e) {

--- a/lib/primary.js
+++ b/lib/primary.js
@@ -206,7 +206,7 @@ var getWellKnown = function (domain, delegates, cb) {
     req.abort();
     logger.debug('timeout trying to load well-known for ' + domain + ': ' + e.toString());
     handleProxyIDP();
-  }, 8000);
+  }, config.get('declaration_of_support_timeout_ms'));
   req.on('response', function() { clearTimeout(reqTimeout) });
 
   req.on('error', function(e) {

--- a/lib/primary.js
+++ b/lib/primary.js
@@ -201,7 +201,16 @@ var getWellKnown = function (domain, delegates, cb) {
     }, handleResponse);
   }
 
+  // front-end shows xhr delay message after 10 sec; timeout sooner to avoid this
+  var reqTimeout = setTimeout(function() {
+    req.abort();
+    logger.debug('timeout trying to load well-known for ' + domain + ': ' + e.toString());
+    handleProxyIDP();
+  }, 8000);
+  req.on('response', function() { clearTimeout(reqTimeout) });
+
   req.on('error', function(e) {
+    if (reqTimeout) { clearTimeout(reqTimeout); }
     logger.debug(domain + ' is not a browserid primary: ' + e.toString());
     handleProxyIDP();
   });


### PR DESCRIPTION
See discussion in #2603 of how SSL connections to some IdPs, e.g. yahoo domains of the form https://yahoo.co.uk, hang forever.

There's a 15 second timeout somewhere in squid or node, but the front-end dialog code looks like it shows the "this is taking a while" error message after 10 seconds.

So, to strike a balance between letting slow IdPs negotiate SSL connection and serve the well-known in time, but also forcing fallback to happen in a timely manner, I pegged the timeout at 8 sec.

I'm not sure how to easily test this, but I could be convinced it's worth spending time figuring out how to do it. My immediate thoughts are: hack the request object to always fire a timeout, monkey-patch the clock to make it look like the timeout has elapsed, or use a wrapper around node to really hold the socket open long enough to cause a timeout (don't like this idea, seems slow and hacky for a unit test).
