### PR TITLE
add a meta tag to all documents to fix environments with an embedded IE ...

### DIFF
--- a/resources/views/authenticate_with_primary.ejs
+++ b/resources/views/authenticate_with_primary.ejs
@@ -2,6 +2,7 @@
 <%- partial('partial/license_with_code_ver') %>
 <html>
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <title>Persona</title>
   <%- cachify_js('/production/authenticate_with_primary.js') %>

--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -2,6 +2,7 @@
 <%- partial('partial/license_with_code_ver') %>
 <html>
 <head><title>non-interactive iframe</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <%- cachify_js('/production/communication_iframe.js') %>
 </head>

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -2,6 +2,7 @@
 <%- partial('partial/license_with_code_ver') %>
 <html LANG="<%= lang %>" dir="<%= lang_dir %>">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0" />
   <meta name="format-detection" content="email=no" />

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -2,6 +2,7 @@
 <%- partial('partial/license_with_code_ver') %>
 <html LANG="<%= lang %>" dir="<%= lang_dir %>">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width" />
   <meta name="format-detection" content="email=no" />

--- a/resources/views/relay.ejs
+++ b/resources/views/relay.ejs
@@ -2,6 +2,7 @@
 <%- partial('partial/license_with_code_ver') %>
 <html>
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <title>Persona</title>
   <%- cachify_js('/production/relay.js') %>

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -5,6 +5,7 @@
 
 <html>
 	<head>
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <meta charset="utf-8">
 		<link rel="stylesheet" type="text/css" href="qunit/qunit.css" />
 		<title>Persona QUnit Test</title>


### PR DESCRIPTION
...forced into compatibility mode.

This makes it possible to verify your email account with a program like lotus notes that displays the verification page in an embedded browser rather than in your default/desktop browser.

closes issue #2566
