### PR TITLE
pass event through when using DOMModule event binding

### DIFF
--- a/resources/static/common/js/helpers.js
+++ b/resources/static/common/js/helpers.js
@@ -53,7 +53,7 @@
   function cancelEvent(callback) {
     return function(event) {
       event && event.preventDefault();
-      callback.call(this);
+      callback.call(this, event);
     };
   }
 


### PR DESCRIPTION
such as this.click(selector, function(e) {});

this lets us access the target, since we can be doing delegation. I recently needed this for adding a new click handler in b2g stuff, and felt it was worth being in dev.

@shane-tomlinson r?
