### PR TITLE
unverified email for b2g

### DIFF
--- a/bin/keysigner
+++ b/bin/keysigner
@@ -88,7 +88,7 @@ try {
 
 
 // and our single function
-app.post('/wsapi/cert_key', validate(certKey.args), function(req, resp) {
+app.post('/wsapi/cert_key', validate({ 'email': 'email', 'pubkey': 'pubkey', 'ephemeral': 'boolean', 'unverified': { type: 'boolean', required: false } }), function(req, resp) {
   var startTime = new Date();
   var forceIssuer = req.params.forceIssuer;
   var opts = {};
@@ -101,7 +101,8 @@ app.post('/wsapi/cert_key', validate(certKey.args), function(req, resp) {
   }
   cc.enqueue(_.extend(opts, {
     pubkey: req.params.pubkey,
-    email: req.params.email,    
+    email: req.params.email,
+    unverified: !!req.params.unverified,
     validityPeriod: (req.params.ephemeral ? config.get('ephemeral_session_duration_ms') : config.get('certificate_validity_ms')),
     hostname: HOSTNAME
   }), function (err, r) {

--- a/bin/verifier
+++ b/bin/verifier
@@ -18,7 +18,8 @@ heartbeat = require('../lib/heartbeat'),
 logger = require('../lib/logging').logger,
 config = require('../lib/configuration'),
 shutdown = require('../lib/shutdown'),
-statsd = require('../lib/statsd');
+statsd = require('../lib/statsd'),
+booleanQuery = require('../lib/boolean-query');
 
 logger.info("verifier server starting up");
 
@@ -57,6 +58,7 @@ if (statsd_config && statsd_config.enabled) {
 }
 
 app.use(express.bodyParser());
+app.use(booleanQuery);
 
 try {
   // explicitly relay VAR_PATH to children
@@ -90,6 +92,8 @@ function doVerification(req, resp, next) {
   } else if (req.body && req.body.forceIssuer) {
     forceIssuer =  req.body.forceIssuer;
   }
+  var allowUnverified = (req.query && req.query.allowUnverified) || req.body.allowUnverified;
+  
 
   if (!(assertion && audience)) {
     // why couldn't we extract these guys?  Is it because the request parameters weren't encoded as we expect? GH-643
@@ -121,7 +125,8 @@ function doVerification(req, resp, next) {
   cc.enqueue({
     assertion: assertion,
     audience: audience,
-    forceIssuer: forceIssuer
+    forceIssuer: forceIssuer,
+    allowUnverified: !!allowUnverified
   }, function (err, r) {
     var reqTime = new Date - startTime;
     statsd.timing('assertion_verification_time', reqTime);

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -80,6 +80,9 @@ pre {
     </li><li>
       <input type="checkbox" id="forceAuthentication">
       <label for="forceAuthentication">Force Authentication</label><br />
+    </li><li>
+      <input type="checkbox" id="allowUnverified">
+      <label for="allowUnverified">Allow Unverified</label><br />
     </li>
   </ul>
     <button class="assertion">Get an assertion</button>
@@ -143,7 +146,8 @@ function checkAssertion(assertion) {
     data: {
       assertion: assertion,
       audience: window.location.protocol + "//" + window.location.host,
-      forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined
+      forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
+      allowUnverified: $('#allowUnverified').attr('checked') ? true : false
     },
     success: function(data, textStatus, jqXHR) {
       var old = $(".loginEvents > pre").text() + "\n";
@@ -192,6 +196,7 @@ $(document).ready(function() {
       returnTo: $('#returnTo').attr('checked') ? "/postVerificationReturn.html" : undefined,
       forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
       forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
+      allowUnverified: $('#allowUnverified').attr('checked') ? true : false,
       oncancel: function() {
         loggit("oncancel");
         $(".specify button.assertion").removeAttr('disabled');

--- a/lib/boolean-query.js
+++ b/lib/boolean-query.js
@@ -1,0 +1,8 @@
+module.exports = function boolean_query(req, res, next) {
+  Object.keys(req.query).forEach(function(key) {
+    if (req.query[key] === "true") req.query[key] = true;
+    else if (req.query[key] === "false") req.query[key] = false;
+  });
+  
+  next();
+};

--- a/lib/db.js
+++ b/lib/db.js
@@ -92,7 +92,8 @@ exports.onReady = function(f) {
   'userKnown',
   'userOwnsEmail',
   'verificationSecretForEmail',
-  'getIDPLastSeen'
+  'getIDPLastSeen',
+  'checkUnverifiedAuth'
 ].forEach(function(fn) {
   exports[fn] = function() {
     checkReady();
@@ -116,7 +117,8 @@ exports.onReady = function(f) {
   'updatePassword',
   'createUserWithPrimaryEmail',
   'addPrimaryEmailToAccount',
-  'updateIDPLastSeen'
+  'updateIDPLastSeen',
+  'createUnverifiedUser'
 ].forEach(function(fn) {
   exports[fn] = function() {
     if (!config.get('database.may_write')) {

--- a/lib/db/json.js
+++ b/lib/db/json.js
@@ -207,11 +207,20 @@ exports.emailToUID = function(email, cb) {
   });
 };
 
-exports.userOwnsEmail = function(uid, email, cb) {
+exports.userOwnsEmail = function(uid, email, staged, cb) {
   sync();
+  if (typeof staged === "function") {
+    cb = staged;
+    staged = false;
+  }
   var m = jsel.match(":root > object:has(:root > .id:expr(x=" + ESC(uid) + ")):has(.emails > ." + ESC(email) + ")", db.users);
+  var owned = m && m.length === 1;
+  if (!owned && staged) {
+    m = jsel.match(":root > object:has(:root > .existing_user:expr(x=" + ESC(uid) +")):has(:root > .email:expr(x=" + ESC(email) + "))", db.staged);
+    owned = m && m.length;
+  }
   process.nextTick(function() {
-    cb(null, m && m.length === 1);
+    cb(null, owned);
   });
 };
 
@@ -476,6 +485,14 @@ exports.checkAuth = function(userID, cb) {
   process.nextTick(function() { cb(null, m); });
 };
 
+exports.checkUnverifiedAuth = function(email, cb) {
+  sync();
+  var m = jsel.match(":root > object:has(:root > .email:expr(x=" + ESC(email) +")) > .passwd", db.staged);
+  if (m.length === 0) m = undefined;
+  else m = m[0];
+  process.nextTick(function() { cb(null, m); });
+};
+
 exports.lastPasswordReset = function(userID, cb) {
   sync();
   var m;
@@ -584,6 +601,25 @@ exports.cancelAccount = function(authenticated_uid, cb) {
   }
 
   process.nextTick(function() { cb(null); });
+};
+
+exports.createUnverifiedUser = function(email, hash, cb) {
+  sync();
+  var emailVal = {};
+  emailVal[email] = {
+    type: 'secondary',
+    verified: false
+  };
+  var row = {
+    id: getNextUserID(),
+    lastPasswordReset: now(),
+    emails: emailVal
+  };
+  db.users.push(row);
+  flush();
+  exports.stageEmail(row.id, email, hash, function(err, secret) {
+    cb(err, row.id, secret);
+  });
 };
 
 exports.addTestUser = function(email, hash, cb) {

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -569,6 +569,15 @@ exports.checkAuth = function(uid, cb) {
     });
 };
 
+exports.checkUnverifiedAuth = function(email, cb) {
+  client.query(
+    'SELECT passwd FROM staged WHERE email = ?',
+    [ email ],
+    function (err, rows) {
+      cb(err, (rows && rows.length === 1) ? rows[0].passwd : undefined);
+    });
+};
+
 exports.lastPasswordReset = function(uid, cb) {
   client.query(
     'SELECT UNIX_TIMESTAMP(lastPasswordReset) AS lastPasswordReset FROM user WHERE id = ?',
@@ -663,6 +672,28 @@ exports.cancelAccount = function(uid, cb) {
     if (err) return cb(err);
     client.query("DELETE LOW_PRIORITY FROM user WHERE id = ?", [ uid ], cb);
   });
+};
+
+exports.createUnverifiedUser = function(email, hash, cb) {
+  client.query(
+    'INSERT INTO users(lastPasswordReset) VALUES(FROM_UNIXTIME(?))',
+    [ now() ],
+    function(err, info) {
+      if (err) return cb(err);
+
+      client.query(
+        'INSERT INTO email(user, address) VALUES(?, ?)',
+        [ info.insertId, email ],
+        function(err) {
+          if (err) {
+            logUnexpectedError(err);
+            return cb(err);
+          }
+          exports.stageEmail(info.insertId, email, hash, function(err, secret) {
+            cb(err, info.insertId, secret);
+          });
+        });
+    });
 };
 
 exports.addTestUser = function(email, hash, cb) {

--- a/lib/keysigner/ca.js
+++ b/lib/keysigner/ca.js
@@ -25,11 +25,17 @@ function parsePublicKey(serializedPK) {
   return jwcrypto.loadPublicKey(serializedPK);
 }
 
-function certify(hostname, email, publicKey, expiration, cb) {
+function certify(hostname, email, publicKey, expiration, unverified, cb) {
   if (expiration == null)
     return cb("expiration cannot be null");
 
-  cert.sign({publicKey: publicKey, principal: {email: email}},
+  //TODO: use a different secret if unverified
+
+  var principal = {};
+  principal[ unverified ? 'unverified-email' : 'email' ] = email;
+  
+
+  cert.sign({publicKey: publicKey, principal: principal},
             {issuer: hostname, issuedAt: new Date(), expiresAt: expiration},
             null,
             secret_key, cb);

--- a/lib/keysigner/keysigner-compute.js
+++ b/lib/keysigner/keysigner-compute.js
@@ -15,7 +15,7 @@ process.on('message', function(m) {
     var expiration = new Date();
     expiration.setTime(new Date().valueOf() + m.validityPeriod);
     var issuer = !!m.forceIssuer ? m.forceIssuer : m.hostname;
-    ca.certify(issuer, m.email, pk, expiration, function(err, cert) {
+    ca.certify(issuer, m.email, pk, expiration, m.unverified, function(err, cert) {
       if (err)
         return process.send({"error": err});
 

--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -25,6 +25,7 @@ try {
 }
 
 const HOSTNAME = urlparse(config.get('public_url')).host;
+const UNVERIFIED_EMAIL = 'unverified-email';
 
 logger.debug("This verifier will accept assertions issued by " + HOSTNAME);
 
@@ -89,7 +90,8 @@ function compareAudiences(want, got) {
 // assertion is a bundle of the underlying assertion and the cert list
 // audience is a web origin, e.g. https://foo.com or http://foo.org:81
 // forceIssuer is a hostname or `undefined` for normal BID protocol
-function verify(assertion, audience, forceIssuer, successCB, errorCB) {
+// allowUnverified is boolean to check for email or unverified-email
+function verify(assertion, audience, forceIssuer, allowUnverified, successCB, errorCB) {
   // assertion is bundle
   var ultimateIssuer;
 
@@ -142,9 +144,23 @@ function verify(assertion, audience, forceIssuer, successCB, errorCB) {
       // principal is in the last cert
       var principal = certParamsArray[certParamsArray.length - 1].certParams.principal;
 
+      // unverified assertions are only valid if they are expected
+      if (principal[UNVERIFIED_EMAIL] && !allowUnverified) {
+        return errorCB("unverified email");
+      }
+
       // verify that the issuer is the same as the email domain or
       // that the email's domain delegated authority to the issuer
-      var domainFromEmail = principal.email.replace(/^.*@/, '');
+      var email = principal.email;
+      if (allowUnverified && !email) {
+        email = principal[UNVERIFIED_EMAIL];
+      }
+      
+      if (!email) {
+        return errorCB("missing email");
+      }
+
+      var domainFromEmail = email.replace(/^.*@/, '');
 
       if (ultimateIssuer !== HOSTNAME &&
           ultimateIssuer !== domainFromEmail &&
@@ -152,14 +168,14 @@ function verify(assertion, audience, forceIssuer, successCB, errorCB) {
       {
           primary.delegatesAuthority(domainFromEmail, ultimateIssuer, function (delegated) {
             if (delegated) {
-              return successCB(principal.email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
+              return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
             } else {
               return errorCB("issuer '" + ultimateIssuer + "' may not speak for emails from '"
                          + domainFromEmail + "'");
             }
           });
       } else {
-        return successCB(principal.email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
+        return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
       }
     }, errorCB);
 }

--- a/lib/verifier/verifier-compute.js
+++ b/lib/verifier/verifier-compute.js
@@ -8,7 +8,7 @@ certassertion = require('./certassertion.js');
 process.on('message', function(m) {
   try {
     certassertion.verify(
-      m.assertion, m.audience, m.forceIssuer,
+      m.assertion, m.audience, m.forceIssuer, !!m.allowUnverified,
       function(email, audienceFromAssertion, expires, issuer) {
         process.send({
           success: {

--- a/lib/wsapi.js
+++ b/lib/wsapi.js
@@ -22,6 +22,7 @@ config = require('./configuration'),
 logger = require('./logging.js').logger,
 httputils = require('./httputils.js'),
 forward = require('./http_forward.js').forward,
+booleanQuery = require('./boolean-query'),
 url = require('url'),
 fs = require('fs'),
 path = require('path'),
@@ -86,6 +87,7 @@ function authenticateSession(options, cb) {
   var uid = options.uid;
   var level = options.level;
   var duration_ms = options.duration_ms;
+  var unverified = options.unverified;
   if (['assertion', 'password'].indexOf(level) === -1)
     cb(new Error("invalid authentication level: " + level));
 
@@ -106,6 +108,7 @@ function authenticateSession(options, cb) {
       session.userid = uid;
       session.auth_level = level;
       session.lastPasswordReset = lastPasswordReset;
+      session.unverified = unverified;
     }
     cb(null);
   });
@@ -282,6 +285,8 @@ exports.setup = function(options, app) {
       secure: overSSL
     }
   });
+
+  app.use(booleanQuery);
 
   app.use(function(req, resp, next) {
     var purl = url.parse(req.url);

--- a/lib/wsapi/authenticate_user.js
+++ b/lib/wsapi/authenticate_user.js
@@ -22,7 +22,11 @@ exports.i18n = false;
 exports.args = {
   'email': 'email',
   'pass':  'password',
-  'ephemeral': 'boolean'
+  'ephemeral': 'boolean',
+  'allowUnverified': {
+    type: 'boolean',
+    required: false
+  }
 };
 
 exports.process = function(req, res) {
@@ -33,6 +37,7 @@ exports.process = function(req, res) {
     logger.debug('authentication fails for user: ' + req.params.email + (reason ? (' - ' + reason) : ""));
     return res.json(r);
   }
+  
 
   db.emailToUID(req.params.email, function(err, uid) {
     if (err) return wsapi.databaseDown(res, err);
@@ -41,13 +46,7 @@ exports.process = function(req, res) {
       return fail('no such user');
     }
 
-    db.checkAuth(uid, function(err, hash) {
-      if (err) return wsapi.databaseDown(res, err);
-
-      if (typeof hash !== 'string') {
-        return fail('no password set for user');
-      }
-
+    function compare(hash, unverified) {
       var startTime = new Date();
       bcrypt.compare(req.params.pass, hash, function (err, success) {
         var reqTime = new Date() - startTime;
@@ -71,6 +70,7 @@ exports.process = function(req, res) {
 
           wsapi.authenticateSession({session: req.session, uid: uid,
                                      level: 'password',
+                                     unverified: unverified,
                                      duration_ms: req.params.ephemeral ?
                                       config.get('ephemeral_session_duration_ms')
                                       : config.get('authentication_duration_ms')
@@ -86,6 +86,26 @@ exports.process = function(req, res) {
                                     });
         }
       });
+    }
+
+    db.checkAuth(uid, function(err, hash) {
+      if (err) return wsapi.databaseDown(res, err);
+
+      if (typeof hash !== 'string') {
+        if (req.params.allowUnverified) {
+          db.checkUnverifiedAuth(req.params.email, function(err, hash) {
+            if (err) return wsapi.databaseDown(res, err);
+            if (!hash) return fail('no password set for user');
+            
+            compare(hash, true);
+          });
+        } else {
+          return fail('no password set for user');
+        }
+      } else {
+        compare(hash, false);
+      }
+
     });
   });
 };

--- a/lib/wsapi/cert_key.js
+++ b/lib/wsapi/cert_key.js
@@ -21,24 +21,23 @@ exports.args = {
   'forceIssuer': {
     type: 'hostname',
     required: false
+  },
+  'allowUnverified': {
+    type: 'boolean',
+    required: false
   }
 };
 exports.i18n = false;
 
 exports.process = function(req, res) {
-  db.userOwnsEmail(req.session.userid, req.params.email, function(err, owned) {
+  db.userOwnsEmail(req.session.userid, req.params.email, req.params.allowUnverified, function(err, owned) {
     if (err) return wsapi.databaseDown(res, err);
 
     // not same account? big fat error
     if (!owned) return httputils.badRequest(res, "that email does not belong to you");
 
-    // secondary addresses in the database may be "unverified".  this occurs when
-    // a user forgets their password.  We will not issue certs for unverified email
-    // addresses
-    db.emailIsVerified(req.params.email, function(err, verified) {
-      if (!verified) return httputils.forbidden(res, "that email requires (re)verification");
-
-      // forward the certification request the keysigner
+    function forwardToKeysigner(unverified) {
+      // forward to the keysigner!
       var keysigner = urlparse(config.get('keysigner_url'));
       keysigner.path = '/wsapi/cert_key';
 
@@ -49,7 +48,14 @@ exports.process = function(req, res) {
       // http_forward, however, will only forward params in req.body
       // or req.query.  so we explicitly copy req.params to req.body
       // to cause them to be forwarded.
-      req.body = req.params;
+      var body = {
+        'email': req.params.email,
+        'pubkey': req.params.pubkey,
+        'ephemeral': req.params.ephemeral,
+        'unverified': unverified
+      };
+      req.body = body;
+
       forward(keysigner, req, res, function(err) {
         if (err) {
           logger.error("error forwarding request to keysigner: " + err);
@@ -81,6 +87,17 @@ exports.process = function(req, res) {
       }, function(err) {
         if (err) logger.warn("couldn't update lastUsedAs: " + err);
       });
+    }
+
+
+
+    // secondary addresses in the database may be "unverified".  this occurs when
+    // a user forgets their password.  We will not issue certs for unverified email
+    // addresses
+    // ... unless allowUnverified is true
+    db.emailIsVerified(req.params.email, function(err, verified) {
+      if (!verified && !req.params.allowUnverified) return httputils.forbidden(res, "that email requires (re)verification");
+      forwardToKeysigner(!verified);
     });
   });
 };

--- a/lib/wsapi/session_context.js
+++ b/lib/wsapi/session_context.js
@@ -19,6 +19,12 @@ exports.method = 'get';
 exports.writes_db = false;
 exports.authed = false;
 exports.i18n = false;
+exports.args = {
+  'allowUnverified': {
+    type: 'boolean',
+    required: false
+  }
+};
 
 // determine the domain key creation date - issue #599
 const domainKeyCreationDate = secrets.publicKeyCreationDate();
@@ -27,6 +33,10 @@ logger.debug("domain key was created at " + domainKeyCreationDate + " (certs iss
 exports.process = function(req, res) {
   if (typeof req.session === 'undefined') {
     req.session = {};
+  }
+
+  if (req.session.unverified && !req.params.allowUnverified) {
+    wsapi.clearAuthenticatedUser(req.session);
   }
 
   if (typeof req.session.csrf === 'undefined') {
@@ -47,6 +57,7 @@ exports.process = function(req, res) {
       authenticated: authenticated,
       auth_level: auth_level,
       has_password: has_password,
+      unverified: req.session.unverified,
       domain_key_creation_time: domainKeyCreationDate.getTime(),
       random_seed: crypto.randomBytes(32).toString('base64'),
       data_sample_rate: config.get('kpi_backend_sample_rate')

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -23,12 +23,18 @@ exports.authed = false;
 exports.args = {
   'email': 'email',
   'pass': 'password',
+  'allowUnverified': {
+    type: 'boolean',
+    required: false
+  },
   'site': 'origin'
 };
 exports.i18n = true;
 
 exports.process = function(req, res) {
   var langContext = wsapi.langContext(req);
+
+  var allowUnverified = !!req.params.allowUnverified;
 
   db.lastStaged(req.params.email, function (err, last) {
     if (err) return wsapi.databaseDown(res, err);
@@ -58,30 +64,50 @@ exports.process = function(req, res) {
       }
 
       try {
-        // upon success, stage_user returns a secret (that'll get baked into a url
-        // and given to the user), on failure it throws
-        db.stageUser(req.params.email, hash, function(err, secret) {
-          if (err) {
-            cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure", req, {msg: err});
-            return wsapi.databaseDown(res, err);
-          }
+        if (allowUnverified) {
+          // if its ok to be unverified, then create the user right now,
+          // and stage their email instead.
+          db.createUnverifiedUser(req.params.email, hash, function(err, uid, secret) {
+            if (err) {
+              cef_logger("DB_FAILURE", "Cannot create unverified user; dbwriter failure", req, {msg: err});
+              return wsapi.databaseDown(res, err);
+            }
 
-          // store the email being registered in the session data
-          if (!req.session) req.session = {};
+            if (!req.session) req.session = {};
+            req.session.pendingAddition = secret;
 
-          // store the secret we're sending via email in the users session, as checking
-          // that it still exists in the database is the surest way to determine the
-          // status of the email verification.
-          req.session.pendingCreation = secret;
+            res.json({ success: true, unverified: true });
 
-          res.json({ success: true });
+            email.sendNewUserEmail(req.params.email, req.params.site, secret, langContext);
+          });
+        } else {
+          // the typical flow
 
-          // let's now kick out a verification email!
-          email.sendNewUserEmail(req.params.email, req.params.site, secret, langContext);
-        });
+          // upon success, stage_user returns a secret (that'll get baked into a url
+          // and given to the user), on failure it throws
+          db.stageUser(req.params.email, hash, function(err, secret) {
+            if (err) {
+              cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure", req, {msg: err});
+              return wsapi.databaseDown(res, err);
+            }
+
+            // store the email being registered in the session data
+            if (!req.session) req.session = {};
+
+            // store the secret we're sending via email in the users session, as checking
+            // that it still exists in the database is the surest way to determine the
+            // status of the email verification.
+            req.session.pendingCreation = secret;
+
+            res.json({ success: true });
+
+            // let's now kick out a verification email!
+            email.sendNewUserEmail(req.params.email, req.params.site, secret, langContext);
+          });
+        }
       } catch(e) {
         // we should differentiate tween' 400 and 500 here.
-        httputils.badRequest(res, e.toString());
+        httputils.badRequest(res, String(e));
       }
     });
   });

--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -472,8 +472,6 @@ footer .help {
 }
 
 #wait, #delay, #error {
-  background:#ccc;
-  /*
   background-color: #dadee1;
   background-image: url("/common/i/grain.png"), -webkit-gradient(linear, left top, left bottom, from(#dadee1), to(#c7ccd0));
   background-image: url("/common/i/grain.png"), -webkit-linear-gradient(top, #dadee1, #c7ccd0);
@@ -481,7 +479,6 @@ footer .help {
   background-image: url("/common/i/grain.png"),     -ms-linear-gradient(top, #dadee1, #c7ccd0);
   background-image: url("/common/i/grain.png"),      -o-linear-gradient(top, #dadee1, #c7ccd0);
   background-image: url("/common/i/grain.png"),         linear-gradient(top, #dadee1, #c7ccd0);
-  */
 }
 
 #wait .contents, #error .contents, #delay .contents {

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -12,6 +12,7 @@ BrowserID.Network = (function() {
       server_time,
       domain_key_creation_time,
       auth_status,
+      allow_unverified = false,
       code_version,
       userid,
       time_until_delay,
@@ -86,13 +87,11 @@ BrowserID.Network = (function() {
     post({
       url: wsapiName,
       data: data,
-      success: function(status) {
-        complete(onComplete, status.success);
-      },
+      success: onComplete,
       error: function(info) {
         // 429 is throttling.
         if (info.network.status === 429) {
-          complete(onComplete, false);
+          complete(onComplete, {});
         }
         else complete(onFailure, info);
       }
@@ -154,7 +153,8 @@ BrowserID.Network = (function() {
         data: {
           email: email,
           pass: password,
-          ephemeral: !storage.usersComputer.confirmed(email)
+          ephemeral: !storage.usersComputer.confirmed(email),
+          allowUnverified: allow_unverified
         },
         success: handleAuthenticationResponse.curry("password", onComplete, onFailure),
         error: onFailure
@@ -255,7 +255,8 @@ BrowserID.Network = (function() {
       var postData = {
         email: email,
         pass: password,
-        site : origin
+        site : origin,
+        allowUnverified: allow_unverified
       };
       stageAddressForVerification(postData, "/wsapi/stage_user", onComplete, onFailure);
     },
@@ -586,7 +587,8 @@ BrowserID.Network = (function() {
         data: _.extend(opts, {
           email: email,
           pubkey: pubkey.serialize(),
-          ephemeral: !storage.usersComputer.confirmed(email)
+          ephemeral: !storage.usersComputer.confirmed(email),
+          allowUnverified: allow_unverified
         }),
         success: onComplete,
         error: onFailure
@@ -757,6 +759,17 @@ BrowserID.Network = (function() {
           complete(onFailure, "user not authenticated");
         }
       }, onFailure);
+    },
+
+    /**
+     * Set whether the network should pass allowUnverified=true in
+     * its requests.
+     * @method setAllowUnverified
+     * @param {boolean} [allow] - True or false, to allow.
+     */
+    setAllowUnverified: function(allow) {
+      allow_unverified = allow;
+      xhr.setAllowUnverified(allow);
     }
   };
 

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -115,8 +115,8 @@ BrowserID.User = (function() {
 
     // stagingStrategy is a curried function that will have all but the
     // onComplete and onFailure functions already set up.
-    stagingStrategy(function(staged) {
-      var status = { success: staged };
+    stagingStrategy(function(status) {
+      var staged = status.success;
 
       if (!staged) status.reason = "throttle";
       // Used on the main site when the user verifies - once

--- a/resources/static/common/js/xhr.js
+++ b/resources/static/common/js/xhr.js
@@ -8,6 +8,7 @@ BrowserID.XHR = (function() {
       mediator = bid.Mediator,
       context,
       csrf_token,
+      allow_unverified = false,
       transport = bid.XHRTransport,
       time_until_delay;
 
@@ -112,9 +113,11 @@ BrowserID.XHR = (function() {
   function withContext(cb, onFailure) {
     if (typeof context !== 'undefined') cb(context);
     else {
+      var data = allow_unverified ? { allowUnverified: true } : undefined;
       request({
         type: "GET",
         url: "/wsapi/session_context",
+        data: data,
         success: function(result) {
           csrf_token = result.csrf_token;
           context = result;
@@ -187,7 +190,11 @@ BrowserID.XHR = (function() {
      * Clear the current context
      * @method clearContext
      */
-    clearContext: clearContext
+    clearContext: clearContext,
+
+    setAllowUnverified: function(allow) {
+      allow_unverified = allow;
+    }
   };
 }());
 

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -16,7 +16,7 @@
    * horizontal lines to appear while the dialog is loading.
    */
   body {
-    /*background-image: url('/common/i/grain.png');*/
+    background-image: url('/common/i/grain.png');
   }
 
 
@@ -78,7 +78,7 @@
        */
       position: static;
       padding: 10px;
-      /*border-bottom: 1px solid rgba(0,0,0,0.05);*/
+      border-bottom: 1px solid rgba(0,0,0,0.05);
       text-align: center;
       left: 0;
   }

--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -4,8 +4,6 @@
 
 body {
   color: #383838;
-  background:#ccc;
-  /*
   background-color: #dee3e6;
   background-image: url('/common/i/grain.png');
   background-image: url("/common/i/grain.png"), -webkit-gradient(linear, left top, left bottom, from(rgba(113, 126, 137, 0)), to(rgba(113, 126, 137, 0.2)));
@@ -14,7 +12,6 @@ body {
   background-image: url('/common/i/grain.png'),     -ms-linear-gradient(top, rgba(113, 126, 137, 0), rgba(113, 126, 137, 0.2));
   background-image: url('/common/i/grain.png'),      -o-linear-gradient(top, rgba(113, 126, 137, 0), rgba(113, 126, 137, 0.2));
   background-image: url('/common/i/grain.png'),         linear-gradient(top, rgba(113, 126, 137, 0), rgba(113, 126, 137, 0.2));
-  */
   line-height: 18px;
 }
 
@@ -43,7 +40,7 @@ body {
 header, footer {
     position: absolute;
     z-index: 2;
-    /*box-shadow: 0 0 24px rgba(0, 0, 0, 0.05) inset;*/
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.05) inset;
 }
 
 header {
@@ -55,21 +52,18 @@ header {
      * overflow the dialog box.
      */
     *padding: 10px 0;
-    /*border-bottom: 1px solid #c7c6c1;*/
+    border-bottom: 1px solid #c7c6c1;
 
     /*-ms-filter through zoom: 1 are fixes for IE6 and IE7 so they show the header
      */
     -ms-filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#0c000000,endColorstr=#0c000000);
     filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#0c000000,endColorstr=#0c000000);
     zoom: 1;
-    background:#ccc;
-    /*
     background-image: -webkit-linear-gradient(top, rgba(0,0,0,.05), rgba(0,0,0,0));
     background-image:    -moz-linear-gradient(top, rgba(0,0,0,.05), rgba(0,0,0,0));
     background-image:     -ms-linear-gradient(top, rgba(0,0,0,.05), rgba(0,0,0,0));
     background-image:      -o-linear-gradient(top, rgba(0,0,0,.05), rgba(0,0,0,0));
     background-image:         linear-gradient(top, rgba(0,0,0,.05), rgba(0,0,0,0));
-    */
 }
 
 h2 {
@@ -83,7 +77,7 @@ h3 {
 
 .home {
   width: 211px;
-  height: 44px;
+  height: 40px;
   background: url("/dialog/i/firefox-accounts-logo.png") 0 0 no-repeat;
   text-indent: -9999px;
   display: inline-block;
@@ -93,7 +87,7 @@ h3 {
 
 footer {
     bottom: 0;
-    border-top: 3px solid #aaa;
+    border-top: 1px solid #c7c6c1;
     /* The *padding is a fix for IE6 and IE7 showing scroll bars in the
      * unsupported dialog.  Since IE6 and IE7 do not support box-sizing:
      * border-box, the left and right padding cause these versions of IE to
@@ -102,14 +96,11 @@ footer {
     padding: 20px;
     *padding: 20px 0;
     text-align: center;
-    background:#ccc;
-    /*
     background-image: -webkit-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,.05));
     background-image:    -moz-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,.05));
     background-image:     -ms-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,.05));
     background-image:      -o-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,.05));
     background-image:         linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,.05));
-    */
 }
 
 label {
@@ -284,7 +275,7 @@ section > .contents {
 
 
 #signIn .table {
-    background-color: #ccc;
+    background-color: #eff0f2;
     padding: 0 20px;
 }
 
@@ -303,12 +294,10 @@ section > .contents {
     bottom: 0;
     left: 0;
     right: 0;
-    /*
     background-image: url('/dialog/i/arrow_grey.png');
     background-repeat: no-repeat;
     background-position: center;
     background-color: transparent;
-    */
 }
 
 #favicon {

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -82,7 +82,13 @@
     user.createSecondaryUser(email, password, function(status) {
       if (status.success) {
         var info = { email: email, password: password };
-        self.publish("user_staged", info, info);
+        if (status.unverified) {
+          info.type = "secondary";
+          info.unverified = true;
+          self.publish("unverified_created", info, info);
+        } else {
+          self.publish("user_staged", info, info);
+        }
         complete(callback, true);
       }
       else {

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -118,6 +118,10 @@ BrowserID.State = (function() {
       self.siteName = info.siteName || info.hostname;
       self.siteTOSPP = !!(info.privacyPolicy && info.termsOfService);
       self.forceIssuer = user.forceIssuer = (!!info.forceIssuer ? info.forceIssuer : 'default');
+      
+      self.allowUnverified = info.allowUnverified;
+      network.setAllowUnverified(info.allowUnverified);
+
       startAction(false, "doRPInfo", info);
 
       if (info.email && info.type === "primary") {
@@ -242,6 +246,10 @@ BrowserID.State = (function() {
     });
 
     handleState("user_staged", handleEmailStaged.curry("doConfirmUser"));
+
+    handleState("unverified_created", function(msg, info) {
+      startAction(false, "doAuthenticateWithUnverifiedEmail", info);
+    });
 
     handleState("user_confirmed", handleEmailConfirmed);
 
@@ -409,7 +417,7 @@ BrowserID.State = (function() {
         self.transitionNoPassword = info.email;
         startAction("doSetPassword", _.extend({transition_no_password: true}, info));
       }
-      else if (info.state === 'unverified') {
+      else if (info.state === 'unverified' && !self.allowUnverified) {
         // user selected an unverified secondary email, kick them over to the
         // verify screen.
         redirectToState("stage_reverify_email", info);

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -95,6 +95,13 @@ BrowserID.Modules.Actions = (function() {
       startService("required_email", info);
     },
 
+    doAuthenticateWithUnverifiedEmail: function(info) {
+      var self = this;
+      dialogHelpers.authenticateUser.call(this, info.email, info.password, function() {
+        self.publish("authenticated", info);
+      });
+    },
+
     doResetPassword: function(info) {
       startService("set_password", _.extend(info, { password_reset: true }), "reset_password");
     },

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -319,6 +319,13 @@ BrowserID.Modules.Dialog = (function() {
           params.forceAuthentication = true;
         }
 
+        // allowUnverified means that the user doesn't need to have
+        // verified their email address in order to send an assertion.
+        // if the user *has* verified, it will be a verified assertion.
+        if (paramsFromRP.allowUnverified) {
+          params.allowUnverified = true;
+        }
+
         if (hash.indexOf("#AUTH_RETURN") === 0) {
           var primaryParams = JSON.parse(win.sessionStorage.primaryVerificationFlow);
           params.email = primaryParams.email;

--- a/scripts/serve_example.js
+++ b/scripts/serve_example.js
@@ -67,7 +67,8 @@ exampleServer.post('/process_assertion', function(req, res, next) {
   var audience = req.headers['host'] ? req.headers['host'] : localHostname;
   var params = {
     assertion: req.body.assertion,
-    audience: audience
+    audience: audience,
+    allowUnverified: req.body.allowUnverified
   };
   if (!! req.body.forceIssuer) params['forceIssuer'] = req.body.forceIssuer;
   var data = querystring.stringify(params);

--- a/tests/ca-test.js
+++ b/tests/ca-test.js
@@ -40,7 +40,7 @@ suite.addBatch({
       topic: function() {
         var expiration = new Date();
         expiration.setTime(new Date().valueOf() + 5000);
-        ca.certify(issuer, email_addr, kp.publicKey, expiration, this.callback);
+        ca.certify(issuer, email_addr, kp.publicKey, expiration, false, this.callback);
       },
       "does not error out": function(err, cert_raw) {
         assert.isNull(err);

--- a/tests/unverified-email-test.js
+++ b/tests/unverified-email-test.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require('./lib/test_env.js');
+
+const assert =
+require('assert'),
+vows = require('vows'),
+start_stop = require('./lib/start-stop.js'),
+wsapi = require('./lib/wsapi.js'),
+db = require('../lib/db.js'),
+config = require('../lib/configuration.js'),
+jwcrypto = require('jwcrypto'),
+http = require('http'),
+querystring = require('querystring'),
+path = require('path');
+
+var suite = vows.describe('verifier');
+
+require("jwcrypto/lib/algs/rs");
+require("jwcrypto/lib/algs/ds");
+
+// disable vows (often flakey?) async error behavior
+suite.options.error = false;
+
+start_stop.addStartupBatches(suite);
+
+
+// allowUnverified emails
+// this requires a whole other test user, since the account has not have
+// had its registration "completed"
+const UNVERIFIED_EMAIL = "unverified@testuser.com";
+const UNVERIFIED_ORIGIN = "http://testdomain.com:8080";
+const UNVERIFIED_DOMAIN = "testdomain.com";
+const UNVERIFIED_PASSWORD = "unverifiedpassword";
+
+suite.addBatch({
+  "account staging of unverified user": {
+    topic: function() {
+      wsapi.post('/wsapi/stage_user', {
+        email: UNVERIFIED_EMAIL,
+        pass: UNVERIFIED_PASSWORD,
+        site: UNVERIFIED_ORIGIN,
+        allowUnverified: true
+      }).call(this);
+    },
+    "is 200 OK":     function(err, r) {
+      assert.equal(r.code, 200);
+    },
+
+    "can then be authenticated": {
+      topic: wsapi.post('/wsapi/authenticate_user', {
+        email: UNVERIFIED_EMAIL,
+        pass: UNVERIFIED_PASSWORD,
+        ephemeral: true,
+        allowUnverified: true
+      }),
+      'successfully': function(err, r) {
+        assert.equal(r.code, 200);
+        var json = JSON.parse(r.body);
+        assert.isTrue(json.success);
+      },
+      "and completes user completion": {
+        topic: wsapi.get('/wsapi/session_context?allowUnverified=true'),
+        "successfully": function(err, r) {
+          assert.isNull(err);
+          assert.strictEqual(r.code, 200);
+          var resp = JSON.parse(r.body);
+          assert.strictEqual(typeof resp.csrf_token, 'string');
+          assert.strictEqual(resp.authenticated, true);
+          assert.strictEqual(resp.auth_level, 'password');
+          assert.strictEqual(resp.unverified, true);
+        }
+      }
+    }
+  }
+});
+
+// now we need to generate a keypair
+var unverified_keypair, unverified_cert;
+
+suite.addBatch({
+  "generating an unverified keypair": {
+    topic: function() {
+      jwcrypto.generateKeypair({algorithm: "DS", keysize: 256}, this.callback);
+    },
+    "succeeds": function(err, r) {
+      assert.isNull(err);
+      assert.isObject(r);
+      assert.isObject(r.publicKey);
+      assert.isObject(r.secretKey);
+      unverified_keypair = r;
+    }
+  }
+});
+
+suite.addBatch({
+  "certifying the public key": {
+    topic: function() {
+      wsapi.post('/wsapi/cert_key', {
+        email: UNVERIFIED_EMAIL,
+        pubkey: unverified_keypair.publicKey.serialize(),
+        allowUnverified: true,
+        ephemeral: false
+      }).call(this);
+    },
+    "works swimmingly": function(err, r) {
+      assert.strictEqual(r.code, 200);
+      assert.isString(r.body);
+    },
+    "provides the unverified cert": function(err, r) {
+      unverified_cert = r.body;
+      assert.lengthOf(unverified_cert.split('.'), 3);
+      var principal = JSON.parse(new Buffer(unverified_cert.split('.')[1], 'base64').toString()).principal;
+      // should not be an email property, only unverified-email
+      assert.strictEqual(principal['unverified-email'], UNVERIFIED_EMAIL);
+      assert.isUndefined(principal.email);
+    }
+  }
+});
+
+suite.addBatch({
+  "generating an assertion with allowsUnverified email": {
+    topic: function() {
+      var expirationDate = new Date(new Date().getTime() + (2 * 60 * 1000));
+      var self = this;
+      var opts = {
+        audience: UNVERIFIED_ORIGIN,
+        expiresAt: expirationDate
+      };
+      jwcrypto.assertion.sign({}, opts, unverified_keypair.secretKey, function(err, assertion) {
+        if (err) return self.callback(err);
+        var b = jwcrypto.cert.bundle([unverified_cert], assertion);
+        self.callback(null, b);
+      });
+    },
+    "yields a good looking assertion": function (err, r) {
+      assert.isString(r);
+      assert.equal(r.length > 0, true);
+    },
+    "will cause the verifier": {
+      topic: function(err, assertion) {
+        wsapi.post('/verify', {
+          audience: UNVERIFIED_ORIGIN,
+          assertion: assertion,
+          allowUnverified: true
+        }).call(this);
+      },
+      "to succeed": function (err, r) {
+        var resp = JSON.parse(r.body);
+        assert.strictEqual(resp.status, 'okay');
+        //assert.strictEqual(resp.issuer, "example.domain");
+        assert.strictEqual(resp.audience, UNVERIFIED_ORIGIN);
+        assert.strictEqual(resp.email, UNVERIFIED_EMAIL);
+      }
+    },
+    "without sending allowUnverified to verifier": {
+      topic: function(err, assertion) {
+        wsapi.post('/verify', {
+          audience: UNVERIFIED_ORIGIN,
+          assertion: assertion
+        }).call(this);
+      },
+      "to fail": function(err, r) {
+        var resp = JSON.parse(r.body);
+        assert.strictEqual(resp.status, "failure");
+        assert.strictEqual(resp.reason, "unverified email");
+      }
+    }
+  }
+});
+
+suite.addBatch({
+  "asking for session_context when unverified=false": {
+    topic: wsapi.get('/wsapi/session_context'),
+    "should not return the unverified session": function(err, r) {
+      assert.isNull(err);
+      assert.strictEqual(r.code, 200);
+      var resp = JSON.parse(r.body);
+      assert.strictEqual(resp.authenticated, false);
+      assert.isUndefined(resp.unverified);
+    }
+  }
+});
+
+
+start_stop.addShutdownBatches(suite);
+
+// run or export the suite.
+if (process.argv[1] === __filename) suite.run();
+else suite.export(module);
+


### PR DESCRIPTION
An implementation for B2G to ask allow users to log in even if
Persona has not verified that the user owns the email address.

Starts with navigator.id.request({ allowUnverified: true });
When the assertion is returned to the RP, and if they are using
the Persona verifier, must be sure to include an allowUnverified=true
parameter to the verifier, otherwise it will be rejected.

Behind the scenes, when the dialog tries to stage the user, instead
the user is created immediately, an email is added in our email table,
and a stagedEmail token is created and send to the user. When
allowUnverified is true, our wsapi will also check for a staged email/pass,
and use that to allow the user to login.
