### PR TITLE
Broken cef_logger call causes crash

### DIFF
--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -62,7 +62,7 @@ exports.process = function(req, res) {
         // and given to the user), on failure it throws
         db.stageUser(req.params.email, hash, function(err, secret) {
           if (err) {
-            cef_logger("DB_FAILURE", "Cannot stage user; dbwriter failure", req, {msg: err});
+            cef_logger.alert("DB_FAILURE", "Cannot stage user; dbwriter failure", req, {msg: err});
             return wsapi.databaseDown(res, err);
           }
 


### PR DESCRIPTION
Is calling the object (and crashing), not the method on the object
