### PR TITLE
downgrade log message for when invalid url is requested from .error() to .info()

### DIFF
--- a/bin/static
+++ b/bin/static
@@ -116,7 +116,7 @@ app.use(function(req, res, next) {
     decodeURIComponent(req.url);
     next();
   } catch (e) {
-    logger.error('invalid url: ' + req.url);
+    logger.info('invalid url requested: ' + req.url);
     httputils.notFound(res);
   }
 });


### PR DESCRIPTION
we reserve `.error()` for fatal or unexpected conditions.  Because anyone on the internet can request a bogus url, it's not really a big deal, just a silly robot (or human).

Just as HTTP `500` errors are a sign of something wrong with our software, so are errors in logs.
