### PR TITLE
Make sure *all* errors are reported.

### DIFF
--- a/automation-tests/lib/results-aggregator.js
+++ b/automation-tests/lib/results-aggregator.js
@@ -20,8 +20,84 @@ function ResultsAggregator() {
 
 utils.inherits(ResultsAggregator, events.EventEmitter);
 
+/*
+ * Asynchronous exceptions come in on stderr. These errors are not reported
+ * in the JSON reporter and must be parsed manually from the stderr output.
+ * Async errors take the form of:
+ *
+ *    /file_path:lineno
+ *    line_causing_problem
+ *          ^ (arrow to location)
+ *    TypeOfError & StackTrace
+ *
+ * Example of an error:
+ *     /Users/stomlinson/development/browserid/automation-tests/tests/sign-in-test.js:45
+ *     o['b'];
+ *     ^
+ *     ReferenceError: o is not defined
+ *         at runner.run.throw an async error (/Users/stomlinson/development/browserid/automation-tests/tests/sign-in-test.js:45:11)
+ *         at process.startup.processNextTick.process._tickCallback (node.js:244:9)
+ *
+ *
+ * Second example:
+ *     timers.js:103
+ *     if (!process.listeners('uncaughtException').length) throw e;
+ *     ^
+ *     ReferenceError: o is not defined
+ *         at Object.runner.run.throw an async error [as _onTimeout] (/Users/stomlinson/development/browserid/automation-tests/tests/sign-in-test.js:45:11)
+ *         at Timer.list.ontimeout (timers.js:101:19)
+ *
+ * Each line of the exception is reported to stderr as its own message. This
+ * means that once an error is detected on stderr, subsequent messages must be
+ * appended until the entire message is captured.
+ *
+ * To fix this (ver brittle):
+ * Look for the test_path on a line.
+ * Capture and append each message until the message with "Error: "
+ */
+ResultsAggregator.prototype.parseErrorLine = function(msg) {
+  /*
+   * look for a message that contains the test path, if the line starts with
+   * the path, there is an asynchronous error.
+   */
+  msg = msg && msg.trim();
+  if (!msg) return;
+
+  if (/https:\/\/saucelabs\.com\/tests\//.test(msg)) {
+    this.addInterestingURL(msg);
+  }
+
+  if (!this.captureLines && /\.js:\d+/.test(msg)) {
+    /*
+     * The first line is the file name which is already reported as part of the
+     * output. Since this is duplicate data, do not capture it.
+     */
+    this.currentException = "";
+    this.captureLines = true;
+  }
+  else if (this.captureLines) {
+    this.currentException += (msg + "\n");
+
+    // The last message contains the Error: and stack trace.
+    this.captureLines = !/Error:/.test(msg);
+
+    if (!this.captureLines) {
+      this.current.name = getSpecFromError(msg);
+      this.handleError(this.currentException);
+    }
+  }
+  /*
+   * If neither branch matched, this message is either not an error message
+   * or we are not collecting messages.
+   */
+};
+
 ResultsAggregator.prototype.parseLine = function(msg) {
   var self = this;
+  /*
+   * Multiple results can come in on one message, split and process each
+   * individually
+   */
   msg.split("\n").forEach(function(msg) {
     msg = msg.trim();
     if (msg.length === 0) return;
@@ -31,27 +107,44 @@ ResultsAggregator.prototype.parseLine = function(msg) {
       self.oddballMessages.push(msg.trim());
       return;
     }
-    // now handle the message
+
     if (msg["0"] === 'context') {
       self.current.name = msg["1"];
-    } else if (msg["0"] === 'end') {
+    /*
+     * If there is a synchronous exception, no "context" message will be
+     * sent, this means the spec name must be fetched from the error message.
+     */
+    } else if (msg["0"] === 'error' && msg["1"].context) {
+      self.current.name = msg["1"].context;
+      self.handleError(msg["1"].exception);
+    // vow is sent when a vow runs and completes normally.
+    } else if (msg["0"] === 'vow') {
+      if (msg["1"].status !== 'honored') {
+        self.handleError(msg["1"].exception);
+      } else {
+        self.emit('pass');
+      }
+    /*
+     * end and finish are the last messages sent
+     * end is sent if the test is completes normally
+     * finish is sent if the test excepts
+     */
+    } else if (msg["0"] === 'end' || msg["0"] === 'finish') {
       if (self.current.errors) {
         self.failures.push(self.current);
       } else {
         self.successes.push(self.current);
       }
       self.current = {};
-    } else if (msg["0"] === 'vow') {
-      if (msg["1"].status !== 'honored') {
-        self.current.success = false;
-        self.current.errors = self.current.errors || [];
-        self.current.errors.push(msg["1"].exception);
-        self.emit('fail');
-      } else {
-        self.emit('pass');
-      }
     }
   });
+};
+
+ResultsAggregator.prototype.handleError = function(errorType) {
+  this.current.success = false;
+  this.current.errors = this.current.errors || [];
+  this.current.errors.push(errorType);
+  this.emit('fail');
 };
 
 ResultsAggregator.prototype.setName = function(testName) {
@@ -75,3 +168,16 @@ ResultsAggregator.prototype.results = function() {
 }
 
 module.exports = ResultsAggregator;
+
+function getSpecFromError(msg) {
+  /* test name on exception is in the form of:
+   *   at runner.run<test_name> (<location>)
+   * Example:
+   *   at runner.run.throw an async error in process.nextTick (/Users/stomlinson/development/browserid/automation-tests/tests/minimal-test.js:54:7)
+   */
+  var possibleNameMatch = /runner\.run\.(.*) \(/.exec(msg);
+  var name = (possibleNameMatch && possibleNameMatch[1])
+                || "unknown spec";
+  return name;
+}
+

--- a/automation-tests/lib/vows_harness.js
+++ b/automation-tests/lib/vows_harness.js
@@ -27,6 +27,7 @@ module.exports = function(spec, mod, opts) {
           lastArgs = Array.prototype.slice.call(arguments, 0);
           self.callback.apply(self, lastArgs);
         });
+
         if (!opts.bailOnError || !failedState) {
           spec[name].apply(this, args);
         } else {
@@ -43,7 +44,7 @@ module.exports = function(spec, mod, opts) {
             suite.batches[i].remaining = 0;
           }
         }
-        if (err) assert.fail(err)
+        if (err) assert.fail(err);
       }
     };
     suite.addBatch(obj);
@@ -51,14 +52,16 @@ module.exports = function(spec, mod, opts) {
 
   // now add cleanup invocation as a batch
 
-  suite.addBatch({
-    "cleanup": {
-      topic: function() {
-        if (opts.cleanup) opts.cleanup(this.callback);
-      },
-      "done": function() { }
-    }
-  });
+  if (opts.cleanup) {
+    suite.addBatch({
+      "cleanup": {
+        topic: function() {
+          opts.cleanup(this.callback);
+        },
+        "done": function() { }
+      }
+    });
+  }
 
   if (path.basename(process.argv[1]) === 'vows') {
     suite.export(mod);


### PR DESCRIPTION
@6a68 - mind reviewing?

I tried using vows_process.on('uncaughtException', callback) but I was never getting the message. Looking at the vows code, they have an uncaughtException handler which prints the results - could this be masking the parent process from receiving this message?

1) the vows JSON reporter reports exceptions differently to passing results. The results aggregator must account for this or else some failures are not counted.
2) If a test has an asynchronous exception, the JSON reporter never gets a record of the error. Instead, errors messages must be fetched from stderr and reported approrpriately.

fixes #2745
