### PR TITLE
dump node version/path and current configuration to logs if NODE_ENV=production

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -30,6 +30,11 @@ app = express.createServer();
 
 logger.info("browserid server starting up");
 
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 // NOTE: ordering of middleware registration is important in this file, it is the
 // order in which middleware will be invoked as requests are processed.
 

--- a/bin/dbwriter
+++ b/bin/dbwriter
@@ -39,6 +39,11 @@ app = express.createServer();
 
 logger.info("dbwriter starting up");
 
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 // Setup health check / heartbeat middleware.
 // This is in front of logging on purpose.  see issue #537
 heartbeat.setup(app, function(cb) {

--- a/bin/keysigner
+++ b/bin/keysigner
@@ -23,6 +23,13 @@ shutdown = require('../lib/shutdown'),
 computecluster = require('compute-cluster'),
 urlparse = require('urlparse');
 
+logger.info("keysigner starting up");
+
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 const HOSTNAME = urlparse(config.get('public_url')).host;
 logger.info("Certs will be issued from: " + HOSTNAME);
 

--- a/bin/router
+++ b/bin/router
@@ -29,6 +29,11 @@ app = express.createServer();
 
 logger.info("router server starting up");
 
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 // verify that we have a keysigner configured
 if (!config.get('keysigner_url')) {
   logger.error('missing required configuration - url for the keysigner (KEYSIGNER_URL in env)');

--- a/bin/static
+++ b/bin/static
@@ -32,6 +32,11 @@ app = express.createServer();
 
 logger.info("static starting up");
 
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 // Setup health check / heartbeat middleware.
 // This is in front of logging on purpose.  see issue #537
 heartbeat.setup(app);

--- a/bin/verifier
+++ b/bin/verifier
@@ -22,6 +22,11 @@ statsd = require('../lib/statsd');
 
 logger.info("verifier server starting up");
 
+if (config.get('env') === 'production') {
+  logger.info('node.js version: ' + process.version + ' at ' + process.execPath);
+  logger.info('configuration: ', JSON.stringify(JSON.parse(config.toString())));
+}
+
 var app = express.createServer();
 
 // setup health check / heartbeat (before logging)


### PR DESCRIPTION
Fixes GH-2800. I realized I was only really interested in the version and path of node.js plus the resolved configuration settings.
