### PR TITLE
Keep track of the handle of the first window. Fixes #2805.

### DIFF
--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -80,8 +80,8 @@ wd.prototype.newSession = function(opts, cb) {
     browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function(err) {
       if (err) return cb(err);
       // keep track of the ID of the first window
-      browser.windowHandle(function(err, handle) {
-        browser._parentWindow = handle;
+      self.windowHandle(function(err, handle) {
+        self._parentWindow = handle;
         return cb(err);
       });
     });
@@ -161,7 +161,7 @@ wd.prototype.wwin = function(opts, cb) {
     cb = arguments[0];
     self.windowHandles(function(err, handles) {
       if (err) return cb(err);
-      self.window(browser._parentWindow, function(err) { cb(err); }); // fire cb whether err is defined or not
+      self.window(self._parentWindow, cb); // fire cb whether err is defined or not
     });
   } else {
     self.waitForWindow(opts, cb);

--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -77,7 +77,14 @@ wd.prototype.newSession = function(opts, cb) {
     // procedures like find_element to succeed (we'll actually wait on the
     // *server* side for an element to become visible).  Having this be
     // the same as the global default timeout is interesting.
-    browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, cb);
+    browser.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function(err) {
+      if (err) return cb(err);
+      // keep track of the ID of the first window
+      browser.windowHandle(function(err, handle) {
+        browser._parentWindow = handle;
+        return cb(err);
+      });
+    });
   });
 };
 
@@ -142,7 +149,8 @@ wd.prototype.find = wd.prototype.elementByCss;
 // convenience method to switch windows
 //
 // if no arguments are passed, switch to the base window--in a dialog flow,
-// this will be the zeroth window in the list of handles.
+// this will be the first window opened in the session, which *should* always
+// be the parent window.
 //
 // if arguments are passed in, they are forwarded to waitForWindow.
 wd.prototype.wwin = function(opts, cb) {
@@ -153,7 +161,7 @@ wd.prototype.wwin = function(opts, cb) {
     cb = arguments[0];
     self.windowHandles(function(err, handles) {
       if (err) return cb(err);
-      self.window(handles[0], function(err) { cb(err); }); // fire cb whether err is defined or not
+      self.window(browser._parentWindow, function(err) { cb(err); }); // fire cb whether err is defined or not
     });
   } else {
     self.waitForWindow(opts, cb);


### PR DESCRIPTION
See #2805 for discussion.

Rather than track the current window as we switch from window to window during a session, I think we can get away with just grabbing a reference to the first window created at the start of a session--that'll always (I think?) be the one we want when the dialog is gone.
