### PR TITLE
Issue 2669 tos pp above button

### DIFF
--- a/resources/static/dialog/js/modules/required_email.js
+++ b/resources/static/dialog/js/modules/required_email.js
@@ -146,19 +146,13 @@ BrowserID.Modules.RequiredEmail = (function() {
             // 2) Authenticated user who does not control address.
             // 3) Unauthenticated user.
             if(info.type === "primary") primaryInfo = info;
-            
+
             if (info.type === "primary" && info.authed) {
               // this is a primary user who is authenticated with their IdP.
               // We know the user has control of this address, give them
               // a chance to hit "sign in" before we kick them off to the
               // primary flow account.
-
-              // Show the Persona TOS/PP to any primary user who is authed with
-              // their IdP but not with Persona.  Unfortunately, addressInfo
-              // does not tell us whether a primary address already has an
-              // account, so we have to show the personaTOSPP to any user who
-              // is not authenticated.
-              showTemplate({ signin: true, primary: true, personaTOSPP: !auth_level });
+              showTemplate({ signin: true, primary: true });
             }
             else if(info.type === "primary" && !info.authed) {
               // User who does not control a primary address.
@@ -214,7 +208,7 @@ BrowserID.Modules.RequiredEmail = (function() {
             ready();
           }
         }, self.getErrorDialog(errors.addressInfo, ready));
-          
+
       }, self.getErrorDialog(errors.checkAuthentication, ready));
 
       function showTemplate(templateData) {
@@ -225,7 +219,6 @@ BrowserID.Modules.RequiredEmail = (function() {
           password: false,
           secondary_auth: false,
           primary: false,
-          personaTOSPP: false,
           cancelable: true
         }, templateData);
 

--- a/resources/static/dialog/js/modules/set_password.js
+++ b/resources/static/dialog/js/modules/set_password.js
@@ -39,8 +39,7 @@ BrowserID.Modules.SetPassword = (function() {
         password_reset: !!options.password_reset,
         transition_no_password: !!options.transition_no_password,
         domain: helpers.getDomainFromEmail(options.email),
-        cancelable: options.cancelable !== false,
-        personaTOSPP: options.personaTOSPP
+        cancelable: options.cancelable !== false
       });
 
       if (options.siteTOSPP) {

--- a/resources/static/dialog/js/modules/upgrade_to_primary_user.js
+++ b/resources/static/dialog/js/modules/upgrade_to_primary_user.js
@@ -39,7 +39,6 @@ BrowserID.Modules.UpgradeToPrimaryUser = (function() {
         email: data.email,
         auth_url: data.auth,
         requiredEmail: data.requiredEmail || false,
-        personaTOSPP: data.personaTOSPP,
         siteName: data.siteName,
         idpName: data.idpName
       });

--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -64,7 +64,6 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
             email: data.email,
             auth_url: data.auth_url,
             requiredEmail: data.requiredEmail || false,
-            personaTOSPP: data.personaTOSPP,
             siteName: data.siteName,
             idpName: data.idpName,
             transition_to_primary: info.state === "transition_to_primary"

--- a/resources/static/dialog/views/required_email.ejs
+++ b/resources/static/dialog/views/required_email.ejs
@@ -49,25 +49,15 @@
 
       </ul>
 
-      <div class="submit cf">
-          <p class="cf">
-            <% if (signin) { %>
-              <button id="sign_in" tabindex="3"><%= gettext("sign in") %></button>
-            <% } else if (verify) { %>
-              <button id="verify_address" tabindex="3"><%= gettext("verify email") %></button>
-            <% } %>
+      <p class="submit cf buttonrow">
+        <% if (signin) { %>
+          <button id="sign_in" tabindex="3"><%= gettext("sign in") %></button>
+        <% } else if (verify) { %>
+          <button id="verify_address" tabindex="3"><%= gettext("verify email") %></button>
+        <% } %>
 
-            <% if (cancelable && secondary_auth) { %>
-              <a href="#" id="cancel" class="action" tabindex="4"><%= gettext("cancel") %></a>
-            <% } %>
-          </p>
-          <% if (personaTOSPP) { %>
-            <p class="tospp">
-               <%- format(gettext("By proceeding, you agree to %(site)'s <a %(terms)>Terms</a> and <a %(privacy)>Privacy Policy</a>."),
-                          { site: "Persona",
-                            terms: 'href="https://login.persona.org/tos" target="_new"',
-                            privacy: 'href="https://login.persona.org/privacy" target="_new"' }) %>
-            </p>
-          <% } %>
-      </div>
+        <% if (cancelable && secondary_auth) { %>
+          <a href="#" id="cancel" class="action" tabindex="4"><%= gettext("cancel") %></a>
+        <% } %>
+      </p>
   </div>

--- a/resources/static/dialog/views/set_password.ejs
+++ b/resources/static/dialog/views/set_password.ejs
@@ -75,12 +75,4 @@
         </p>
       <% } %>
 
-      <% if (personaTOSPP) { %>
-        <p id="persona_tospp" class="submit tospp">
-            <%- format(gettext("By proceeding, you agree to %(site)'s <a %(terms)>Terms</a> and <a %(privacy)>Privacy Policy</a>."),
-                       { site: "Persona",
-                         terms: 'href="https://login.persona.org/tos" target="_new"',
-                         privacy: 'href="https://login.persona.org/privacy" target="_new"' }) %>
-        </p>
-      <% } %>
   </div>

--- a/resources/static/dialog/views/verify_primary_user.ejs
+++ b/resources/static/dialog/views/verify_primary_user.ejs
@@ -21,18 +21,11 @@
     <%= format(gettext("Once you verify your account there, you will be signed in to %(aWebsite)."),
                {aWebsite : siteName}) %>
   </p>
-    <p class="submit cf buttonrow">
-        <button id="verifyWithPrimary"><%= format(gettext("sign in with %s"), [idpName]) %></button>
-        <a href="#" id="cancel" class="emphasize right"><%= gettext("Use a different email address") %></a>
-    </p>
 
-    <% if (personaTOSPP) { %>
-      <p id="persona_tospp" class="submit tospp">
-         <%- format(gettext("By proceeding, you agree to %(site)'s <a %(terms)>Terms</a> and <a %(privacy)>Privacy Policy</a>."),
-                    { site: "Persona",
-                      terms: 'href="https://login.persona.org/tos" target="_new"',
-                      privacy: 'href="https://login.persona.org/privacy" target="_new"' }) %>
-      </p>
-    <% } %>
+  <p class="submit cf buttonrow">
+      <button id="verifyWithPrimary"><%= format(gettext("sign in with %s"), [idpName]) %></button>
+      <a href="#" id="cancel" class="emphasize right"><%= gettext("Use a different email address") %></a>
+  </p>
+
 
 </div>

--- a/resources/static/test/cases/dialog/js/modules/set_password.js
+++ b/resources/static/test/cases/dialog/js/modules/set_password.js
@@ -35,7 +35,6 @@
     ok($("#set_password").length, "set_password template added");
     testElementExists("#verify_user");
     testElementExists("#cancel");
-    testElementNotExists("#persona_tospp");
   });
 
   test("create with password_reset option - show template, show reset password button", function() {
@@ -44,12 +43,6 @@
     testElementExists("#set_password");
     testElementExists("#password_reset");
     testElementExists("#cancel");
-  });
-
-  test("create with personaTOSPP option - show Persona TOS/PP", function() {
-    controller.destroy();
-    createController({ personaTOSPP: true });
-    testElementExists("#persona_tospp");
   });
 
   test("create with cancelable=false option - cancel button not shown", function() {

--- a/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
@@ -35,38 +35,6 @@
     }
   });
 
-  asyncTest("personaTOSPP true, requiredEmail: true - show TOS/PP", function() {
-    createController({
-      window: win,
-      add: false,
-      email: "unregistered@testuser.com",
-      auth_url: "http://testuser.com/sign_in",
-      requiredEmail: true,
-      personaTOSPP: false,
-      ready: function ready() {
-        testElementNotExists("#persona_tospp");
-        start();
-      }
-    });
-
-  });
-
-  asyncTest("personaTOSPP true, requiredEmail: false - show TOS/PP", function() {
-    createController({
-      window: win,
-      add: false,
-      email: "unregistered@testuser.com",
-      auth_url: "http://testuser.com/sign_in",
-      requiredEmail: false,
-      personaTOSPP: false,
-      ready: function ready() {
-        testElementNotExists("#persona_tospp");
-        start();
-      }
-    });
-
-  });
-
   asyncTest("submit with `add: false` option opens a new tab with proper URL (updated for sessionStorage)", function() {
 
     xhr.useResult("primaryUnknown");
@@ -77,10 +45,7 @@
       add: false,
       email: "unregistered@testuser.com",
       auth_url: "http://testuser.com/sign_in",
-      personaTOSPP: true,
       ready: function ready() {
-        testElementExists("#persona_tospp");
-
         mediator.subscribe("primary_user_authenticating", function() {
           messageTriggered = true;
         });
@@ -106,10 +71,7 @@
       add: true,
       email: "unregistered@testuser.com",
       auth_url: "http://testuser.com/sign_in",
-      personaTOSPP: true,
       ready: function ready() {
-        testElementExists("#persona_tospp");
-
         // Also checking to make sure the NATIVE is stripped out.
         win.document.location.href = "sign_in";
         win.document.location.hash = "#NATIVE";
@@ -121,7 +83,7 @@
       }
     });
 
-    
+
 
   });
 
@@ -195,7 +157,7 @@
       }
     });
   });
-  
+
   asyncTest("known_primary doesn't show verify_primary_user dialog", function() {
     xhr.useResult("primary");
 

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -69,19 +69,20 @@
 
                     </ul>
 
-                    <p class="submit cf buttonrow">
-                      <button class="start addressInfo"><%= gettext('next') %></button>
-                      <button class="returning"><%= gettext('sign in') %></button>
-                      <a id="forgotPassword" class="returning" href="#"><%= gettext('Forgot your password?') %></a>
-                    </p>
-
-
                     <p class="submit tospp">
                        <%- format(gettext("By proceeding, you agree to %(site)'s <a %(terms)>Terms</a> and <a %(privacy)>Privacy Policy</a>."),
                                   { site: "Persona",
                                     terms: 'href="https://login.persona.org/tos" target="_new"',
                                     privacy: 'href="https://login.persona.org/privacy" target="_new"' }) %>
                     </p>
+
+
+                    <p class="submit cf buttonrow">
+                      <button class="start addressInfo"><%= gettext('next') %></button>
+                      <button class="returning"><%= gettext('sign in') %></button>
+                      <a id="forgotPassword" class="returning" href="#"><%= gettext('Forgot your password?') %></a>
+                    </p>
+
 
                 </div>
               </div>

--- a/resources/views/signin.ejs
+++ b/resources/views/signin.ejs
@@ -77,6 +77,17 @@
                 </li>
             </ul>
 
+            <!-- The TOS/PP agreement must be shown to all users who are not
+                 signed in before they enter their email address. -->
+            <p class="submit tospp cf">
+               <%- format(
+                    gettext('By proceeding, you agree to %(persona)\'s <a %(termsLink)>Terms</a> and <a %(privacyLink)>Privacy Policy</a>.'),
+                         { persona: "Persona",
+                           termsLink: 'href="https://login.persona.org/tos" target="_new"',
+                           privacyLink: 'href="https://login.persona.org/privacy" target="_new"',
+                         }) %>
+            </p>
+
             <div class="submit cf forminputs start">
                 <button id="next"><%- gettext('Next') %></button>
             </div>
@@ -90,14 +101,6 @@
                   <button id="verifyEmail"><%- gettext('Verify Email') %></button>
                 </p>
 
-                <p class="tospp cf">
-                   <%- format(
-                        gettext('By proceeding, you agree to %(persona)\'s <a %(termsLink)>Terms</a> and <a %(privacyLink)>Privacy Policy</a>.'),
-                             { persona: "Persona",
-                               termsLink: 'href="https://login.persona.org/tos" target="_new"',
-                               privacyLink: 'href="https://login.persona.org/privacy" target="_new"',
-                             }) %>
-                  </p>
 
             </div>
 


### PR DESCRIPTION
This is a two part TOS/PP update.

First, the Persona TOS/PP text is _only_ supposed to be shown to unauthenticated users before they enter their email address. Because it is never shown anywhere else, I removed all other Persona TOS/PP references.

Second, the request in #2669 is to place the Persona TOS/PP text above the submit button. This is done in both the dialog and the main site /signin page.
