### PR TITLE
Replace implicit waits with explicit waits.

### DIFF
--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -120,7 +120,6 @@ testSetup.newBrowserSession = function(b, cb) {
 };
 
 testSetup.teardown = function(cb) {
-  console.log('teardown called')
   var enders = [];
   // quit all browser sessions
   for (var i = 0, b; b = testSetup.browsers[i]; i++) enders.push(Q.ncall(b.quit, b));

--- a/automation-tests/lib/timeouts.js
+++ b/automation-tests/lib/timeouts.js
@@ -1,3 +1,7 @@
 exports.DEFAULT_POLL_MS = 500;
-exports.DEFAULT_TIMEOUT_MS = 20000;
+exports.DEFAULT_TIMEOUT_MS = 40000;
+// At the advice of the WebQA team, setting the default implicit wait to 0 and
+// using explicit waits. This helps reduce the number of errors due to explicit
+// timeouts.
+exports.DEFAULT_IMPLICIT_WAIT_MS = 0;
 exports.DEFAULT_LOAD_PAGE_MS = 1500;

--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -69,15 +69,14 @@ wd.prototype.newSession = function(opts, cb) {
 
   self.init(opts, function(err) {
     if (err) return cb(err);
-    // let's set the http timeout at 2x the implicit wait timeout for
-    // faster failures. (!300s)
+    // let's set the http timeout at 2x the default wait timeout for
+    // faster failures. (without this set, http timeouts are 300s)
     self.setHTTPInactivityTimeout(2 * timeouts.DEFAULT_TIMEOUT_MS);
     // note!  the implicit wait timeout is different from other timeouts,
     // it's the amount of time certain wire transactions will wait for
     // procedures like find_element to succeed (we'll actually wait on the
-    // *server* side for an element to become visible).  Having this be
-    // the same as the global default timeout is interesting.
-    self.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function(err) {
+    // *server* side for an element to become visible).
+    self.setImplicitWaitTimeout(timeouts.DEFAULT_IMPLICIT_WAIT_MS, function(err) {
       if (err) return cb(err);
       // keep track of the ID of the first window
       self.windowHandle(function(err, handle) {
@@ -230,12 +229,30 @@ wd.prototype.click = function(which, cb) {
 // great, click it. If not, move on.
 wd.prototype.wclickIfExists = function(opts, cb) {
   var self=this;
+  // This function assumes the implicit wait when entering wclickIfExists is
+  // the same as the DEFAULT_IMPLICIT_WAIT_MS. Calling this function allows us
+  // to set the implicit wait and only send the request over the wire if the
+  // implicit wait actually needs updated. If the default is set to 0, no wire
+  // protocol request will be made.
+  var currImplicitWaitMS = timeouts.DEFAULT_IMPLICIT_WAIT_MS;
+  function setImplicitWaitTimeout(implicitWaitMS, done) {
+    if (implicitWaitMS !== currImplicitWaitMS) {
+      self.setImplicitWaitTimeout(implicitWaitMS, function(err) {
+        if (!err) currImplicitWaitMS = implicitWaitMS;
+        done(err);
+      });
+    }
+    else {
+      done(null);
+    }
+  }
+
   // webdriver has a problem where if you search for an element that is
   // contained in a window that has closed itself, no response is returned. To
   // avoid this, set the implicit wait timeout to 0, try the click, if the
   // timeout hit or window gone exceptions are thrown, things are ok,
   // just move on.
-  self.setImplicitWaitTimeout(0, function() {
+  setImplicitWaitTimeout(0, function() {
     self.wclick(opts, function(err, el) {
       if (err) {
         // These two errors mean the element does not exist (or is not shown)
@@ -249,7 +266,7 @@ wd.prototype.wclickIfExists = function(opts, cb) {
       // setImplictWaitTimeout fails if the 'window gone' error is
       // returned from wclick.
       if (!/window gone/.test(err)) {
-        self.setImplicitWaitTimeout(timeouts.DEFAULT_TIMEOUT_MS, function(err) {
+        setImplicitWaitTimeout(timeouts.DEFAULT_IMPLICIT_WAIT_MS, function(err) {
           cb(err, el);
         });
       }


### PR DESCRIPTION
@6a68 - Could you review this one?
- Set the default implicit wait to 0.
- Increase the DEFAULT_TIMEOUT_MS to 40s to give webdriver more time to find elements.

fixes #2857
