### PR TITLE
Issue 2891 email normalization

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -19,9 +19,32 @@ check = require('validator').check;
 
 var hostnameRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
+// This could easily be inlined in its current form, but our choice of 
+// normalization algorithm has been contentious to date. extracted to call
+// attention to it. see #2891 or:
+// https://groups.google.com/d/topic/mozilla.dev.identity/tvQdyLbfyH8/discussion
+var normalizeEmail = function(addr) { return addr.toLocaleLowerCase() }
+
 var types = {
-  email: function(x) {
-    check(x).isEmail();
+  email: function(address) {
+    // return normalized email or false
+    // pulled over from client-side resources/common/js/validation.js
+    if (typeof(address) !== "string")
+      return false;
+    // Original gotten from http://blog.gerv.net/2011/05/html5_email_address_regexp/
+    // changed the requirement that there must be a ldh-str because BrowserID
+    // is only used on internet based networks.
+    var parts = address.split("@");
+
+    return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d\-]+(\.[a-z\d\-]+)+$/i).test(address)
+           // total address allwed to be 254 bytes long
+           && address.length <= 254
+           // local side only allowed to be 64 bytes long
+           && parts[0] && parts[0].length <= 64
+           // domain side allowed to be up to 253 bytes long
+           && parts[1] && parts[1].length <= 253
+           // return normalized version
+           && normalizeEmail(address);
   },
   email_type: function(x) {
     check(x).isIn([ 'primary', 'secondary' ]);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -19,41 +19,34 @@ check = require('validator').check;
 
 var hostnameRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
+// Original gotten from http://blog.gerv.net/2011/05/html5_email_address_regexp/
+// changed the requirement that there must be a ldh-str because BrowserID
+// is only used on internet based networks.
+var emailRegex = /^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d\-]+(\.[a-z\d\-]+)+$/i;
+
 // This could easily be inlined in its current form, but our choice of 
 // normalization algorithm has been contentious to date. extracted to call
 // attention to it. see #2891 or:
 // https://groups.google.com/d/topic/mozilla.dev.identity/tvQdyLbfyH8/discussion
 var normalizeEmail = function(addr) { return addr.toLocaleLowerCase() }
 
-function validateEmail(opts /* {address: address, normalize: true/false} */) {
-    // return normalized email or false
-    // pulled over from client-side resources/common/js/validation.js
-    if (typeof opts.address !== "string") 
-      return false;
+function validateEmail(address) {
+    // validation criteria from client-side resources/common/js/validation.js
+    if (typeof address !== "string") throw "email must be string";
 
-    // Original gotten from http://blog.gerv.net/2011/05/html5_email_address_regexp/
-    // changed the requirement that there must be a ldh-str because BrowserID
-    // is only used on internet based networks.
     var parts = address.split("@");
-    var isValid =  (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d\-]+(\.[a-z\d\-]+)+$/i).test(address)
-           // total address allwed to be 254 bytes long
-           && address.length <= 254
-           // local side only allowed to be 64 bytes long
-           && parts[0] && parts[0].length <= 64
-           // domain side allowed to be up to 253 bytes long
-           && parts[1] && parts[1].length <= 253;
-    return isValid && opts.normalize ? normalizeEmail(addr) : addr;
-  // TODO looks like the existing checks throw if something fails.
-  // I don't see how we're going to overwrite the request here.
-  // this means it's not the right place for this.
+    if (!emailRegex.test(address)) throw 'invalid email address';
+    if (address.length > 254) throw 'email address is longer than 254 chars';
+    if (parts[0] && parts[0].length > 64) throw 'email address local part is longer than 64 chars';
+    if (parts[1] && parts[1].length > 253) throw 'email address domain part is longer than 253 chars';
 }
 
 var types = {
   email: function(x) {
-    return validateEmail({address: x, normalize: true})
+    validateEmail(x);
   },
   display_email: function(x) {
-    return validateEmail({address: x, normalize: false})
+    validateEmail(x);
   },
   email_type: function(x) {
     check(x).isIn([ 'primary', 'secondary' ]);
@@ -166,6 +159,11 @@ module.exports = function (params) {
       return resp.json(msg);
     }
 
+    // we validated. now let's sanitize.
+    Object.keys(reqParams).forEach(function(p) {
+      if (reqParams[p].type != 'email') return;
+      reqParams[p] = normalizeEmail(reqParams[p]); // TODO: is this going to work? if so, extract out cleanly using types analogue.
+    });
 
     // this is called outside the try/catch because errors
     // in the handling of the request should be caught separately

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -25,26 +25,35 @@ var hostnameRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0
 // https://groups.google.com/d/topic/mozilla.dev.identity/tvQdyLbfyH8/discussion
 var normalizeEmail = function(addr) { return addr.toLocaleLowerCase() }
 
-var types = {
-  email: function(address) {
+function validateEmail(opts /* {address: address, normalize: true/false} */) {
     // return normalized email or false
     // pulled over from client-side resources/common/js/validation.js
-    if (typeof(address) !== "string")
+    if (typeof opts.address !== "string") 
       return false;
+
     // Original gotten from http://blog.gerv.net/2011/05/html5_email_address_regexp/
     // changed the requirement that there must be a ldh-str because BrowserID
     // is only used on internet based networks.
     var parts = address.split("@");
-
-    return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d\-]+(\.[a-z\d\-]+)+$/i).test(address)
+    var isValid =  (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d\-]+(\.[a-z\d\-]+)+$/i).test(address)
            // total address allwed to be 254 bytes long
            && address.length <= 254
            // local side only allowed to be 64 bytes long
            && parts[0] && parts[0].length <= 64
            // domain side allowed to be up to 253 bytes long
-           && parts[1] && parts[1].length <= 253
-           // return normalized version
-           && normalizeEmail(address);
+           && parts[1] && parts[1].length <= 253;
+    return isValid && opts.normalize ? normalizeEmail(addr) : addr;
+  // TODO looks like the existing checks throw if something fails.
+  // I don't see how we're going to overwrite the request here.
+  // this means it's not the right place for this.
+}
+
+var types = {
+  email: function(x) {
+    return validateEmail({address: x, normalize: true})
+  },
+  display_email: function(x) {
+    return validateEmail({address: x, normalize: false})
   },
   email_type: function(x) {
     check(x).isIn([ 'primary', 'secondary' ]);

--- a/lib/wsapi/address_info.js
+++ b/lib/wsapi/address_info.js
@@ -12,6 +12,7 @@ urlparse = require('urlparse'),
 logger = require('../logging.js').logger,
 config = require('../configuration.js');
 
+// email: {string} // normalized email address
 // type: {primary, secondary} // indicates email type right now
 // state: {string}
 //   "known": the email address is known

--- a/lib/wsapi/address_info.js
+++ b/lib/wsapi/address_info.js
@@ -64,6 +64,10 @@ exports.i18n = false;
 const HOSTNAME = urlparse(config.get('public_url')).host;
 
 exports.process = function(req, res) {
+  function normalizeEmail(addr) { return addr.toLocaleLowerCase(); /* TODO: export to separate util */ }
+
+  var normalizedEmail = normalizeEmail(req.params.email);
+  console.error('normalizedEmail is ' + normalizedEmail)
 
   function forgetIDP(domain) {
     wsapi.requestToDBWriter({
@@ -74,7 +78,7 @@ exports.process = function(req, res) {
   }
 
   // parse out the domain from the email
-  var domain = primary.emailRegex.exec(req.params.email)[1];
+  var domain = primary.emailRegex.exec(normalizedEmail)[1];
 
   // to determine the state of this email, we need the following information:
   // * emailKnown: is this in the database
@@ -141,7 +145,7 @@ exports.process = function(req, res) {
   });
 
   // third question: get information about the email address
-  db.emailInfo(req.params.email, function(err, info) {
+  db.emailInfo(normalizedEmail, function(err, info) {
     questionsToAnswer--;
 
     if (err) {

--- a/lockdown.json
+++ b/lockdown.json
@@ -21,7 +21,7 @@
     "0.0.5": "971b8995078d83c80f2372f134c496e71b293a46"
   },
   "awsbox": {
-    "0.3.4": "6bbd87f39df830eca333806604499728cef2e1a3"
+    "0.3.5": "0972aa4b3acb0ac82ca1c586fe3ef0357b07c5f6"
   },
   "bcrypt": {
     "0.7.3": "7523db1fdd8b0bda337bade63b5b90a7ee9c448a"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     },
     "devDependencies": {
         "vows": "0.5.13",
-        "awsbox": "0.3.4",
+        "awsbox": "0.3.5",
         "irc": "0.3.3",
         "jshint": "0.9.1",
         "which": "1.0.5",

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -11,8 +11,8 @@ URL:           https://github.com/mozilla/browserid
 Source0:       %{name}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root
 AutoReqProv:   no
-Requires:      openssl, nodejs >= 0.8.12
-BuildRequires: gcc-c++, git, jre, make, npm, openssl-devel, expat-devel, nodejs >= 0.8.12
+Requires:      openssl, nodejs >= 0.8.17
+BuildRequires: gcc-c++, git, jre, make, npm, openssl-devel, expat-devel, nodejs >= 0.8.17
 
 %description
 persona server & web home for persona.org

--- a/tests/address-info-test.js
+++ b/tests/address-info-test.js
@@ -121,6 +121,28 @@ suite.addBatch({
   }
 });
 
+suite.addBatch({
+  "when a user creates an account with the email capitalized": {
+     topic: function() {
+       secondary.create({ email: "Test@Example.com" }, this.callback);
+     },
+    "successfully": function(e, r) {
+      assert.isNull(e);
+    },
+    "address_info for that account": {
+      topic: wsapi.get('/wsapi/address_info', {
+        email: 'test@example.com'
+      }),
+      "should return display_email field capitalized, email field normalized": function(e, r) {
+        assert.isNull(e);
+        var r = JSON.parse(r.body);
+        assert.equal(r.display_email, "Test@Example.com");
+      }
+    }
+  }
+});
+
+
 // now let's generate an assertion using this user
 suite.addBatch({
   "setting up a primary user": {

--- a/tests/address-info-test.js
+++ b/tests/address-info-test.js
@@ -80,22 +80,43 @@ suite.addBatch({
 
 suite.addBatch({
   "address_info for a known secondary address, user part capitalized, bug 2866": {
-     topic: wsapi.get('/wsapi/address_info', {
-      email: 'Test@example.com'
-     }),
-    "returns known": function(e, r) {
-      assert.equal(r.state, "known");
+     topic: function() {
+       secondary.create({ email: "test@example.com" }, this.callback);
+     },
+    "works": function(e, r) {
+      assert.isNull(e);
+    },
+    "actually calling address_info": {
+       topic: wsapi.get('/wsapi/address_info', {
+        email: 'TEST@example.com' 
+      }),
+      "returns known": function(e, r) {
+        assert.isNull(e)
+        var r = JSON.parse(r.body);
+        assert.equal(r.state, "known");
+      }
     }
   }
 });
 
+
 suite.addBatch({
   "address_info for a known secondary address, domain part capitalized, bug 2891": {
-     topic: wsapi.get('/wsapi/address_info', {
-      email: 'test@Example.com'
-     }),
-    "returns known": function(e, r) {
-      assert.equal(r.state, "known");
+     topic: function() {
+       secondary.create({ email: "test@example.com" }, this.callback);
+     },
+    "works": function(e, r) {
+      assert.isNull(e);
+    },
+    "actually calling address_info": {
+       topic: wsapi.get('/wsapi/address_info', {
+        email: 'test@EXAMPLE.com' 
+      }),
+      "returns known": function(e, r) {
+        assert.isNull(e)
+        var r = JSON.parse(r.body);
+        assert.equal(r.state, "known");
+      }
     }
   }
 });

--- a/tests/address-info-test.js
+++ b/tests/address-info-test.js
@@ -78,6 +78,28 @@ suite.addBatch({
   }
 });
 
+suite.addBatch({
+  "address_info for a known secondary address, user part capitalized, bug 2866": {
+     topic: wsapi.get('/wsapi/address_info', {
+      email: 'Test@example.com'
+     }),
+    "returns known": function(e, r) {
+      assert.equal(r.state, "known");
+    }
+  }
+});
+
+suite.addBatch({
+  "address_info for a known secondary address, domain part capitalized, bug 2891": {
+     topic: wsapi.get('/wsapi/address_info', {
+      email: 'test@Example.com'
+     }),
+    "returns known": function(e, r) {
+      assert.equal(r.state, "known");
+    }
+  }
+});
+
 // now let's generate an assertion using this user
 suite.addBatch({
   "setting up a primary user": {


### PR DESCRIPTION
NOT READY TO BE MERGED YET. JUST LOOKING FOR INPUT.

This is in a bit of a weird state currently.

Initially, I just threw the normalize call inside the address_info wsapi, added unit tests for two of the email normalization bugs to address_info tests, and got them to pass.

After getting that to pass, I looked for a more natural place to globally normalize emails, and decided to expand on what lib/validate is already doing. Since lib/validate just throws on validation error, killing the current request with an error, I thought I'd add a separate sanitize step after validation succeeds. This is barely implemented in the current code.

Is wsapi.js the right place to add sanitization? Is it too implicit, too magical? I think the alternative is to call normalizeEmail inside each wsapi that handles email--a step that could easily be forgotten. I'm cool either way, or open to other suggestions.

Assuming the normalization code is in the right place, I'd next like to return display emails by adding a display_email field to the DB, returning it where user info is returned by the server (IIRC list_emails and address_info wsapi output). If a user has no display_email, just let it be the same as the email field.

To insert un-normalized display_emails into the DB, I think I'd need to add a display_email or raw_email param to the signup endpoints, and add this to the lib/validate set of types. The idea is to validate, but not normalize, display_emails.

Once this is done, I'll ensure all the dialog and site code handles display emails appropriately and add tests.

After that, finally, I'll add unit tests for the bugs caused by assertion case mismatch to be certain we've fixed that bug.

This is taking a while, but it's a great intro bug, and I think I'm catching on--hope to get this fully done tomorrow or Friday. Am I on the right track? Comments welcome.
