### PR TITLE
When showing the authentication screen, make sure to hide the warning screens

### DIFF
--- a/resources/static/common/js/modules/page_module.js
+++ b/resources/static/common/js/modules/page_module.js
@@ -52,16 +52,13 @@ BrowserID.Modules.PageModule = (function() {
       sc.stop.call(this);
     },
 
-    renderDialog: function(template, data) {
+    renderForm: function(template, data) {
       var self=this;
-
-      self.hideWait();
-      self.hideError();
-      self.hideDelay();
 
       dom.removeClass("body", "rptospp");
 
       screens.form.show(template, data);
+      self.hideWarningScreens();
       dom.focus("input:visible:not(:disabled):eq(0)");
       // XXX jQuery.  bleck.
       if($("*:focus").length === 0) {
@@ -69,6 +66,7 @@ BrowserID.Modules.PageModule = (function() {
       }
     },
 
+    // the wait, error and delay screens make up the warning screens.
     renderWait: showScreen.curry(screens.wait),
     hideWait: hideScreen.curry(screens.wait),
 
@@ -77,6 +75,17 @@ BrowserID.Modules.PageModule = (function() {
 
     renderDelay: showScreen.curry(screens.delay),
     hideDelay: hideScreen.curry(screens.delay),
+
+    /**
+     * Hides the warning screens
+     * @method hideWarningScreens
+     */
+    hideWarningScreens: function() {
+      var self=this;
+      self.hideWait();
+      self.hideError();
+      self.hideDelay();
+    },
 
     /**
      * Validate the form, if returns false when called, submit will not be

--- a/resources/static/dialog/js/modules/add_email.js
+++ b/resources/static/dialog/js/modules/add_email.js
@@ -60,7 +60,7 @@ BrowserID.Modules.AddEmail = (function() {
       var self=this,
           originEmail = user.getOriginEmail();
 
-      self.renderDialog("add_email", options);
+      self.renderForm("add_email", options);
       hideHint("addressInfo");
 
       self.click("#cancel", cancelAddEmail);

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -226,6 +226,7 @@ BrowserID.Modules.Authenticate = (function() {
       currentHint = null;
       dom.setInner(CONTENTS_SELECTOR, "");
       dom.hide(".returning,.start");
+      self.hideError();
 
       // We have to show the TOS/PP agreements to *all* users here. Users who
       // are already authenticated to their IdP but do not have a Persona

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -38,7 +38,7 @@ BrowserID.Modules.Authenticate = (function() {
   }
 
   function hasPassword(info) {
-    return (info && info.email && info.type === "secondary" && 
+    return (info && info.email && info.type === "secondary" &&
       (info.state === "known" || info.state === "transition_to_secondary" ));
   }
 
@@ -226,7 +226,12 @@ BrowserID.Modules.Authenticate = (function() {
       currentHint = null;
       dom.setInner(CONTENTS_SELECTOR, "");
       dom.hide(".returning,.start");
-      self.hideError();
+
+      // Since the authentication form is ALWAYS in the DOM, there is no
+      // renderForm call which will hide the error, wait or delay screens.
+      // Because one of those may be shown, just show the normal form. See
+      // issue #2839
+      self.hideWarningScreens();
 
       // We have to show the TOS/PP agreements to *all* users here. Users who
       // are already authenticated to their IdP but do not have a Persona

--- a/resources/static/dialog/js/modules/pick_email.js
+++ b/resources/static/dialog/js/modules/pick_email.js
@@ -125,7 +125,7 @@ BrowserID.Modules.PickEmail = (function() {
 
       var identities = getSortedIdentities();
 
-      self.renderDialog("pick_email", {
+      self.renderForm("pick_email", {
         identities: identities,
         siteEmail: user.getOriginEmail()
       });

--- a/resources/static/dialog/js/modules/primary_user_provisioned.js
+++ b/resources/static/dialog/js/modules/primary_user_provisioned.js
@@ -25,7 +25,7 @@ BrowserID.Modules.PrimaryUserProvisioned = (function() {
 
       self.checkRequired(options, "email", "assertion");
 
-      self.renderDialog("primary_user_verified", { email: email });
+      self.renderForm("primary_user_verified", { email: email });
 
       if(addEmailToCurrentUser) {
         network.addEmailWithAssertion(assertion, function(status) {

--- a/resources/static/dialog/js/modules/required_email.js
+++ b/resources/static/dialog/js/modules/required_email.js
@@ -229,7 +229,7 @@ BrowserID.Modules.RequiredEmail = (function() {
           cancelable: true
         }, templateData);
 
-        self.renderDialog("required_email", templateData);
+        self.renderForm("required_email", templateData);
 
         if (options.siteTOSPP) {
           dialogHelpers.showRPTosPP.call(self);

--- a/resources/static/dialog/js/modules/set_password.js
+++ b/resources/static/dialog/js/modules/set_password.js
@@ -34,7 +34,7 @@ BrowserID.Modules.SetPassword = (function() {
       var self=this;
       options = options || {};
 
-      self.renderDialog("set_password", {
+      self.renderForm("set_password", {
         email: options.email,
         password_reset: !!options.password_reset,
         transition_no_password: !!options.transition_no_password,

--- a/resources/static/dialog/js/modules/upgrade_to_primary_user.js
+++ b/resources/static/dialog/js/modules/upgrade_to_primary_user.js
@@ -35,7 +35,7 @@ BrowserID.Modules.UpgradeToPrimaryUser = (function() {
       add = data.add;
       email = data.email;
       auth_url = data.auth_url;
-      self.renderDialog("upgrade_to_primary_user", {
+      self.renderForm("upgrade_to_primary_user", {
         email: data.email,
         auth_url: data.auth,
         requiredEmail: data.requiredEmail || false,

--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -60,7 +60,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
 
       user.addressInfo(email, function onSuccess(info) {
         if (showsPrimaryTransition(info.state)) {
-          self.renderDialog("verify_primary_user", {
+          self.renderForm("verify_primary_user", {
             email: data.email,
             auth_url: data.auth_url,
             requiredEmail: data.requiredEmail || false,

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -68,19 +68,39 @@
 
   asyncTest("authentication form initialized on startup, hidden on stop", function() {
     $(CONTENTS_SELECTOR).text("some contents that need to be removed");
+
     createController({
       ready: function() {
         // auth form visible when controller is ready
         testElementHasClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
 
         equal($(CONTENTS_SELECTOR).text(), "", "normal form contents are removed");
-
         testElementFocused("#authentication_email", "email field is focused");
 
         // auth form not visible after stop;
         controller.stop();
         testElementNotHasClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
 
+        start();
+      }
+    });
+  });
+
+  asyncTest("warning sreens hidden on startup", function() {
+    var classNames = ["waiting", "error", "delay"];
+
+    // simulate the warning screens being shown in a module other than
+    // authenticate.
+    _.each(classNames, function(className) {
+      $(BODY_SELECTOR).addClass(className);
+    });
+
+    // the authenticate module should hide the screens.
+    createController({
+      ready: function() {
+        _.each(classNames, function(className) {
+          testElementNotHasClass(BODY_SELECTOR, className);
+        });
         start();
       }
     });


### PR DESCRIPTION
@ozten - mind reviewing this?
- For clarity, rename renderDialog to renderForm.

fixes #2839
