### PR TITLE
Fix siteName in dialog regression

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -22,7 +22,7 @@ BrowserID.Modules.Authenticate = (function() {
       EMAIL_SELECTOR = "#authentication_email",
       PASSWORD_SELECTOR = "#authentication_password",
       FORGOT_PASSWORD_SELECTOR = "#forgotPassword",
-      RP_NAME_SELECTOR = "#rp_name",
+      RP_NAME_SELECTOR = "#start_rp_name",
       BODY_SELECTOR = "body",
       AUTHENTICATION_CLASS = "authentication",
       currentHint;

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -20,7 +20,7 @@
                      not fill in passwords -->
                 <div id="authentication_form" class="form_section">
                     <p class="start">
-                        <%- format(gettext('%s uses Persona instead of usernames to sign you in.'), ["<strong id='rp_name'></strong>"]) %>
+                        <%- format(gettext('%s uses Persona instead of usernames to sign you in.'), ['<strong id="start_rp_name"></strong>']) %>
 
                     </p>
 


### PR DESCRIPTION
Since we needed to access this element by selector now, it was given a reasonable id of `rp_name`. However, `rp_name` is already the id of another element. So, then selecting by id would return the previous element. This PR just picks a new, unique id for our fancy little element.

fixes #2632
