### PR TITLE
Issue 2846 ie8 failures

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -38,7 +38,7 @@ BrowserID.Modules.Authenticate = (function() {
   }
 
   function hasPassword(info) {
-    return (info && info.email && info.type === "secondary" && 
+    return (info && info.email && info.type === "secondary" &&
       (info.state === "known" || info.state === "transition_to_secondary" ));
   }
 
@@ -182,13 +182,18 @@ BrowserID.Modules.Authenticate = (function() {
       dom.setInner(IDP_SELECTOR, helpers.getDomainFromEmail(addressInfo.email));
     }
     dom.setInner(AUTHENTICATION_LABEL, dom.getInner(labelSelector));
+
     showHint("returning", function() {
-      dom.focus(PASSWORD_SELECTOR);
+      try {
+        dom.focus(PASSWORD_SELECTOR);
+      } catch(e) {
+        // IE8 blows up if the element is disabled.
+        helpers.log("Could not focus password element: " + String(e));
+      }
+
+      self.publish("enter_password", addressInfo);
+      complete(callback);
     });
-
-
-    self.publish("enter_password", addressInfo);
-    complete(callback);
   }
 
   function forgotPassword() {

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -184,14 +184,11 @@ BrowserID.Modules.Authenticate = (function() {
     dom.setInner(AUTHENTICATION_LABEL, dom.getInner(labelSelector));
 
     showHint("returning", function() {
-      try {
-        dom.focus(PASSWORD_SELECTOR);
-      } catch(e) {
-        // IE8 blows up if the element is disabled.
-        helpers.log("Could not focus password element: " + String(e));
-      }
-
+      dom.focus(PASSWORD_SELECTOR);
       self.publish("enter_password", addressInfo);
+      // complete must be called after focus or else the front end unit tests
+      // fail. When complete was called outside of showHint, IE8 complained
+      // because the element we are trying to focus was no longer available.
       complete(callback);
     });
   }

--- a/resources/static/dialog/js/modules/primary_offline.js
+++ b/resources/static/dialog/js/modules/primary_offline.js
@@ -5,12 +5,7 @@ BrowserID.Modules.PrimaryOffline = (function() {
   "use strict";
 
   var bid = BrowserID,
-      dom = bid.DOM,
-      helpers = bid.Helpers,
-      user = bid.User,
-      errors = bid.Errors,
-      domHelpers = bid.DOMHelpers,
-      email;
+      helpers = bid.Helpers;
 
   function startDialogOver() {
     /*jshint validthis:true*/

--- a/resources/static/dialog/views/primary_offline.ejs
+++ b/resources/static/dialog/views/primary_offline.ejs
@@ -3,6 +3,8 @@
       file, You can obtain one at http://mozilla.org/MPL/2.0/. */ %>
 
   <div id="primary_offline">
-    <p><%= format(gettext('%(primary) is not responding. Please wait a few minutes and try again.'), {primary: idpName}) %></p>
-        <button id="primary_offline_confirm" tabindex="1"><%= gettext('Cancel') %></button>
+    <p>
+      <%= format(gettext('%(primary) is not responding. Please wait a few minutes and try again.'), { primary: idpName }) %>
+    </p>
+    <button id="primary_offline_confirm"><%= gettext('Cancel') %></button>
   </div>

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -480,7 +480,6 @@
       type: 'secondary',
       state: 'transition_to_secondary'
     });
-    console.log('actions called=' + JSON.stringify(actions.called));
     equal(actions.called.doAuthenticate, true, "doAuthenticate called");
   });
 

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -18,6 +18,7 @@
       testElementHasClass = testHelpers.testHasClass,
       testElementNotHasClass = testHelpers.testNotHasClass,
       testElementFocused = testHelpers.testElementFocused,
+      testElementTextEquals = testHelpers.testElementTextEquals,
       register = testHelpers.register,
       provisioning = bid.Mocks.Provisioning,
       AUTH_FORM_SELECTOR = "#authentication_form",
@@ -156,7 +157,7 @@
     xhr.useResult("known_secondary");
 
     register("enter_password", function() {
-      equal($(AUTHENTICATION_LABEL).html(), $(PASSWORD_LABEL).html(), "enter password message shown");
+      testElementTextEquals(AUTHENTICATION_LABEL, $(PASSWORD_LABEL).html(), "enter password message shown");
       start();
     });
 

--- a/resources/static/test/cases/dialog/js/modules/primary_offline.js
+++ b/resources/static/test/cases/dialog/js/modules/primary_offline.js
@@ -6,7 +6,8 @@
 
   var controller,
       bid = BrowserID,
-      testHelpers = bid.TestHelpers;
+      testHelpers = bid.TestHelpers,
+      testElementTextContains = testHelpers.testElementTextContains;
 
   module("dialog/js/modules/primary_offline", {
     setup: function() {
@@ -22,7 +23,7 @@
           // could already be destroyed from the close
         }
       }
-      testHelpers.setup();
+      testHelpers.teardown();
     }
   });
 
@@ -30,7 +31,6 @@
   function createController(config) {
     controller = bid.Modules.PrimaryOffline.create();
     config = config || {};
-    config.complete_delay = 1;
     controller.start(config);
   }
 
@@ -45,12 +45,12 @@
     equal(error.message, "missing config option: email", "correct error message printed");
   });
 
-  test("start controller with `add: false` and XHR error displays error screen", function() {
+  test("start controller idp that is not responding - display offline screen", function() {
     createController({
       email: "unregistered@testuser.com"
     });
-    ok($('#primary_offline').text().indexOf('testuser.com is not responding') > 0,
-       "Copy includes idpName");
+    testElementTextContains("#primary_offline",
+        'testuser.com is not responding', "Copy includes idpName");
   });
 
 }());

--- a/resources/static/test/cases/dialog/js/modules/set_password.js
+++ b/resources/static/test/cases/dialog/js/modules/set_password.js
@@ -10,6 +10,7 @@
       testHelpers = bid.TestHelpers,
       testElementExists = testHelpers.testElementExists,
       testElementNotExists = testHelpers.testElementDoesNotExist,
+      testElementTextContains = testHelpers.testElementTextContains,
       register = testHelpers.register;
 
   function createController(options) {
@@ -63,9 +64,9 @@
       email: "transition@password.no",
       transition_no_password: true
     });
-    var msg = $("#set_password .inputs li").text();
-    ok(msg.indexOf("no longer allows"), "transition message shown");
-    ok(msg.indexOf("password.no"), "message shows IdP domain");
+    var selector = "#set_password .inputs li";
+    testElementTextContains(selector, "no longer allows", "transition message shown");
+    testElementTextContains(selector, "password.no", "message shows IdP domain");
   });
 
   asyncTest("submit with good password/vpassword - password_set message raised", function() {

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -327,9 +327,13 @@ BrowserID.TestHelpers = (function() {
       }
     },
 
+    testElementTextContains: function(selector, expected, msg) {
+      var elText = $(selector).eq(0).text();
+      ok(elText.indexOf(expected) > -1, msg || (selector + " text contains: " + expected));
+    },
+
     testElementTextEquals: function(selector, expected, msg) {
       equal($(selector).eq(0).text(), expected, msg || (selector + " text is: " + expected));
-
     },
 
     testEmailMarkedVerified: function(email, msg) {

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -328,12 +328,17 @@ BrowserID.TestHelpers = (function() {
     },
 
     testElementTextContains: function(selector, expected, msg) {
-      var elText = $(selector).eq(0).text();
+      var el = $(selector).eq(0),
+          elText = (el && el.text()) || "";
+
       ok(elText.indexOf(expected) > -1, msg || (selector + " text contains: " + expected));
     },
 
     testElementTextEquals: function(selector, expected, msg) {
-      equal($(selector).eq(0).text(), expected, msg || (selector + " text is: " + expected));
+      var el = $(selector).eq(0),
+          elText = (el && el.text()) || "";
+
+      equal(elText, expected, msg || (selector + " text is: " + expected));
     },
 
     testEmailMarkedVerified: function(email, msg) {


### PR DESCRIPTION
@ozten - can you review this?

Fix IE8 errors
- Added a new test helpers - testElementTextContains.
- Use the new helper instead of text.indexOf to check for text in the DOM.
- Remove extra variables that were not used.
- Fix the thrown exception when focusing the password field in the unit tests.
- Remove the console.log message for `actions called={"doAuthenticate":true}`

fixes #2846
Partial fix for #2828
