### PR TITLE
[b2g] The verifier service should be explicit about unverified email

### DIFF
--- a/bin/verifier
+++ b/bin/verifier
@@ -7,6 +7,7 @@
 require('../lib/baseExceptions').addExceptionHandler();
 
 const
+_ = require('underscore'),
 util = require("util"),
 path = require('path'),
 url = require('url'),
@@ -144,13 +145,11 @@ function doVerification(req, resp, next) {
         rp: audience
       });
     } else {
-      resp.json({
+      resp.json(_.extend(r.success, {
         status : "okay",
-        email : r.success.email,
         audience : audience, // NOTE: we return the audience formatted as the RP provided it, not normalized in any way.
-        expires : new Date(r.success.expires).valueOf(),
-        issuer: r.success.issuer
-      });
+        expires : new Date(r.success.expires).valueOf()
+      }));
 
       metrics.report('verify', {
         result: 'success',

--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -93,7 +93,8 @@ function compareAudiences(want, got) {
 // allowUnverified is boolean to check for email or unverified-email
 function verify(assertion, audience, forceIssuer, allowUnverified, successCB, errorCB) {
   // assertion is bundle
-  var ultimateIssuer;
+  var ultimateIssuer,
+      verified = true;
 
   jwcrypto.cert.verifyBundle(
     assertion,
@@ -154,6 +155,7 @@ function verify(assertion, audience, forceIssuer, allowUnverified, successCB, er
       var email = principal.email;
       if (allowUnverified && !email) {
         email = principal[UNVERIFIED_EMAIL];
+        verified = false;
       }
       
       if (!email) {
@@ -168,14 +170,14 @@ function verify(assertion, audience, forceIssuer, allowUnverified, successCB, er
       {
           primary.delegatesAuthority(domainFromEmail, ultimateIssuer, function (delegated) {
             if (delegated) {
-              return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
+              return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer, verified);
             } else {
               return errorCB("issuer '" + ultimateIssuer + "' may not speak for emails from '"
                          + domainFromEmail + "'");
             }
           });
       } else {
-        return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer);
+        return successCB(email, assertionParams.audience, assertionParams.expiresAt, ultimateIssuer, verified);
       }
     }, errorCB);
 }

--- a/lib/verifier/verifier-compute.js
+++ b/lib/verifier/verifier-compute.js
@@ -9,15 +9,16 @@ process.on('message', function(m) {
   try {
     certassertion.verify(
       m.assertion, m.audience, m.forceIssuer, !!m.allowUnverified,
-      function(email, audienceFromAssertion, expires, issuer) {
-        process.send({
+      function(email, audienceFromAssertion, expires, issuer, verified) {
+        var data = {
           success: {
-            email: email,
             audience: audienceFromAssertion,
             expires: expires,
             issuer: issuer
           }
-        });
+        };
+        verified ? data.success.email = email : data.success['unverified-email'] = email;
+        process.send(data);
       },
       function(error) {
         process.send({error: error});

--- a/tests/unverified-email-test.js
+++ b/tests/unverified-email-test.js
@@ -157,7 +157,7 @@ suite.addBatch({
         assert.strictEqual(resp.status, 'okay');
         //assert.strictEqual(resp.issuer, "example.domain");
         assert.strictEqual(resp.audience, UNVERIFIED_ORIGIN);
-        assert.strictEqual(resp.email, UNVERIFIED_EMAIL);
+        assert.strictEqual(resp['unverified-email'], UNVERIFIED_EMAIL);
       }
     },
     "without sending allowUnverified to verifier": {


### PR DESCRIPTION
Steps to Reproduce
1) Sign in with a new secondary address and allow unverified
2) create password
3) Note success of assertion

Actual

```
{"status":"okay","email":"unv@foo.com","audience":"192.168.186.138:10001", "expires":1356117306992,"issuer":"192.168.186.138"}
```

Expected

```
{"status":"okay","unverified-email":"unv@foo.com","audience":"192.168.186.138:10001", "expires":1356117306992,"issuer":"192.168.186.138"}
```

Note: this requirement is specified in https://bugzilla.mozilla.org/show_bug.cgi?id=794634#c2
