### PR TITLE
Allow logout to be called before .request or .watch.

### DIFF
--- a/resources/static/common/js/lib/jschannel.js
+++ b/resources/static/common/js/lib/jschannel.js
@@ -451,8 +451,8 @@
                     // tis a notification.
                     if (regTbl[method]) {
                         // yep, there's a handler for that.
-                        // transaction is null for notifications.
-                        regTbl[method](null, m.params);
+                        // transaction has only origin for notifications.
+                        regTbl[method]({ origin: origin }, m.params);
                         // if the client throws, we'll just let it bubble out
                         // what can we do?  Also, here we'll ignore return values
                     }

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -92,8 +92,18 @@
   });
 
   chan.bind("logout", function(trans, params) {
-    if (loggedInUser != null) {
+    // The assumption is that the intention behind a call to
+    // navigator.id.logout is to clear any session, whether it's locally
+    // cached or not; and that this intention should be honored until a new
+    // session is requested through navigator.id.request.
+    // See https://github.com/mozilla/browserid/pull/2529
+    setRemoteOrigin(trans.origin);
+    // loggedInUser will be undefined if none of loaded, loggedInUser nor
+    // logout have been called before. This allows the user to be force logged
+    // out.
+    if (loggedInUser !== null) {
       storage.setLoggedIn(remoteOrigin, false);
+      loggedInUser = null;
       chan.notify({ method: 'logout' });
     }
   });

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -92,10 +92,8 @@
   });
 
   chan.bind("logout", function(trans, params) {
-    // The assumption is that the intention behind a call to
-    // navigator.id.logout is to clear any session, whether it's locally
-    // cached or not; and that this intention should be honored until a new
-    // session is requested through navigator.id.request.
+    // set remote origin so that .logout can be called even if .request has
+    // not.
     // See https://github.com/mozilla/browserid/pull/2529
     setRemoteOrigin(trans.origin);
     // loggedInUser will be undefined if none of loaded, loggedInUser nor

--- a/resources/static/include_js/include.js
+++ b/resources/static/include_js/include.js
@@ -463,8 +463,8 @@
             // tis a notification.
             if (regTbl[method]) {
               // yep, there's a handler for that.
-              // transaction is null for notifications.
-              regTbl[method](null, m.params);
+              // transaction has only origin for notifications.
+              regTbl[method]({ origin: origin }, m.params);
               // if the client throws, we'll just let it bubble out
               // what can we do?  Also, here we'll ignore return values
             }


### PR DESCRIPTION
A slightly simpler solution than #2916 which adds a feature to jschannel so we don't have to use `.call` just to get origin provided to callee.
