### PR TITLE
Fix 400 response for /wsapi/used_address_as_primary 

### DIFF
--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -291,10 +291,13 @@ BrowserID.Modules.Dialog = (function() {
         self.publish("start", params);
       }
 
-      if (params.type === "primary") {
+      if (params.type === "primary" && !params.add) {
         // at this point, we will only have type of primary if we're
         // returning from #AUTH_RETURN. Mark that email as having been
         // used as a primary, in case it used to be a secondary.
+        // If being added, the user doesn't own this email yet, and the
+        // status will be changed in add_email_with_assertion.
+        //
         // NOTE: calling start for a request failure is the desired behavior.
         // If this call fails, it is no big deal, the user should not be
         // blocked. See

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -253,7 +253,7 @@
   asyncTest("#AUTH_RETURN while authenticated should call usedAddressAsPrimary", function() {
     winMock.location.hash = "#AUTH_RETURN";
     winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
-      add: true,
+      add: false,
       email: TESTEMAIL
     });
     xhr.setContextInfo("authenticated", true);
@@ -264,6 +264,35 @@
         mediator.subscribe("start", function(msg, info) {
           var req = xhr.getLastRequest();
           equal(req && req.url, "/wsapi/used_address_as_primary", "sent correct request");
+          start();
+        });
+
+        try {
+          controller.get(testHelpers.testOrigin, {}, function() {}, function() {});
+        }
+        catch(e) {
+          // do nothing, an exception will be thrown because no modules are
+          // registered for the any services.
+        }
+      }
+    });
+  });
+  
+  asyncTest("#AUTH_RETURN with add=true should not call usedAddressAsPrimary", function() {
+    winMock.location.hash = "#AUTH_RETURN";
+    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+      add: true,
+      email: TESTEMAIL
+    });
+    xhr.setContextInfo("authenticated", true);
+    xhr.setContextInfo("auth_level", "assertion");
+    delete xhr.request;
+
+    createController({
+      ready: function() {
+        mediator.subscribe("start", function(msg, info) {
+          var req = xhr.getLastRequest();
+          notEqual(req && req.url, "/wsapi/used_address_as_primary", "request should not be sent");
           start();
         });
 


### PR DESCRIPTION
dont call used_address_as_primary if adding email

if adding, then user doesn't yet own this email. if not
adding, then user does own it, so we should mark it.

fixes #2840
