### PR TITLE
Issue 2768 ie9 java errors

### DIFF
--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -58,10 +58,7 @@ const defaultCapabilities = {
   'idle-timeout': 90,
   // timeout global time used by a test. should avoid runaway tests eating
   // 10 min of sauce time. setting to 3 min for now, relax if needed.
-  'max-session': 180,
-  // XXX pegged at latest selenium version for IE9 stability testing
-  // when IE9 default reaches this number, need to unset this value
-  'selenium-version': '2.26.0'
+  'max-session': 180
 };
 
 exports.platforms = platforms;

--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -58,7 +58,10 @@ const defaultCapabilities = {
   'idle-timeout': 90,
   // timeout global time used by a test. should avoid runaway tests eating
   // 10 min of sauce time. setting to 3 min for now, relax if needed.
-  'max-session': 180
+  'max-session': 180,
+  // XXX pegged at latest selenium version for IE9 stability testing
+  // when IE9 default reaches this number, need to unset this value
+  'selenium-version': '2.26.0'
 };
 
 exports.platforms = platforms;

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -161,6 +161,11 @@ function setSessionOpts(opts) {
     sessionOpts.proxy = { proxyType: 'direct' };
   }
 
+  if (sessionOpts.browserName == 'internet explorer' && sessionOpts.version == 9) {
+    // fix ugly java errors with IE9 specifically
+    sessionOpts['selenium-version'] = '2.26.0';
+  }
+
   // Ensure a test name for saucelabs
   if (!sessionOpts.name) sessionOpts.name = createTestName();
 


### PR DESCRIPTION
See discussion in #2768. Turns out that you have to ask for the latest version of the selenium-server, and then IE9 doesn't freak out at all. Yay.
