### PR TITLE
Allow logout to be called before .request or .watch.

### DIFF
--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -92,8 +92,18 @@
   });
 
   chan.bind("logout", function(trans, params) {
-    if (loggedInUser != null) {
+    // The assumption is that the intention behind a call to
+    // navigator.id.logout is to clear any session, whether it's locally
+    // cached or not; and that this intention should be honored until a new
+    // session is requested through navigator.id.request.
+    // See https://github.com/mozilla/browserid/pull/2529
+    setRemoteOrigin(trans.origin);
+    // loggedInUser will be undefined if none of loaded, loggedInUser nor
+    // logout have been called before. This allows the user to be force logged
+    // out.
+    if (loggedInUser !== null) {
       storage.setLoggedIn(remoteOrigin, false);
+      loggedInUser = null;
       chan.notify({ method: 'logout' });
     }
   });

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -1254,7 +1254,7 @@
         // allocate iframe if it is not allocated
         _open_hidden_iframe();
         // send logout message if the commChan exists
-        if (commChan) commChan.notify({ method: 'logout' });
+        if (commChan) commChan.call({ method: 'logout', success: function() {} });
         if (typeof callback === 'function') {
           warn('navigator.id.logout callback argument has been deprecated.');
           setTimeout(callback, 0);


### PR DESCRIPTION
A slightly simpler solution to #2529 which pushes the majority of the logic into communication_iframe/start.js
