### PR TITLE
add form class to body when authenticate screen shows

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -25,6 +25,7 @@ BrowserID.Modules.Authenticate = (function() {
       RP_NAME_SELECTOR = "#rp_name",
       BODY_SELECTOR = "body",
       AUTHENTICATION_CLASS = "authentication",
+      FORM_CLASS = "form",
       currentHint;
 
   function getEmail() {
@@ -184,6 +185,7 @@ BrowserID.Modules.Authenticate = (function() {
       var self=this;
 
       dom.addClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
+      dom.addClass(BODY_SELECTOR, FORM_CLASS);
       dom.setInner(RP_NAME_SELECTOR, options.siteName);
       dom.setInner(EMAIL_SELECTOR, lastEmail);
 
@@ -212,6 +214,7 @@ BrowserID.Modules.Authenticate = (function() {
 
     stop: function() {
       dom.removeClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
+      dom.removeClass(BODY_SELECTOR, FORM_CLASS);
       Module.sc.stop.call(this);
     }
 


### PR DESCRIPTION
The formWrap element was made display none in m.css, and `renderDialog` (which used to be called in the authenticate module) would add the `.form` class to body, to show the formWrap. Since renderDialog is no longer called, it was invisible.

This adds that class manually to the body during this module.

@shane-tomlinson r?

fixes #2638
