### PR TITLE
Added issuer to localStorage. Fixes issue #2674

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -151,6 +151,7 @@ BrowserID.Storage = (function() {
       delete id.priv;
       delete id.pub;
       delete id.cert;
+      delete id.issuer;
       addEmail(email, id);
     }
     else {

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -87,13 +87,14 @@
   });
 
   test("invalidateEmail with valid email address", function() {
-    storage.addEmail("testuser@testuser.com", {priv: "key", pub: "pub", cert: "cert"});
+    storage.addEmail("testuser@testuser.com", {priv: "key", pub: "pub", cert: "cert", issuer: 'login.persona.org'});
 
     storage.invalidateEmail("testuser@testuser.com");
     var id = storage.getEmail("testuser@testuser.com");
     ok(id && !("priv" in id), "private key was removed");
     ok(id && !("pub" in id), "public key was removed");
     ok(id && !("cert" in id), "cert was removed");
+    ok(id && !("issuer" in id), "issuer was removed");
   });
 
   test("invalidateEmail with invalid email address", function() {

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -275,6 +275,7 @@
         equal(info.authenticated, true, "user is authenticated");
         ok(info.keypair, "keypair passed");
         ok(info.cert, "cert passed");
+        equal(info.issuer, "testuser.com", "issuer passed");
         start();
       },
       testHelpers.unexpectedXHRError


### PR DESCRIPTION
Updates `localStorage.emails` with `issuer` at the same level as `cert`.
