### PR TITLE
Prefetch dialog components from the communication_iframe

### DIFF
--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -4,6 +4,15 @@
 <head><title>non-interactive iframe</title>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
+  <%- cachify(util.format('/production/%s/dialog.js', locale), {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/production/dialog.css', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/grain.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/dialog/i/persona-logo-transparent.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/dialog/i/arrow_grey.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-loader.gif', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow-hover.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow-active.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
   <%- cachify_js('/production/communication_iframe.js') %>
 </head>
 <body></body>


### PR DESCRIPTION
When the browser is idle, it will start fetching and caching the dialog's Javascript, CSS and images. This works on IE9 and Firefox
(it's currently disabled in Chromium).

The trick is to make sure that the communication iframe is open while the user is busy reading the RP's site. When using the
Observer API, this happens automatically at the end of the navigator.id.watch() call.

More background on this feature here: http://feeding.cloud.geek.nz/2012/11/prefetching-resources-to-prime-browser.html
