### PR TITLE
Increase Strict-Transport-Security max-age

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -86,7 +86,7 @@ if (statsd_config && statsd_config.enabled) {
 if (config.get('scheme') == 'https') {
   app.use(function(req, resp, next) {
     // expires in 30 days, include subdomains like www
-    resp.setHeader("Strict-Transport-Security", "max-age=2592000; includeSubdomains");
+    resp.setHeader("Strict-Transport-Security", "max-age=10886400; includeSubdomains");
     next();
     });
 }


### PR DESCRIPTION
This is required to get onto the Firefox HSTS preload list. Should fix GH-2903.
