### PR TITLE
if PERSONA_WITH_COVER, do a graceful shutdown so cover can generate .coverage_data

### DIFF
--- a/bin/static
+++ b/bin/static
@@ -12,7 +12,8 @@ path = require('path'),
 url = require('url'),
 http = require('http'),
 urlparse = require('urlparse'),
-express = require('express');
+express = require('express'),
+shutdown = require('../lib/shutdown');
 
 const
 assets = require('../lib/static_resources').all,
@@ -101,6 +102,14 @@ app.use(function(req, res, next) {
 });
 
 app.use(express.static(static_root));
+
+// Do this only when PERSONA_WITH_COVER is set. Without a graceful shutdown,
+// `cover` will not generate .coverage_data
+if (process.env.PERSONA_WITH_COVER) {
+  shutdown.handleTerminationSignals(app, function() {
+    // nothing particular to do here for static daemon, yet..
+  });
+}
 
 var bindTo = config.get('bind_to');
 app.listen(bindTo.port, bindTo.host, function() {


### PR DESCRIPTION
This is the PR for mozilla/browserid#2807. Does what the summary says and otherwise has no effect if PERSONA_WITH_COVER is not set.
