### PR TITLE
transition_no_password flow

### DIFF
--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -191,6 +191,12 @@ BrowserID.State = (function() {
       complete(info.complete);
     });
 
+    handleState("transition_no_password", function(msg, info) {
+      self.resetPasswordEmail = info.email;
+      startAction(false, "doSetPassword", info);
+      complete(info.complete);
+    });
+
     handleState("password_set", function(msg, info) {
       /* A password can be set for one of three reasons - 1) This is a new user
        * or 2) a user is adding the first secondary address to an account that

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -90,6 +90,8 @@ BrowserID.Modules.Authenticate = (function() {
       }
       else if(hasPassword(info)) {
         enterPasswordState.call(self);
+      } else if ("transition_no_password" === info.state) {
+        transitionNoPassword.call(self, info);
       } else {
         createSecondaryUser.call(self);
       }
@@ -105,6 +107,17 @@ BrowserID.Modules.Authenticate = (function() {
       self.close("new_user", { email: email }, { email: email });
     } else {
       complete(callback);
+    }
+  }
+
+  function transitionNoPassword(info) {
+    /*jshint validthis: true*/
+    var self = this;
+    var email = getEmail();
+
+    if (email) {
+      var data = { email: email, transition_no_password: true };
+      self.close("transition_no_password", data, data);
     }
   }
 

--- a/resources/static/dialog/js/modules/set_password.js
+++ b/resources/static/dialog/js/modules/set_password.js
@@ -37,6 +37,8 @@ BrowserID.Modules.SetPassword = (function() {
       self.renderDialog("set_password", {
         email: options.email,
         password_reset: !!options.password_reset,
+        transition_no_password: !!options.transition_no_password,
+        domain: helpers.getDomainFromEmail(options.email),
         cancelable: options.cancelable !== false,
         personaTOSPP: options.personaTOSPP
       });

--- a/resources/static/dialog/views/set_password.ejs
+++ b/resources/static/dialog/views/set_password.ejs
@@ -10,7 +10,13 @@
       <ul class="inputs">
           <li>
             <% if (!password_reset) { %>
-              <%= gettext("Your email address is new to us. Please create a password to use with Persona.") %>
+              <% if (transition_no_password) { %>
+                <%- format(gettext("%(idp) no longer allows you to log into Persona with your %(idp) password. Please create a new password to use with your Persona account."), {
+                  idp: "<strong>" + escape(domain) + "</strong>"
+                }) %>
+              <% } else { %>
+                <%= gettext("Your email address is new to us. Please create a password to use with Persona.") %>
+              <% } %>
             <% } %>
           </li>
 

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -140,6 +140,17 @@
     testUserUnregistered();
   });
 
+  asyncTest("checkEmail with transition_no_password, transition message", function() {
+    $(EMAIL_SELECTOR).val("registered@testuser.com");
+    xhr.useResult("secondaryTransitionPassword");
+
+    register("transition_no_password", function(msg, info) {
+      ok(info.transition_no_password, "no_password state passed to set_password");
+      start();
+    });
+    controller.checkEmail();
+  });
+
   asyncTest("checkEmail with normal email, user registered - 'enter_password' message", function() {
     $(EMAIL_SELECTOR).val("registered@testuser.com");
     xhr.useResult("known_secondary");

--- a/resources/static/test/cases/dialog/js/modules/set_password.js
+++ b/resources/static/test/cases/dialog/js/modules/set_password.js
@@ -10,8 +10,7 @@
       testHelpers = bid.TestHelpers,
       testElementExists = testHelpers.testElementExists,
       testElementNotExists = testHelpers.testElementDoesNotExist,
-      register = testHelpers.register,
-      controller;
+      register = testHelpers.register;
 
   function createController(options) {
     controller = bid.Modules.SetPassword.create();
@@ -56,6 +55,17 @@
     controller.destroy();
     createController({ cancelable: false });
     testElementNotExists("#cancel");
+  });
+
+  test("create with transition_no_password", function() {
+    controller.destroy();
+    createController({
+      email: "transition@password.no",
+      transition_no_password: true
+    });
+    var msg = $("#set_password .inputs li").text();
+    ok(msg.indexOf("no longer allows"), "transition message shown");
+    ok(msg.indexOf("password.no"), "message shows IdP domain");
   });
 
   asyncTest("submit with good password/vpassword - password_set message raised", function() {


### PR DESCRIPTION
fixes #2779

This shows a new message, but otherwise follows the reset password flow. @lloyd tells me that everything else should just work. Like magic.
