### PR TITLE
call used_address_as_primary when returning from an idp

### DIFF
--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -269,7 +269,18 @@ BrowserID.Modules.Dialog = (function() {
       // XXX Perhaps put this into the state machine.
       self.bind(win, "unload", onWindowUnload);
 
-      self.publish("start", params);
+      function start() {
+        self.publish("start", params);
+      }
+
+      if (params.type === "primary") {
+        // at this point, we will only have type of primary if we're
+        // returning from #AUTH_RETURN. Mark that email as having been
+        // used as a primary, in case it used to be a secondary.
+        user.usedAddressAsPrimary(params.email, start, start);
+      } else {
+        start();
+      }
     }
 
     // BEGIN TESTING API

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -249,6 +249,35 @@
     });
   });
 
+
+  asyncTest("#AUTH_RETURN while authenticated should call usedAddressAsPrimary", function() {
+    winMock.location.hash = "#AUTH_RETURN";
+    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+      add: true,
+      email: TESTEMAIL
+    });
+    xhr.setContextInfo("authenticated", true);
+    xhr.setContextInfo("auth_level", "assertion");
+
+    createController({
+      ready: function() {
+        mediator.subscribe("start", function(msg, info) {
+          var req = xhr.getLastRequest();
+          equal(req && req.url, "/wsapi/used_address_as_primary", "sent correct request");
+          start();
+        });
+
+        try {
+          controller.get(testHelpers.testOrigin, {}, function() {}, function() {});
+        }
+        catch(e) {
+          // do nothing, an exception will be thrown because no modules are
+          // registered for the any services.
+        }
+      }
+    });
+  });
+
   asyncTest("onWindowUnload", function() {
     createController({
       ready: function() {


### PR DESCRIPTION
If the user is authed, no other network calls would have been made, and we need to call this.

If the user isn't authed, this call will fail, but we carry right on, ignoring the failure. auth_with_assertion would have to be called later, so that call can flip the bit for us in this case.

fixes #2795
