### PR TITLE
Fixes cancel button issue related to issue #2839

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -226,6 +226,7 @@ BrowserID.Modules.Authenticate = (function() {
       currentHint = null;
       dom.setInner(CONTENTS_SELECTOR, "");
       dom.hide(".returning,.start");
+      self.hideError();
 
       // We have to show the TOS/PP agreements to *all* users here. Users who
       // are already authenticated to their IdP but do not have a Persona


### PR DESCRIPTION
No Auth user has a non-functioning cancel button, also.

STR

1) Create a new IdP https://testidp.org/
2) Log in with the primary
3) Log out
4) Update IdP's well known to {}
5) Attempt to log in
6) Note offline copy and click 'Cancel'

Actual: Nothing happens

Expected: Return to Auth screen

I see that this is because offline primary shows the error. Clicking cancel we do go back into the authentication state, but the error screen is still shown. This fix always hides the error screen when restarting the authentication flow. Not sure if that is the right fix.
