### PR TITLE
Fix primary support on dev

### DIFF
--- a/resources/static/common/js/provisioning.js
+++ b/resources/static/common/js/provisioning.js
@@ -4,7 +4,9 @@
 BrowserID.Provisioning = (function() {
   "use strict";
 
-  var jwcrypto = require("./lib/jwcrypto");
+  var jwcrypto = require("./lib/jwcrypto"),
+       network = BrowserID.Network;
+
   var MAX_TIMEOUT = 20000; // 20s
 
   var Provisioning = function(args, successCB, failureCB) {
@@ -96,9 +98,13 @@ BrowserID.Provisioning = (function() {
 
     chan.bind('genKeyPair', function(trans, s) {
       trans.delayReturn(true);
-      jwcrypto.generateKeypair({algorithm: "DS", keysize: BrowserID.KEY_LENGTH}, function(err, kp) {
-        keypair = kp;
-        trans.complete(keypair.publicKey.serialize());
+      // ensure we have session_context at this point so that the random number
+      // generator is seeded
+      network.withContext(function() {
+        jwcrypto.generateKeypair({algorithm: "DS", keysize: BrowserID.KEY_LENGTH}, function(err, kp) {
+          keypair = kp;
+          trans.complete(keypair.publicKey.serialize());
+        });
       });
     });
 

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -467,6 +467,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - called on failure
      */
     provisionPrimaryUser: function(email, info, onComplete, onFailure) {
+
       User.primaryUserAuthenticationInfo(email, info, function(authInfo) {
         if(authInfo.authenticated) {
           persistEmailKeypair(email, "primary", authInfo.keypair, authInfo.cert,


### PR DESCRIPTION
A fix for issue #2624.

This PR should fix primary support on dev.  Specifically, our support was broken during key generation and certification post in-dialog authentication.  This likely introduced with 3e49e6f06060e7ff03db1316f49644808cde88e7 where we removed a call to session_context at dialog startup.  

A side effect of calling session_context is that it gets server supplied entropy to seed jwcrypto's random number generator.  With shane's optimization, apparently session_context was getting called before generateKeypair for all codepaths except `#AUTH_RETURN` - the path where we return from the IdP after an in-dialog redirect.

This PR fixes the problem by calling `session_context` during provisioning if it has not yet been called, to ensure the PRNG is seeded.
