### PR TITLE
Focus the #authentication_email field when first loading the dialog and the user is not authenticated.

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -138,6 +138,7 @@ BrowserID.Modules.Authenticate = (function() {
       self.publish("enter_email");
       self.submit = checkEmail;
       showHint("start");
+      dom.focus(EMAIL_SELECTOR);
     }
   }
 

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -17,6 +17,7 @@
       testHelpers = bid.TestHelpers,
       testElementHasClass = testHelpers.testHasClass,
       testElementNotHasClass = testHelpers.testNotHasClass,
+      testElementFocused = testHelpers.testElementFocused,
       register = testHelpers.register,
       provisioning = bid.Mocks.Provisioning,
       AUTH_FORM_SELECTOR = "#authentication_form",
@@ -68,6 +69,9 @@
         testElementHasClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
 
         equal($(CONTENTS_SELECTOR).text(), "", "normal form contents are removed");
+
+        testElementFocused("#authentication_email", "email field is focused");
+
         // auth form not visible after stop;
         controller.stop();
         testElementNotHasClass(BODY_SELECTOR, AUTHENTICATION_CLASS);


### PR DESCRIPTION
issue #2711
