### PR TITLE
Update wclickIfExists to handle closed windows.

### DIFF
--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -1,7 +1,7 @@
 // add helper routines onto wd that make common operations easy to do
 // correctly
 
-const wd        = require('wd/lib/webdriver')
+const wd        = require('wd/lib/webdriver'),
       utils     = require('./utils.js'),
       timeouts  = require('./timeouts.js');
 
@@ -9,29 +9,6 @@ function setTimeouts(opts) {
   opts.poll = opts.poll || timeouts.DEFAULT_POLL_MS;
   opts.timeout = opts.timeout || timeouts.DEFAULT_TIMEOUT_MS;
 }
-
-// save a handle to the current window so that its existence can be
-// checked for later. This is necessary in Firefox because the wd
-// driver hangs when querying elements on windows that do not exist.
-function updateWindowHandle(browser, handle, cb) {
-  if (!cb) {
-    cb = handle;
-    handle = null;
-  }
-
-  if (handle) {
-    browser._currentWindow = handle;
-    cb(null);
-  }
-  else {
-    browser.windowHandle(function(err, handle) {
-      if (err) return cb(err);
-      browser._currentWindow = handle;
-      cb(null);
-    });
-  }
-}
-
 
 // wait for a element to become part of the dom and be visible to
 // the user.  The element is identified by CSS selector.  options:
@@ -46,7 +23,21 @@ wd.prototype.waitForDisplayed = function(opts, cb) {
 
   utils.waitFor(opts.poll, opts.timeout, function(done) {
     browser.elementByCss(opts.which, function(err, elem) {
-      if (err) return done(!err, err + " - " + opts.which, elem);
+      if (err) {
+        var isComplete = false;
+        if (typeof err === "object" && err.inspect) {
+          // window is no longer available, we are done.
+          if(/Window not found/.test(err.inspect())) {
+            err = ("window gone - " + opts.which);
+            isComplete = true;
+          }
+        } else if (typeof err === "string") {
+          err = err + " - " + opts.which;
+        }
+
+        return done(isComplete, err, elem);
+      }
+
       browser.displayed(elem, function(err, displayed) {
         done(!err && displayed, err, elem);
       });
@@ -72,9 +63,7 @@ wd.prototype.newSession = function(opts, cb) {
     // procedures like find_element to succeed (we'll actually wait on the
     // *server* side for an element to become visible).  Having this be
     // the same as the global default timeout is interesting.
-    browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function() {
-      updateWindowHandle(browser, cb);
-    });
+    browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, cb);
   });
 };
 
@@ -93,7 +82,7 @@ wd.prototype.waitForWindow = function(opts, cb) {
   setTimeouts(opts);
   utils.waitFor(opts.poll, opts.timeout, function(done) {
     browser.window(opts.name, function(err) {
-      updateWindowHandle(browser, cb);
+      done(!err, err);
     });
   }, cb);
 };
@@ -138,7 +127,7 @@ wd.prototype.find = wd.prototype.elementByCss;
 
 // convenience method to switch windows
 //
-// if no arguments are passed, switch to the base window--in a diaerror flow,
+// if no arguments are passed, switch to the base window--in a dialog flow,
 // this will be the zeroth window in the list of handles.
 //
 // if arguments are passed in, they are forwarded to waitForWindow.
@@ -150,10 +139,7 @@ wd.prototype.wwin = function(opts, cb) {
     cb = arguments[0];
     self.windowHandles(function(err, handles) {
       if (err) return cb(err);
-      var handle=handles[0];
-      self.window(handle, function(err) {
-        updateWindowHandle(self, handle, cb);
-      }); // fire cb whether err is defined or not
+      self.window(handles[0], function(err) { cb(err); }); // fire cb whether err is defined or not
     });
   } else {
     self.waitForWindow(opts, cb);
@@ -179,42 +165,39 @@ wd.prototype.click = function(which, cb) {
 };
 
 // Click a button if it exists. If there is a timeout, no problem.
+// Some buttons (like the Is this your computer) are only shown after
+// a certain amount of time has elapsed. If the button is in the DOM,
+// great, click it. If not, move on.
 wd.prototype.wclickIfExists = function(opts, cb) {
   var self=this;
-  if (typeof opts === 'string') opts = { which: opts };
+  // webdriver has a problem where if you search for an element that is
+  // contained in a window that has closed itself, no response is returned. To
+  // avoid this, set the implicit wait timeout to 0, try the click, if the
+  // timeout hit or window gone exceptions are thrown, things are ok,
+  // just move on.
+  self.setImplicitWaitTimeout(0, function() {
+    self.wclick(opts, function(err, el) {
+      if (err) {
+        // These two errors mean the element does not exist (or is not shown)
+        // and we can move on without failing. Any other failures should cause
+        // a stop in action.
+        if(!(/timeout hit/.test(err) || /window gone/.test(err))) {
+          return cb(err);
+        }
+      }
 
-  // shorten the timeout if it is not already specified. This only gets clicked
-  // if it is available. This may belong in a higher abstraction layer.
-  if (!opts.timeout) opts.timeout = 1000;
-
-  // yes, this is janktastic as anything. I am trying to wait until the dialog
-  // is closed to see if a window exists.
-  setTimeout(function() {
-    // check if the current window still exists. Firefox has a problem where if
-    // a window is closed when you check for an element's existence, it just
-    // hangs. Not ideal.
-    self.windowHandles(function(err, handles) {
-      if (handles && handles.indexOf(self._currentWindow) > -1) {
-        self.wclick(opts, function(err, el) {
-          // Some buttons (like the Is this your computer) are only shown after
-          // a certain amount of time has elapsed. If the button is in the DOM,
-          // great, click it. If not, move on.
-          if (err && (err.indexOf('timeout hit') === -1)) {
-            cb(err, null);
-          }
-          else {
-            cb(null, el);
-          }
+      // setImplictWaitTimeout fails if the 'window gone' error is
+      // returned from wclick.
+      if (!/window gone/.test(err)) {
+        self.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function(err) {
+          cb(err, el);
         });
       }
       else {
-        // either there was an error or the window no longer exists. If there
-        // was an error, pass it back, if the window no longer exists, no
-        // problem, the element does not exist either.
-        cb(err, null);
+        cb(null, el);
       }
     });
-  }, 15000);
+  });
 };
 
 wd.prototype.wgetAttribute = function(opts, attribute, cb) {

--- a/automation-tests/tests/remove-email.js
+++ b/automation-tests/tests/remove-email.js
@@ -14,7 +14,8 @@ CSS = require('../pages/css.js'),
 dialog = require('../pages/dialog.js'),
 runner = require('../lib/runner.js'),
 testSetup = require('../lib/test-setup.js'),
-user = require('../lib/user.js');
+user = require('../lib/user.js'),
+timeouts = require('../lib/timeouts.js');
 
 // pull in test environment, including wd
 var browser,


### PR DESCRIPTION
Set the implict wait timeout to 0 and check for the window gone exception. This is to get around a bug in Webdriver where a request never returns when trying to query for an element on a window that has been closed.

fixes #2741
