### PR TITLE
Validator should accept FirefoxOS app:// origins

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -48,7 +48,7 @@ var types = {
   origin: function(x) {
     /* origin regex
     /^                          // beginning
-    https?:\/\/                 // starts with http:// or https://
+    (?:https?|app):\/\/         // starts with http://, https://, or app:// (FirefoxOS)
     (?=.{1,254}(?::|$))         // hostname must be within 1-254 characters
     (?:                         // match hostname part (<part>.<part>...)
       (?!-)                     // cannot start with a dash (allow it to start with a digit re issue #2042)
@@ -61,7 +61,7 @@ var types = {
     (:\d+)?                     // optional port
     $/i;                        // end; case-insensitive
     */
-    var regex = /^https?:\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
+    var regex = /^(?:https?|app):\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
     if (typeof x !== 'string' || !x.match(regex)) {
       throw new Error("not a valid origin");
     }


### PR DESCRIPTION
Issue #2965

Tested using the navigator.mozId part of the b2g UI tests app to check regular assertion, allow unverified, and allow unverified + force issuer.

@ozten can I get your blessing on this one?  Did I miss anything?
