### PR TITLE
always pass done to browser.quit()

### DIFF
--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -167,7 +167,6 @@ runner.run(module, {
   },
 
   "shut down remaining browsers": function(done) {
-    browser.quit();
-    done();
+    browser.quit(done);
   }
 }, module);

--- a/automation-tests/tests/frontend-qunit-test.js
+++ b/automation-tests/tests/frontend-qunit-test.js
@@ -91,7 +91,6 @@ runner.run(module, {
     utils.waitFor(20000, 15*60*1000, check, complete);
   },
   "shut down": function(done) {
-    browser.quit();
-    done();
+    browser.quit(done);
   }
 });

--- a/automation-tests/tests/new-user/new-user-primary-test.js
+++ b/automation-tests/tests/new-user/new-user-primary-test.js
@@ -56,6 +56,9 @@ var primary_123done = {
         assert.equal(text, eyedeemail);
         done()
       });
+  },
+  "123done end this browser session": function(done) {
+    browser.quit(done);
   }
 };
 

--- a/automation-tests/tests/remove-email.js
+++ b/automation-tests/tests/remove-email.js
@@ -215,7 +215,6 @@ runner.run(module, {
   },
 
   "shut down remaining browsers": function(done) {
-    browser.quit();
-    done();
+    browser.quit(done);
   }
 });

--- a/automation-tests/tests/reset-password-test.js
+++ b/automation-tests/tests/reset-password-test.js
@@ -92,7 +92,6 @@ runner.run(module, {
   },
 
   "shut down remaining browsers": function(done) {
-    browser.quit();
-    done();
+    browser.quit(done);
   }
 });


### PR DESCRIPTION
Otherwise sending DELETE session is in a race with process quit, and when that loses, the session lives on for 90 seconds and is marked as error
