### PR TITLE
dont call used_address_as_primary if adding email

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ train-2012.12.07:
   * (hotfix 2012.12.11) verifier default port number fix: bug #820446
   * (hotfix 2012.12.12) fix ie8 exceptions noticed in unit tests: #2846
   * (hotfix 2012.12.12) fixes how warning screens are shown and dismissed #2839
+  * (hotfix 2012.12.13) fixes 400 from used_address_as_primary: #2840
 
 train-2012.11.23:
   * New selenium tests authored in node.js merged.

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -291,10 +291,17 @@ BrowserID.Modules.Dialog = (function() {
         self.publish("start", params);
       }
 
-      if (params.type === "primary") {
+      if (params.type === "primary" && !params.add) {
         // at this point, we will only have type of primary if we're
         // returning from #AUTH_RETURN. Mark that email as having been
         // used as a primary, in case it used to be a secondary.
+        // If being added, the user doesn't own this email yet, and the
+        // status will be changed in add_email_with_assertion.
+        //
+        // NOTE: calling start for a request failure is the desired behavior.
+        // If this call fails, it is no big deal, the user should not be
+        // blocked. See
+        // https://github.com/mozilla/browserid/issues/2840#issuecomment-11215155
         user.usedAddressAsPrimary(params.email, start, start);
       } else {
         start();

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -253,7 +253,7 @@
   asyncTest("#AUTH_RETURN while authenticated should call usedAddressAsPrimary", function() {
     winMock.location.hash = "#AUTH_RETURN";
     winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
-      add: true,
+      add: false,
       email: TESTEMAIL
     });
     xhr.setContextInfo("authenticated", true);
@@ -264,6 +264,35 @@
         mediator.subscribe("start", function(msg, info) {
           var req = xhr.getLastRequest();
           equal(req && req.url, "/wsapi/used_address_as_primary", "sent correct request");
+          start();
+        });
+
+        try {
+          controller.get(testHelpers.testOrigin, {}, function() {}, function() {});
+        }
+        catch(e) {
+          // do nothing, an exception will be thrown because no modules are
+          // registered for the any services.
+        }
+      }
+    });
+  });
+  
+  asyncTest("#AUTH_RETURN with add=true should not call usedAddressAsPrimary", function() {
+    winMock.location.hash = "#AUTH_RETURN";
+    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+      add: true,
+      email: TESTEMAIL
+    });
+    xhr.setContextInfo("authenticated", true);
+    xhr.setContextInfo("auth_level", "assertion");
+    delete xhr.request;
+
+    createController({
+      ready: function() {
+        mediator.subscribe("start", function(msg, info) {
+          var req = xhr.getLastRequest();
+          notEqual(req && req.url, "/wsapi/used_address_as_primary", "request should not be sent");
           start();
         });
 

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2012.12.07
-Release:       3%{?dist}_%{svnrev}
+Release:       4%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
if adding, then user doesn't yet own this email. if not
adding, then user does own it, so we should mark it.

fixes #2840

Conflicts:

```
resources/static/dialog/js/modules/dialog.js
```
