### PR TITLE
Adding forceAuthentication parameter to request

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -68,15 +68,15 @@ pre {
     </li><li>
       <input type="checkbox" id="siteName">
       <label for="siteName">Supply Site Name</label><br />
-    </li>
     </li><li>
       <input type="checkbox" id="siteLogo">
       <label for="siteLogo">Supply Site Logo</label><br />
-    </li>
     </li><li>
       <input type="checkbox" id="returnTo">
       <label for="returnTo">Supply returnTo</label><br />
-    </li>
+    </li><li>
+      <input type="checkbox" id="forceAuthentication">
+      <label for="forceAuthentication">Force Authentication</label><br />
     </li>
   </ul>
     <button class="assertion">Get an assertion</button>
@@ -186,6 +186,7 @@ $(document).ready(function() {
       siteName: $('#siteName').attr('checked') ? "Persona Test Relying Party" : undefined,
       siteLogo: $('#siteLogo').attr('checked') ? "/i/logo.png" : undefined,
       returnTo: $('#returnTo').attr('checked') ? "/postVerificationReturn.html" : undefined,
+      forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
       oncancel: function() {
         loggit("oncancel");
         $(".specify button.assertion").removeAttr('disabled');

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -125,7 +125,7 @@ BrowserID.State = (function() {
         redirectToState("primary_user", info);
       }
       else {
-        startAction("doCheckAuth");
+        startAction("doCheckAuth", info);
       }
     });
 

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -131,9 +131,11 @@ BrowserID.Modules.Actions = (function() {
       user.logoutUser(self.publish.bind(self, "logged_out"), self.getErrorDialog(errors.logoutUser));
     },
 
-    doCheckAuth: function() {
+    doCheckAuth: function(info) {
       var self=this;
-      user.checkAuthenticationAndSync(function(authenticated) {
+      user.checkAuthenticationAndSync(function (authenticated) {
+        // Does the RP want us to force the user to authenticate?
+        authenticated = info.forceAuthentication ? false : authenticated;
         self.publish("authentication_checked", {
           authenticated: authenticated
         });

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -287,6 +287,13 @@ BrowserID.Modules.Dialog = (function() {
           user.setReturnTo(returnTo);
         }
 
+        // forceAuthentication is used by the Marketplace to ensure that the
+        // user knows the password to this account. We ignore any active session.
+        if (paramsFromRP.forceAuthentication &&
+            true === paramsFromRP.forceAuthentication) {
+          params.forceAuthentication = true;
+        }
+
         if (hash.indexOf("#AUTH_RETURN") === 0) {
           var primaryParams = JSON.parse(win.sessionStorage.primaryVerificationFlow);
           params.email = primaryParams.email;


### PR DESCRIPTION
Adding forceAuthentication parameter to `navigator.id.request`.

If `true`, force the user to re-enter their credentials. This meets the b2g requirements for wrong PIN entry lockout. See [Bug #808831](https://bugzilla.mozilla.org/show_bug.cgi?id=808831)

**Note:** The user has to type their email address in. If we want to try to do something better, please file a new GH issue with those requirements.

**Note:** This PR makes [PR 2679](https://github.com/mozilla/browserid/pull/2679) obsolete.
