### PR TITLE
Bug 827558 - rename native navigator.id to .mozId

### DIFF
--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -942,7 +942,13 @@
   }());
 
   if (!navigator.id) {
-    navigator.id = {};
+    // Is there a native implementation on this platform?
+    // If so, hook navigator.id onto it.
+    if (navigator.mozId) {
+      navigator.id = navigator.mozId;
+    } else {
+      navigator.id = {};
+    }
   }
 
   if (!navigator.id.request || navigator.id._shimmed) {


### PR DESCRIPTION
Updates the shim to glom `navigator.id` onto native `navigator.mozId` if the latter exists.

This is for https://bugzilla.mozilla.org/show_bug.cgi?id=827558

@seanmonstar, can I ask you to check this out for me?
