### PR TITLE
Create a generic tooltip type within the module to make the overall thing easier to grok.

### DIFF
--- a/resources/static/common/js/lib/dom-jquery.js
+++ b/resources/static/common/js/lib/dom-jquery.js
@@ -391,7 +391,7 @@ BrowserID.DOM = ( function() {
          * @param {function} [done] called when animation completes
          */
         fadeOut: function( elementToFade, animationTime, done ) {
-          return jQuery( elementToFade ).fadeOut( animationTime );
+          return jQuery( elementToFade ).fadeOut( animationTime, done );
         },
 
         /**
@@ -400,7 +400,7 @@ BrowserID.DOM = ( function() {
          * @param {selector || element} elementToStop
          */
         stopAnimations: function( elementToStop ) {
-          return jQuery( elementToStop );
+          return jQuery( elementToStop ).stop();
         }
     };
 

--- a/resources/static/common/js/lib/dom-jquery.js
+++ b/resources/static/common/js/lib/dom-jquery.js
@@ -199,14 +199,7 @@ BrowserID.DOM = ( function() {
         * @return {boolean} true if the element has the attribute, false otw.
         */
         hasAttr: function( element, attrName ) {
-            var el = jQuery( element )[ 0 ],
-                val = null;
-
-            if (el) {
-              val = el.getAttribute( attrName );
-            }
-
-            return val !== null;
+            return typeof jQuery( element ).attr( attrName ) !== "undefined";
         },
 
         /**
@@ -362,9 +355,10 @@ BrowserID.DOM = ( function() {
          * @method slideDown
          * @param {selector || element} elementToSlide
          * @param {number} [animationTime]
+         * @param {function} [done] called when animation completes
          */
-        slideDown: function( elementToSlide, animationTime ) {
-          return jQuery( elementToSlide ).slideDown( animationTime );
+        slideDown: function( elementToSlide, animationTime, done ) {
+          return jQuery( elementToSlide ).slideDown( animationTime, done );
         },
 
         /**
@@ -372,9 +366,10 @@ BrowserID.DOM = ( function() {
          * @method slideUp
          * @param {selector || element} elementToSlide
          * @param {number} [animationTime]
+         * @param {function} [done] called when animation completes
          */
-        slideUp: function( elementToSlide, animationTime ) {
-          return jQuery( elementToSlide ).slideUp( animationTime );
+        slideUp: function( elementToSlide, animationTime, done ) {
+          return jQuery( elementToSlide ).slideUp( animationTime, done );
         },
 
         /**
@@ -382,9 +377,10 @@ BrowserID.DOM = ( function() {
          * @method fadeIn
          * @param {selector || element} elementToFade
          * @param {number} [animationTime]
+         * @param {function} [done] called when animation completes
          */
-        fadeIn: function( elementToFade, animationTime ) {
-          return jQuery( elementToFade ).fadeIn( animationTime );
+        fadeIn: function( elementToFade, animationTime, done ) {
+          return jQuery( elementToFade ).fadeIn( animationTime, done );
         },
 
         /**
@@ -392,9 +388,19 @@ BrowserID.DOM = ( function() {
          * @method fadeOut
          * @param {selector || element} elementToFade
          * @param {number} [animationTime]
+         * @param {function} [done] called when animation completes
          */
-        fadeOut: function( elementToFade, animationTime ) {
+        fadeOut: function( elementToFade, animationTime, done ) {
           return jQuery( elementToFade ).fadeOut( animationTime );
+        },
+
+        /**
+         * Stop any animations that are occurring on an element.
+         * @method stopAnimations
+         * @param {selector || element} elementToStop
+         */
+        stopAnimations: function( elementToStop ) {
+          return jQuery( elementToStop );
         }
     };
 

--- a/resources/static/common/js/tooltip.js
+++ b/resources/static/common/js/tooltip.js
@@ -7,6 +7,8 @@ BrowserID.Tooltip = (function() {
 
   var ANIMATION_TIME = 250,
       TOOLTIP_MIN_DISPLAY = 2000,
+      TOOLTIP_OFFSET_TOP_PX = 5,
+      TOOLTIP_OFFSET_LEFT_PX = 10,
       READ_WPM = 200,
       bid = BrowserID,
       dom = bid.DOM,
@@ -69,8 +71,8 @@ BrowserID.Tooltip = (function() {
   function anchorTooltip(tooltip, target) {
     target = $(target);
     var targetOffset = target.offset();
-    targetOffset.top -= (tooltip.outerHeight() + 5);
-    targetOffset.left += 10;
+    targetOffset.top -= (tooltip.outerHeight() + TOOLTIP_OFFSET_TOP_PX);
+    targetOffset.left += TOOLTIP_OFFSET_LEFT_PX;
 
     tooltip.css(targetOffset);
   }
@@ -90,7 +92,6 @@ BrowserID.Tooltip = (function() {
 
 
 
-
   // BrowserID.Tooltip singleton public interface.
 
   return {
@@ -100,6 +101,7 @@ BrowserID.Tooltip = (function() {
     showTooltip: showTooltip
     // BEGIN TESTING API
     ,
+    visible: isTooltipVisible,
     reset: removeAttachedTooltip
     // END TESTING API
   };
@@ -115,8 +117,6 @@ BrowserID.Tooltip = (function() {
     onlyAttachedTooltip = new Tooltip();
     var tooltipConfig = getTooltipConfig(tooltipText, tooltipAnchor, complete);
     var displayTimeMS = onlyAttachedTooltip.start(tooltipConfig);
-
-    bid.Tooltip.shown = true;
 
     return displayTimeMS;
   }
@@ -147,8 +147,12 @@ BrowserID.Tooltip = (function() {
   function removeAttachedTooltip() {
     if (onlyAttachedTooltip) {
       onlyAttachedTooltip.stop();
+      onlyAttachedTooltip = null;
     }
-
-    bid.Tooltip.shown = false;
   }
+
+  function isTooltipVisible() {
+    return !!onlyAttachedTooltip;
+  }
+
 }());

--- a/resources/static/dialog/views/tooltip.ejs
+++ b/resources/static/dialog/views/tooltip.ejs
@@ -1,5 +1,5 @@
 <div class="tooltip">
-  <%= contents %>
+  <span class="contents"><%= contents %></span>
   <div class="arrow-down"></div>
 </div>
 

--- a/resources/static/test/cases/common/js/tooltip.js
+++ b/resources/static/test/cases/common/js/tooltip.js
@@ -7,7 +7,9 @@
   var bid = BrowserID,
       tooltip = bid.Tooltip,
       testHelpers = bid.TestHelpers,
-      testUndefined = testHelpers.testUndefined;
+      testUndefined = testHelpers.testUndefined,
+      testTooltipVisible = testHelpers.testTooltipVisible,
+      testTooltipNotVisible = testHelpers.testTooltipNotVisible;
 
   module("common/js/tooltip", {
     setup: function() {
@@ -22,7 +24,7 @@
   test("show short tooltip - shows for about 2.5 seconds", function() {
     var displayTime = tooltip.showTooltip("#shortTooltip");
     ok(2000 <= displayTime && displayTime <= 3000, displayTime + " - minimum of 2 seconds, max of 3 seconds");
-    equal(tooltip.shown, true, "tooltip says that it is shown");
+    testTooltipVisible();
   });
 
   test("show long tooltip - shows for about 5 seconds", function() {
@@ -36,7 +38,7 @@
       tooltip.reset();
 
       equal($(".tooltip:visible").length, 0, "after reset, all tooltips are hidden");
-      equal(tooltip.shown, false, "after reset, tooltip status is reset");
+      testTooltipNotVisible();
       start();
     }, 100);
   });
@@ -50,6 +52,11 @@
   test("show a tooltip by specifying the text and the anchor", function() {
     tooltip.showTooltip("some tooltip contents", "#page_head");
     equal($(".tooltip:visible").text().trim(), "some tooltip contents", "correct contents when specified from the command line");
+  });
+
+  test("tooltip contents are escaped", function() {
+    tooltip.showTooltip("4 < 5", "#page_head");
+    equal($(".tooltip:visible .contents").html().trim(), "4 &lt; 5", "tooltip contents are escaped");
   });
 
   test("no exception thrown if tooltip element does not exist", function() {

--- a/resources/static/test/cases/dialog/js/misc/helpers.js
+++ b/resources/static/test/cases/dialog/js/misc/helpers.js
@@ -10,11 +10,12 @@
       xhr = bid.Mocks.xhr,
       storage = bid.Storage,
       tooltip = bid.Tooltip,
-      testHelpers = bid.TestHelpers,
       user = bid.User,
       provisioning = bid.Mocks.Provisioning,
       mediator = bid.Mediator,
       errorCB,
+      testHelpers = bid.TestHelpers,
+      testTooltipVisible = testHelpers.testTooltipVisible,
       expectedError = testHelpers.expectedXHRFailure,
       expectedMessage = testHelpers.expectedMessage,
       unexpectedMessage = testHelpers.unexpectedMessage,
@@ -157,7 +158,7 @@
     storage.addEmail("registered@testuser.com", {});
     dialogHelpers.addEmail.call(controllerMock, "registered@testuser.com", function(added) {
       equal(added, false, "email should not have been added");
-      equal(bid.Tooltip.shown, true, "tooltip should be shown");
+      testTooltipVisible();
       start();
     });
   });

--- a/resources/static/test/cases/dialog/js/modules/add_email.js
+++ b/resources/static/test/cases/dialog/js/modules/add_email.js
@@ -12,6 +12,7 @@
       xhr = bid.Mocks.xhr,
       modules = bid.Modules,
       testHelpers = bid.TestHelpers,
+      testTooltipVisible = testHelpers.testTooltipVisible,
       register = testHelpers.register;
 
 
@@ -119,7 +120,7 @@
       // another line to the XHR mock for syncEmailKeypair.
       xhr.useResult("known_secondary");
       controller.addEmail(function() {
-        ok(bid.Tooltip.shown, "tooltip should be shown");
+        testTooltipVisible();
         start();
       });
     });

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -191,11 +191,11 @@ BrowserID.TestHelpers = (function() {
     },
 
     testTooltipVisible: function() {
-      equal(tooltip.shown, true, "tooltip is visible");
+      equal(tooltip.visible(), true, "tooltip is visible");
     },
 
     testTooltipNotVisible: function() {
-      equal(tooltip.shown, false, "tooltip is not visible");
+      equal(tooltip.visible(), false, "tooltip is not visible");
     },
 
     failureCheck: function failureCheck(cb) {

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -12,6 +12,20 @@
   <!--[if lt IE 9]>
     <script src="/common/js/lib/html5shim.js"></script>
   <![endif]-->
+  <style>
+    #qunit-fixture {
+      position: absolute;
+      top: -1000px;
+      left: 100px;
+      right: 100px;
+      height: 300px;
+    }
+
+    .tooltip {
+      display: none;
+    }
+
+  </style>
 	</head>
 	<body>
 
@@ -22,7 +36,7 @@
 		<ol id="qunit-tests"></ol>
 		<div id="qunit-test-area"></div>
 
-    <div id="qunit-fixture" style="position: absolute; top: -1000px; left: 100px; right: 100px; height: 300px;">
+    <div id="qunit-fixture">
         <a href="#" onclick="$('#contents').hide(); return false;">Close</a>
         <h3>Test Contents, this will be updated and can be safely ignored</h3>
 


### PR DESCRIPTION
- Prevent tooltips from being closed prematurely if it replaces an old tooltip.
- Add a "done" callback to the dom-jquery animation functions.
- Use the done in the tooltips to work towards the goal of remove direct jQuery calls.
