### PR TITLE
Improve language in email when an IdP drops support AND improve password reset flow

### DIFF
--- a/automation-tests/pages/css.js
+++ b/automation-tests/pages/css.js
@@ -49,11 +49,12 @@ module.exports = {
     forgotPassword: 'a#forgotPassword',
     choosePassword: 'div#set_password input#password',
     verifyPassword: 'input#vpassword',
+    postVerificationPassword: 'input#password',
     // the button you click on after typing and re-typing your password
     createUserButton: 'button#verify_user',
-    resetPasswordButton: 'button#password_reset',
     returningUserButton: 'button.returning',
     verifyWithPrimaryButton: 'button#verifyWithPrimary',
+    postVerificationPasswordButton: 'button#sign_in',
     thisIsNotMe: '#thisIsNotMe',
     useNewEmail: 'a#useNewEmail',
     newEmail: 'input#newEmail',

--- a/config/aws.json
+++ b/config/aws.json
@@ -21,7 +21,7 @@
   },
   "proxy": { "bind_to": { "port": 10006 } },
   "router": { "bind_to": { "port": 8080 } },
-  "kpi_backend_db_url" : "https://kpiggybank.hacksign.in/wsapi/interaction_data",
+  "kpi_backend_db_url" : "https://piggy.personatest.org/wsapi/interaction_data",
   // whether to show the development menu.
   "enable_development_menu": true,
   // explicitly undefine public_static_url, as the configuration will then fallback to

--- a/config/aws.json
+++ b/config/aws.json
@@ -21,7 +21,7 @@
   },
   "proxy": { "bind_to": { "port": 10006 } },
   "router": { "bind_to": { "port": 8080 } },
-  "kpi_backend_db_url" : "https://piggy.personatest.org/wsapi/interaction_data",
+  "kpi_backend_db_url" : "https://kpiggybank.hacksign.in/wsapi/interaction_data",
   // whether to show the development menu.
   "enable_development_menu": true,
   // explicitly undefine public_static_url, as the configuration will then fallback to

--- a/lib/db/json.js
+++ b/lib/db/json.js
@@ -295,11 +295,13 @@ exports.authForVerificationSecret = function(secret, cb) {
     if (!db.staged[secret]) return cb("no such secret");
 
     if (db.staged[secret].passwd) {
-      return cb(null, db.staged[secret].passwd, db.staged[secret].existing_user);
+      return cb(null, db.staged[secret].passwd, db.staged[secret].existing_user, true);
     }
 
     exports.checkAuth(db.staged[secret].existing_user, function (err, hash) {
-      cb(err, hash, db.staged[secret].existing_user);
+      // fourth parameter indicates that there was no
+      // password in the stage table
+      cb(err, hash, db.staged[secret].existing_user, false);
     });
   });
 };
@@ -396,7 +398,7 @@ exports.completeCreateUser = function(secret, cb) {
   });
 };
 
-exports.completePasswordReset = function(secret, cb) {
+exports.completePasswordReset = function(secret, password, cb) {
   getAndDeleteRowForSecret(secret, function(err, o) {
     exports.emailKnown(o.email, function(err) {
       if (err) return cb(err);
@@ -422,7 +424,7 @@ exports.completePasswordReset = function(secret, cb) {
         flush();
 
         // update the password!
-        exports.updatePassword(uid, o.passwd, true, function(err) {
+        exports.updatePassword(uid, password || o.passwd, true, function(err) {
           cb(err, o.email, uid);
         });
       });

--- a/lib/db/mysql.js
+++ b/lib/db/mysql.js
@@ -356,13 +356,15 @@ exports.authForVerificationSecret = function(secret, cb) {
       var o = rows[0];
 
       // if there is a hashed passwd in the result, we're done
-      if (o.passwd) return cb(null, o.passwd, o.existing_user);
+      if (o.passwd) return cb(null, o.passwd, o.existing_user, true);
 
       // otherwise, let's get the passwd from the user record
       if (!o.existing_user) return cb("no password for user");
 
       exports.checkAuth(o.existing_user, function(err, hash) {
-        cb(err, hash, o.existing_user);
+        // fourth parameter indicates that there was no
+        // password in the stage table
+        cb(err, hash, o.existing_user, false);
       });
     });
 };
@@ -458,11 +460,11 @@ exports.completeConfirmEmail = function(secret, cb) {
   });
 };
 
-exports.completePasswordReset = function(secret, cb) {
+exports.completePasswordReset = function(secret, password, cb) {
   getAndDeleteRowForSecret(secret, function(err, o) {
     if (err) return cb(err);
 
-    if (o.new_acct || !o.passwd || !o.existing_user) {
+    if (o.new_acct || (!password && !o.passwd) || !o.existing_user) {
       return cb("this verification link is not for a password reset");
     }
 
@@ -485,7 +487,7 @@ exports.completePasswordReset = function(secret, cb) {
           if (err) return cb(err);
 
           // update the password!
-          exports.updatePassword(uid, o.passwd, true, function(err) {
+          exports.updatePassword(uid, password || o.passwd, true, function(err) {
             cb(err, o.email, uid);
           });
         });
@@ -536,9 +538,13 @@ exports.userOwnsEmail = function(uid, email, cb) {
 
 exports.stageEmail = function(existing_user, new_email, hash, cb) {
   secrets.generate(48, function(secret) {
+    // if we are staging a password reset in the new flow,
+    // we nullify any previously staged password
+    // this will clear out stale attempts from the old flow
+    var overwrite_password = (hash === null);
     // overwrite previously staged users
     client.query('INSERT INTO staged (secret, new_acct, existing_user, email, passwd) VALUES(?,FALSE,?,?,?) ' +
-                 'ON DUPLICATE KEY UPDATE secret=VALUES(secret), existing_user=VALUES(existing_user), new_acct=FALSE, ts=NOW(), passwd=VALUES(passwd)',
+                 'ON DUPLICATE KEY UPDATE secret=VALUES(secret), existing_user=VALUES(existing_user), new_acct=FALSE, ts=NOW()' + (overwrite_password ? ', passwd=VALUES(passwd)' : ''),
                  [ secret, existing_user, new_email, hash ],
                  function(err) {
                    cb(err, err ? undefined : secret);

--- a/lib/email.js
+++ b/lib/email.js
@@ -53,7 +53,13 @@ const templates = {
     subject: _("Confirm email address for Persona"),
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.html.ejs'))
-  }
+  },
+  "transition": {
+    landing: 'confirm',
+    subject: _("Confirm email address for Persona"),
+    template: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.ejs')),
+    templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.html.ejs'))
+  },
 };
 
 // now turn file contents into compiled templates
@@ -144,4 +150,8 @@ exports.sendConfirmationEmail = function(email, site, secret, langContext) {
 
 exports.sendForgotPasswordEmail = function(email, site, secret, langContext) {
   doSend('reset', email, site, secret, langContext);
+};
+
+exports.sendTransitionEmail = function(email, site, secret, langContext) {
+  doSend('transition', email, site, secret, langContext);
 };

--- a/lib/email.js
+++ b/lib/email.js
@@ -55,7 +55,7 @@ const templates = {
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.html.ejs'))
   },
   "transition": {
-    landing: 'confirm',
+    landing: 'complete_transition',
     subject: _("Confirm email address for Persona"),
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.html.ejs'))

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -211,7 +211,7 @@ exports.setup = function(app) {
 
 
   app.get("/reset_password", function(req,res) {
-    renderCachableView(req, res, 'confirm.ejs', {title: _('Reset Password')});
+    renderCachableView(req, res, 'reset_password.ejs', {title: _('Reset Password')});
   });
 
   app.get("/confirm", function(req,res) {

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -209,12 +209,15 @@ exports.setup = function(app) {
     renderCachableView(req, res, 'confirm.ejs', {title: _('Verify Email Address'), fullpage: false});
   });
 
-
   app.get("/reset_password", function(req,res) {
     renderCachableView(req, res, 'reset_password.ejs', {title: _('Reset Password')});
   });
 
   app.get("/confirm", function(req,res) {
+    renderCachableView(req, res, 'confirm.ejs', {title: _('Confirm Email')});
+  });
+
+  app.get("/complete_transition", function(req,res) {
     renderCachableView(req, res, 'confirm.ejs', {title: _('Confirm Email')});
   });
 

--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -68,6 +68,7 @@ var browserid_js = und.flatten([
     '/pages/js/index.js',
     '/pages/js/start.js',
     '/pages/js/verify_secondary_address.js',
+    '/pages/js/reset_password.js',
     '/pages/js/forgot.js',
     '/pages/js/manage_account.js',
     '/pages/js/signin.js',

--- a/lib/wsapi/complete_reset.js
+++ b/lib/wsapi/complete_reset.js
@@ -27,39 +27,74 @@ exports.i18n = true;
 exports.process = function(req, res) {
   // in order to complete a password reset, one of the following must be true:
   //
-  // 1. you are using the same browser to complete the email verification as you
+  // 1. (new flow) you followed the verification link after a reset and have
+  //    provided a new password
+  //
+  // 2. (old flow) you staged the reset with a password in the dialog and
+  //    you are using the same browser to complete the email verification as you
   //    used to start it
-  // 2. you have provided the password chosen by the initiator of the verification
+  // 3. (old flow) you staged the reset with a password in the dialog and
+  //    have provided the password chosen by the initiator of the verification
   //    request
 
-  // is this the same browser?
-  if (req.params.token === req.session.pendingReset) {
-    return postAuthentication();
-  }
-  // is a password provided?
-  else if (typeof req.params.pass === 'string') {
-    return db.authForVerificationSecret(req.params.token, function(err, hash) {
-      if (err) {
-        logger.warn("couldn't get password for verification secret: " + err);
-        return wsapi.databaseDown(res, err);
+
+  db.authForVerificationSecret(req.params.token, function(err, hash, existing_user, staged_password) {
+    if (err) {
+      logger.warn("couldn't get password for verification secret: " + err);
+      return wsapi.databaseDown(res, err);
+    }
+
+    // password has been set in the dialog, use the old flow
+    if (staged_password) {
+      // is this the same browser?
+      if (req.params.token === req.session.pendingReset) {
+        return postAuthentication();
       }
+      // is a password provided?
+      else if (typeof req.params.pass === 'string') {
+        return db.authForVerificationSecret(req.params.token, function(err, hash) {
+          if (err) {
+            logger.warn("couldn't get password for verification secret: " + err);
+            return wsapi.databaseDown(res, err);
+          }
 
-      bcrypt.compare(req.params.pass, hash, function (err, success) {
-        if (err) {
-          logger.warn("max load hit, failing on auth request with 503: " + err);
-          return httputils.serviceUnavailable(res, "server is too busy");
-        } else if (!success) {
-          return httputils.authRequired(res, "password mismatch");
-        } else {
-          return postAuthentication();
-        }
-      });
-    });
-  } else {
-    return httputils.authRequired(res, 'Provide your password');
-  }
+          bcrypt.compare(req.params.pass, hash, function (err, success) {
+            if (err) {
+              logger.warn("max load hit, failing on auth request with 503: " + err);
+              return httputils.serviceUnavailable(res, "server is too busy");
+            } else if (!success) {
+              return httputils.authRequired(res, "password mismatch");
+            } else {
+              return postAuthentication();
+            }
+          });
+        });
+      } else {
+        return httputils.authRequired(res, 'Provide your password');
+      }
+    } else {
+      // new password provided as param
+      if (typeof req.params.pass === 'string') {
+        // now bcrypt the password
+        wsapi.bcryptPassword(req.params.pass, function (err, hash) {
+          if (err) {
+            if (err.indexOf('exceeded') !== -1) {
+              logger.warn("max load hit, failing on auth request with 503: " + err);
+              return httputils.serviceUnavailable(res, "server is too busy");
+            }
+            logger.error("can't bcrypt: " + err);
+            return res.json({ success: false });
+          }
+          return postAuthentication(hash);
+        });
+      } else {
+        return httputils.authRequired(res, 'Provide your password');
+      }
+    }
+  });
 
-  function postAuthentication() {
+
+  function postAuthentication(hash) {
     db.haveVerificationSecret(req.params.token, function(err, known) {
       if (err) return wsapi.databaseDown(res, err);
 
@@ -70,7 +105,7 @@ exports.process = function(req, res) {
         return res.json({ success: false} );
       }
 
-      db.completePasswordReset(req.params.token, function(err, email, uid) {
+      db.completePasswordReset(req.params.token, hash, function(err, email, uid) {
         if (err) {
           logger.warn("couldn't complete email verification: " + err);
           wsapi.databaseDown(res, err);

--- a/lib/wsapi/complete_transition.js
+++ b/lib/wsapi/complete_transition.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const
+db = require('../db.js'),
+logger = require('../logging.js').logger,
+wsapi = require('../wsapi.js'),
+bcrypt = require('../bcrypt.js'),
+httputils = require('../httputils.js'),
+config = require('../configuration.js');
+
+exports.method = 'post';
+exports.writes_db = true;
+exports.authed = false;
+// NOTE: this API also takes a 'pass' parameter which is required
+// when a user has a null password (only primaries on their acct)
+exports.args = {
+  'token': 'token',
+  'pass': {
+    type: 'password',
+    required: false
+  }
+};
+exports.i18n = true;
+
+exports.process = function(req, res) {
+  // in order to complete a transition, one of the following must be true:
+  //
+  // 1. you are using the same browser to complete the email verification as you
+  //    used to start it
+  // 2. you have provided the password chosen by the initiator of the verification
+  //    request
+
+  // is this the same browser?
+  if (req.params.token === req.session.pendingReset) {
+    return postAuthentication();
+  }
+  // is a password provided?
+  else if (typeof req.params.pass === 'string') {
+    return db.authForVerificationSecret(req.params.token, function(err, hash) {
+      if (err) {
+        logger.warn("couldn't get password for verification secret: " + err);
+        return wsapi.databaseDown(res, err);
+      }
+
+      bcrypt.compare(req.params.pass, hash, function (err, success) {
+        if (err) {
+          logger.warn("max load hit, failing on auth request with 503: " + err);
+          return httputils.serviceUnavailable(res, "server is too busy");
+        } else if (!success) {
+          return httputils.authRequired(res, "password mismatch");
+        } else {
+          return postAuthentication();
+        }
+      });
+    });
+  } else {
+    return httputils.authRequired(res, 'Provide your password');
+  }
+
+  function postAuthentication() {
+    db.haveVerificationSecret(req.params.token, function(err, known) {
+      if (err) return wsapi.databaseDown(res, err);
+
+      if (!known) {
+        // clear the pendingReset token from the session if we find no such
+        // token in the database
+        delete req.session.pendingReset;
+        return res.json({ success: false} );
+      }
+
+      db.completePasswordReset(req.params.token, null, function(err, email, uid) {
+        if (err) {
+          logger.warn("couldn't complete email verification: " + err);
+          wsapi.databaseDown(res, err);
+        } else {
+          // clear the pendingReset token from the session once we
+          // successfully complete password reset
+          delete req.session.pendingReset;
+
+          // At this point, the user is either on the same browser with a token from
+          // their email address, OR they've provided their account password.  It's
+          // safe to grant them an authenticated session.
+          wsapi.authenticateSession({session: req.session,
+                                     uid: uid,
+                                     level: 'password',
+                                     duration_ms: config.get('ephemeral_session_duration_ms')
+                                    }, function(err) {
+            if (err) return wsapi.databaseDown(res, err);
+            res.json({ success: true });
+          });
+        }
+      });
+    });
+  }
+};

--- a/lib/wsapi/email_for_token.js
+++ b/lib/wsapi/email_for_token.js
@@ -28,7 +28,7 @@ exports.i18n = false;
 
 exports.process = function(req, res) {
 
-  db.emailForVerificationSecret(req.params.token, function(err, email, uid) {
+  db.emailForVerificationSecret(req.params.token, function(err, email, uid, passwd) {
     if (err) {
       if (err === 'database unavailable') {
         return httputils.serviceUnavailable(res, err);
@@ -39,6 +39,8 @@ exports.process = function(req, res) {
         });
       }
     }
+
+    var needs_password = !passwd;
 
     // now let's determine whether the user must authenticate.
     var must_auth = true;
@@ -66,7 +68,8 @@ exports.process = function(req, res) {
     res.json({
       success: true,
       email: email,
-      must_auth: must_auth
+      must_auth: must_auth,
+      needs_password: needs_password
     });
   });
 };

--- a/lib/wsapi/stage_email.js
+++ b/lib/wsapi/stage_email.js
@@ -67,7 +67,7 @@ exports.process = function(req, res) {
         });
       }
       else {
-        completeStage(null);
+        completeStage();
       }
 
       function completeStage(hash) {

--- a/lib/wsapi/stage_reset.js
+++ b/lib/wsapi/stage_reset.js
@@ -21,8 +21,7 @@ exports.writes_db = true;
 exports.authed = false;
 exports.args = {
   email: 'email',
-  site:  'origin',
-  pass:  'password'
+  site:  'origin'
 };
 exports.i18n = true;
 
@@ -52,37 +51,25 @@ exports.process = function(req, res) {
       // staging a user logs you out.
       wsapi.clearAuthenticatedUser(req.session);
 
-      // now bcrypt the password
-      wsapi.bcryptPassword(req.params.pass, function (err, hash) {
-        if (err) {
-          if (err.indexOf('exceeded') !== -1) {
-            logger.warn("max load hit, failing on auth request with 503: " + err);
-            return httputils.serviceUnavailable(res, "server is too busy");
-          }
-          logger.error("can't bcrypt: " + err);
-          return res.json({ success: false });
-        }
+      // on failure stageEmail may throw
+      try {
+        db.stageEmail(uid, req.params.email, null, function(err, secret) {
+          if (err) return wsapi.databaseDown(res, err);
 
-        // on failure stageEmail may throw
-        try {
-          db.stageEmail(uid, req.params.email, hash, function(err, secret) {
-            if (err) return wsapi.databaseDown(res, err);
+          var langContext = wsapi.langContext(req);
 
-            var langContext = wsapi.langContext(req);
+          // store the email being added in session data
+          req.session.pendingReset = secret;
 
-            // store the email being added in session data
-            req.session.pendingReset = secret;
-            
-            res.json({ success: true });
+          res.json({ success: true });
 
-            // let's now kick out a verification email!
-            email.sendForgotPasswordEmail(req.params.email, req.params.site, secret, langContext);
-          });
-        } catch(e) {
-          // we should differentiate tween' 400 and 500 here.
-          httputils.badRequest(res, e.toString());
-        }
-      });
+          // let's now kick out a verification email!
+          email.sendForgotPasswordEmail(req.params.email, req.params.site, secret, langContext);
+        });
+      } catch (e) {
+        // we should differentiate tween' 400 and 500 here.
+        httputils.badRequest(res, e.toString());
+      }
     });
   });
 };

--- a/lib/wsapi/stage_transition.js
+++ b/lib/wsapi/stage_transition.js
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const
+db = require('../db.js'),
+wsapi = require('../wsapi.js'),
+httputils = require('../httputils'),
+logger = require('../logging.js').logger,
+email = require('../email.js'),
+config = require('../configuration');
+
+/* Stage an email address that is transitioning from a primary to a secondary
+ * and doesn't have a password.
+ */
+
+exports.method = 'post';
+exports.writes_db = true;
+exports.authed = false;
+exports.args = {
+  email: 'email',
+  site:  'origin',
+  pass:  'password'
+};
+exports.i18n = true;
+
+exports.process = function(req, res) {
+  db.lastStaged(req.params.email, function (err, last) {
+    if (err) return wsapi.databaseDown(res, err);
+
+    if (last && (new Date() - last) < config.get('min_time_between_emails_ms')) {
+      logger.warn('throttling request to stage email address ' + req.params.email + ', only ' +
+                  ((new Date() - last) / 1000.0) + "s elapsed");
+      return httputils.throttled(res, "Too many emails sent to that address, try again later.");
+    }
+
+    db.emailToUID(req.params.email, function(err, uid) {
+      if (err) {
+        logger.info("reset password fails: " + err);
+        return res.json({ success: false });
+      }
+
+      if (!uid) {
+        return res.json({
+          reason: "No such email address.",
+          success: false
+        });
+      }
+
+      // staging a user logs you out.
+      wsapi.clearAuthenticatedUser(req.session);
+
+      // now bcrypt the password
+      wsapi.bcryptPassword(req.params.pass, function (err, hash) {
+        if (err) {
+          if (err.indexOf('exceeded') !== -1) {
+            logger.warn("max load hit, failing on auth request with 503: " + err);
+            return httputils.serviceUnavailable(res, "server is too busy");
+          }
+          logger.error("can't bcrypt: " + err);
+          return res.json({ success: false });
+        }
+
+        // on failure stageEmail may throw
+        try {
+          db.stageEmail(uid, req.params.email, hash, function(err, secret) {
+            if (err) return wsapi.databaseDown(res, err);
+
+            var langContext = wsapi.langContext(req);
+
+            // store the email being added in session data
+            req.session.pendingReset = secret;
+            
+            res.json({ success: true });
+
+            // let's now kick out a verification email!
+            email.sendTransitionEmail(req.params.email, req.params.site, secret, langContext);
+          });
+        } catch(e) {
+          // we should differentiate tween' 400 and 500 here.
+          httputils.badRequest(res, e.toString());
+        }
+      });
+    });
+  });
+};

--- a/lib/wsapi/transition_status.js
+++ b/lib/wsapi/transition_status.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const
+db = require('../db.js'),
+wsapi = require('../wsapi.js'),
+logger = require('../logging.js').logger,
+httputils = require('../httputils.js');
+
+exports.method = 'get';
+exports.writes_db = false;
+exports.authed = false;
+exports.args = { email: 'email' };
+exports.i18n = false;
+
+exports.process = function(req, res) {
+  var email = req.params.email;
+
+  // if the email is in the staged table, we are not complete yet.
+  // if the email is not in the staged table -
+  //   * if we are authenticated as the owner of the email we're done
+  //   * if we are not authenticated as the owner of the email, we must auth
+  db.isStaged(email, function(err, staged) {
+    if (err) wsapi.databaseDown(res, err);
+
+    if (staged) {
+      return res.json({ status: 'pending' });
+    } else {
+      if (wsapi.isAuthed(req, 'assertion')) {
+        db.userOwnsEmail(req.session.userid, email, function(err, owned) {
+          if (err) wsapi.databaseDown(res, err);
+          else if (owned) res.json({ status: 'complete', userid: req.session.userid });
+          else res.json({ status: 'mustAuth' });
+        });
+      } else {
+        return res.json({ status: 'mustAuth' });
+      }
+    }
+  });
+};

--- a/resources/email_templates/transition.ejs
+++ b/resources/email_templates/transition.ejs
@@ -1,0 +1,10 @@
+<%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
+
+<%= gettext('To continue, you need to re-confirm this email address and set up a new, Persona-specific password.') %>
+
+<%= gettext('Click to set your new password:') %>
+<%= link %>
+
+<%= gettext('Thank you,') %>
+<%= gettext('The Persona Team') %>
+

--- a/resources/email_templates/transition.html.ejs
+++ b/resources/email_templates/transition.html.ejs
@@ -1,0 +1,102 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Persona</title>
+        <style type="text/css">
+            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
+            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
+            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
+
+            body{
+              background: #45505b;
+              margin:0;
+              padding:0;
+              width:100% !important;
+              -webkit-text-size-adjust:none;
+              font-family: Helvetica, Arial, sans-serif;
+              font-size: 14px;
+              color: #424f5a;
+            }
+            img{
+              border:0;
+              height:auto;
+              line-height:100%;
+              outline:none;
+              text-decoration:none;
+            }
+            a{
+              color: #3b9bda;
+              text-decoration: none;
+            }
+            a:hover{
+              text-decoration: underline;
+            }
+            p{
+              margin: 0 0 15px;
+              line-height: 1.5;
+            }
+
+            h2{
+              font-size: 18px;
+              margin: 20px 0 15px;
+            }
+
+            p:last-child{
+              margin-bottom: 0;
+            }
+            table td{
+              border-collapse:collapse;
+            }
+        </style>
+  </head>
+  <body style="-webkit-text-size-adjust: none;margin: 0;padding: 0;background-color: #45505b;width: 100% !important;">
+    <center>
+    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+      <tr style="margin: 0;
+        padding: 0;
+        height: 100% !important;
+        width: 100% !important; 
+        background: #45505b;
+        -webkit-text-size-adjust:none;
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color: #424f5a;">
+        <td align="center" valign="top" style="border-collapse: collapse;">
+          
+
+                <table border="0" cellpadding="0" cellspacing="0" width="90%">
+                  <tr class="spacer">
+                    <td height="30px"></td>
+                  </tr>
+                  <tr>
+                    <td align="left" valign="top" style="border-collapse: collapse;">
+                      <img src="<%= cachify('/pages/i/persona-logo-wordmark.png') %>" alt="Mozilla Persona" />
+                    </td>
+                  </tr>
+                  <tr class="spacer">
+                    <td height="30px"></td>
+                  </tr>
+                </table><!-- #header -->
+                <table id="content" border="0" cellpadding="0" cellspacing="0" width="90%" style="background-color: #fff; border-radius: 3px; margin-bottom: 60px;">
+                  <tr>
+                    <td align="left" valign="top" class="email-content" style="border-collapse: collapse; padding: 30px;">
+                      <p><%= gettext('It looks like your email provider is having trouble with their Persona support.') %></p>
+                      <p><%= gettext('To continue, you need to re-confirm this email address and set up a new, Persona-specific password.') %></p>
+
+                      <p><a href="<%= link %>" style="color: #3b9bda; font-weight: bold;"><%= gettext('Click here to set your new password.') %></a></p>
+
+                      <p><%= gettext('Thank you,') %><br />
+                      <%= gettext('The Persona team') %></p>
+                    </td>
+                  </tr>
+                </table><!-- #content -->
+              
+
+        </td>
+      </tr>
+    </table><!-- #container table -->
+    </center>
+
+  </body>
+</html>

--- a/resources/static/common/js/lib/dom-jquery.js
+++ b/resources/static/common/js/lib/dom-jquery.js
@@ -142,12 +142,19 @@ BrowserID.DOM = ( function() {
         */
         setInner: function( element, value ) {
             var target = jQuery( element );
-            if( isValBased( target ) ) {
-                target.val( value );
-            }
-            else {
-                target.html( value );
-            }
+
+            // If using a class selector, multiple elements can be returned.
+            // One element could be an input, another a normal DOM element.
+            // Loop over each element and inspect one at a time.
+            target.each(function(idx, element) {
+                element = $( element );
+                if( isValBased( element ) ) {
+                    element.val( value );
+                }
+                else {
+                    element.html( value );
+                }
+            });
         },
 
         /**

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -106,12 +106,16 @@ BrowserID.Network = (function() {
   }
 
   function completeAddressVerification(wsapiName, token, password, onComplete, onFailure) {
+      var data = {
+        token: token
+      };
+
+      // Only send the password along if it was actually given
+      if (password !== null) data.pass = password;
+
       post({
         url: wsapiName,
-        data: {
-          token: token,
-          pass: password
-        },
+        data: data,
         success: function(status, textStatus, jqXHR) {
           // If the user has successfully completed an address verification,
           // they are authenticated to the password status.

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -774,9 +774,7 @@ BrowserID.Network = (function() {
         pass: password,
         site : origin
       };
-      // XXX - This is going to have to change when zaach adds a transition
-      // function.
-      stageAddressForVerification(postData, "/wsapi/stage_reset", onComplete, onFailure);
+      stageAddressForVerification(postData, "/wsapi/stage_transition", onComplete, onFailure);
     },
 
     /**
@@ -787,21 +785,17 @@ BrowserID.Network = (function() {
      * @param {function} [onComplete] - Called when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-      // XXX - This is going to have to change when zaach adds a transition
-      // completion function.
-    completeTransitionToSecondary: completeAddressVerification.curry("/wsapi/complete_reset"),
+    completeTransitionToSecondary: completeAddressVerification.curry("/wsapi/complete_transition"),
 
     /**
      * Check the registration status of a transition to secondary
-     * @method checkPasswordReset
+     * @method checkTransitionToSecondary
      * @param {function} [onsuccess] - called when complete.
      * @param {function} [onfailure] - called on xhr failure.
      */
     checkTransitionToSecondary: function(email, onComplete, onFailure) {
-      // XXX - This is going to have to change when zaach adds a check
-      // transition function.
       get({
-        url: "/wsapi/password_reset_status?email=" + encodeURIComponent(email),
+        url: "/wsapi/transition_status?email=" + encodeURIComponent(email),
         success: handleAddressVerifyCheckResponse.curry(onComplete),
         error: onFailure
       });

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -753,6 +753,56 @@ BrowserID.Network = (function() {
           complete(onFailure, "user not authenticated");
         }
       }, onFailure);
+    },
+
+    /**
+     * Request that an account transitions from a primary to a secondary. Used
+     * whenever a user has only primary addresses and one of the addresses
+     * belongs to an IdP which converts to a secondary.
+     * @method requestTransitionToSecondary
+     * @param {string} email
+     * @param {string} password
+     * @param {string} origin - site user is trying to sign in to.
+     * @param {function} [onComplete] - Callback to call when complete.
+     * @param {function} [onFailure] - Called on XHR failure.
+     */
+    requestTransitionToSecondary: function(email, password, origin, onComplete, onFailure) {
+      var postData = {
+        email: email,
+        pass: password,
+        site : origin
+      };
+      // XXX - This is going to have to change when zaach adds a transition
+      // function.
+      stageAddressForVerification(postData, "/wsapi/stage_reset", onComplete, onFailure);
+    },
+
+    /**
+     * Complete transition to secondary
+     * @method completeTransitionToSecondary
+     * @param {string} token - token to register for.
+     * @param {string} password
+     * @param {function} [onComplete] - Called when complete.
+     * @param {function} [onFailure] - Called on XHR failure.
+     */
+      // XXX - This is going to have to change when zaach adds a transition
+      // completion function.
+    completeTransitionToSecondary: completeAddressVerification.curry("/wsapi/complete_reset"),
+
+    /**
+     * Check the registration status of a transition to secondary
+     * @method checkPasswordReset
+     * @param {function} [onsuccess] - called when complete.
+     * @param {function} [onfailure] - called on xhr failure.
+     */
+    checkTransitionToSecondary: function(email, onComplete, onFailure) {
+      // XXX - This is going to have to change when zaach adds a check
+      // transition function.
+      get({
+        url: "/wsapi/password_reset_status?email=" + encodeURIComponent(email),
+        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        error: onFailure
+      });
     }
   };
 

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -322,15 +322,13 @@ BrowserID.Network = (function() {
      * Request a password reset for the given email address.
      * @method requestPasswordReset
      * @param {string} email
-     * @param {string} password
      * @param {string} origin
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    requestPasswordReset: function(email, password, origin, onComplete, onFailure) {
+    requestPasswordReset: function(email, origin, onComplete, onFailure) {
       var postData = {
         email: email,
-        pass: password,
         site : origin
       };
       stageAddressForVerification(postData, "/wsapi/stage_reset", onComplete, onFailure);

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -638,7 +638,7 @@ BrowserID.User = (function() {
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a password reset.
         if (info.state === "unknown") {
-          complete(onComplete, { success: false, reason: "invalid_user" });
+          complete(onComplete, { success: false, reason: "invalid_email" });
         }
         // user is trying to reset the password of a primary address.
         else if (info.type === "primary") {
@@ -734,7 +734,7 @@ BrowserID.User = (function() {
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a transition to secondary.
         if (info.state === "unknown") {
-          complete(onComplete, { success: false, reason: "invalid_user" });
+          complete(onComplete, { success: false, reason: "invalid_email" });
         }
         // user is trying to transition to a secondary for a primary address.
         else if (info.type === "primary") {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1056,10 +1056,7 @@ BrowserID.User = (function() {
      */
     addEmail: function(email, password, onComplete, onFailure) {
       stageAddressVerification(email, password,
-        network.addSecondaryEmail.bind(network, email, password, origin),
-        function(status) {
-          complete(onComplete, status.success);
-        }, onFailure);
+        network.addSecondaryEmail.bind(network, email, password, origin), onComplete, onFailure);
     },
 
     /**

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -618,14 +618,13 @@ BrowserID.User = (function() {
      * Request a password reset for the given email address.
      * @method requestPasswordReset
      * @param {string} email
-     * @param {string} password
      * @param {function} [onComplete] - Callback to call when complete, called
      * with a single object, info.
      *    info.status {boolean} - true or false whether request was successful.
      *    info.reason {string} - if status false, reason of failure.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    requestPasswordReset: function(email, password, onComplete, onFailure) {
+    requestPasswordReset: function(email, onComplete, onFailure) {
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a password reset.
         if (info.state === "unknown") {
@@ -636,8 +635,8 @@ BrowserID.User = (function() {
           complete(onComplete, { success: false, reason: "primary_address" });
         }
         else {
-          stageAddressVerification(email, password,
-            network.requestPasswordReset.bind(network, email, password, origin),
+          stageAddressVerification(email, null,
+            network.requestPasswordReset.bind(network, email, origin),
             onComplete, onFailure);
         }
       }, onFailure);

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -148,6 +148,11 @@ BrowserID.User = (function() {
 
   }
 
+  /**
+   * onSuccess, if called, will return with "complete" if the verification
+   * completes and the user is authed to the "password" level, or "mustAuth" if
+   * the user must enter their password.
+   */
   function addressVerificationPoll(checkFunc, email, onSuccess, onFailure) {
     function userVerified(completionStatus) {
       if (stagedEmail && stagedPassword) {
@@ -166,11 +171,18 @@ BrowserID.User = (function() {
       }
       else {
         // If the user's completionStatus is complete but their
-        // authStatus is not password, that means they have not entered in
-        // their authentication credentials this session and *must*
-        // do so.  If not, the backend will reject any requests to certify
-        // a key because the user will not have the correct creds to do so.
+        // original authStatus was not password, meaning they have
+        // not entered in their authentication credentials this session.
+        // If the user is not authenticated to the password level, the backend
+        // will reject any requests to certify a key because the user will
+        // not have the correct creds to do so.
         // See issue #2088 https://github.com/mozilla/browserid/issues/2088
+        //
+        // Since a user may have entered their password on the main site during
+        // a password reset, the only reliable way to know the user's auth
+        // status is to ask the backend. Clear the current context and ask
+        // the backend for an updated session_context.
+        network.clearContext();
         network.checkAuth(function(authStatus) {
           if (completionStatus === "complete" && authStatus !== "password")
             completionStatus = "mustAuth";
@@ -552,9 +564,7 @@ BrowserID.User = (function() {
      * Cancel the waitForUserValidation poll
      * @method cancelUserValidation
      */
-    cancelUserValidation: function() {
-      cancelRegistrationPoll();
-    },
+    cancelUserValidation: cancelRegistrationPoll,
 
     /**
      * Get site and email info for a token
@@ -1079,9 +1089,7 @@ BrowserID.User = (function() {
      * Cancel the waitForEmailValidation poll
      * @method cancelEmailValidation
      */
-    cancelEmailValidation: function() {
-      cancelRegistrationPoll();
-    },
+    cancelEmailValidation: cancelRegistrationPoll,
 
     /**
      * Verify a users email address given by the token

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -711,6 +711,63 @@ BrowserID.User = (function() {
     cancelWaitForEmailReverifyComplete: cancelRegistrationPoll,
 
     /**
+     * Request a transition to secondary for the given email address.
+     * @method requestTransitionToSecondary
+     * @param {string} email
+     * @param {string} password
+     * @param {function} [onComplete] - Callback to call when complete, called
+     * with a single object, info.
+     *    info.status {boolean} - true or false whether request was successful.
+     *    info.reason {string} - if status false, reason of failure.
+     * @param {function} [onFailure] - Called on XHR failure.
+     */
+    requestTransitionToSecondary: function(email, password, onComplete, onFailure) {
+      User.addressInfo(email, function(info) {
+        // user is not known.  Can't request a transition to secondary.
+        if (info.state === "unknown") {
+          complete(onComplete, { success: false, reason: "invalid_user" });
+        }
+        // user is trying to transition to a secondary for a primary address.
+        else if (info.type === "primary") {
+          complete(onComplete, { success: false, reason: "primary_address" });
+        }
+        else {
+          stageAddressVerification(email, password,
+            network.requestTransitionToSecondary.bind(network, email, password, origin),
+            onComplete, onFailure);
+        }
+      }, onFailure);
+    },
+
+    /**
+     * Verify the transition to secondary for a user.
+     * @method completeTransitionToSecondary
+     * @param {string} token - token to verify.
+     * @param {string} password
+     * @param {function} [onComplete] - Called on completion.
+     *   Called with an object with valid, email, and origin if valid, called
+     *   with valid=false otw.
+     * @param {function} [onFailure] - Called on error.
+     */
+    completeTransitionToSecondary: completeAddressVerification.curry(network.completeTransitionToSecondary),
+
+    /**
+     * Wait for the transition to secondary to complete
+     * @method waitForTransitionToSecondaryComplete
+     * @param {string} email - email address to check.
+     * @param {function} [onSuccess] - Called to give status updates.
+     * @param {function} [onFailure] - Called on error.
+     */
+    waitForTransitionToSecondaryComplete: addressVerificationPoll.curry(network.checkTransitionToSecondary),
+
+    /**
+     * Cancel the waitForTransitionToSecondaryComplete poll
+     * @method cancelWaitForTransitionToSecondaryComplete
+     */
+    cancelWaitForTransitionToSecondaryComplete: cancelRegistrationPoll,
+
+
+    /**
      * Cancel the current user's account.  Remove last traces of their
      * identity.
      * @method cancelUser

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -94,10 +94,10 @@
     }, self.getErrorDialog(errors.createUser, callback));
   }
 
-  function resetPassword(email, password, callback) {
+  function resetPassword(email, callback) {
     /*jshint validthis:true*/
     var self=this;
-    user.requestPasswordReset(email, password, function(status) {
+    user.requestPasswordReset(email, function(status) {
       if (status.success) {
         self.publish("reset_password_staged", { email: email });
       }

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -177,15 +177,15 @@
     /*jshint validthis:true*/
     var self=this;
 
-    user.addEmail(email, password, function(added) {
-      if (added) {
+    user.addEmail(email, password, function(status) {
+      if (status.success) {
         var info = { email: email, password: password };
         self.publish("email_staged", info, info );
       }
       else {
         tooltip.showTooltip("#could_not_add");
       }
-      complete(callback, added);
+      complete(callback, status.success);
     }, self.getErrorDialog(errors.addEmail, callback));
   }
 

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -86,8 +86,6 @@
         complete(callback, true);
       }
       else {
-        // XXX will this tooltip ever be shown, the authentication screen has
-        // already been torn down by this point?
         tooltip.showTooltip("#could_not_add");
         complete(callback, false);
       }

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -102,10 +102,27 @@
         self.publish("reset_password_staged", { email: email });
       }
       else {
+        // XXX the tooltip should talk about being unable to reset the
+        // password.
         tooltip.showTooltip("#could_not_add");
       }
       complete(callback, status.success);
     }, self.getErrorDialog(errors.requestPasswordReset, callback));
+  }
+
+  function transitionToSecondary(email, password, callback) {
+    /*jshint validthis:true*/
+    var self=this;
+    user.requestTransitionToSecondary(email, password, function(status) {
+      if (status.success) {
+        self.publish("transition_to_secondary_staged", { email: email });
+      }
+      else {
+        // XXX the tooltip should talk about being unable to set the password.
+        tooltip.showTooltip("#could_not_add");
+      }
+      complete(callback, status.success);
+    }, self.getErrorDialog(errors.transitionToSecondary, callback));
   }
 
   function reverifyEmail(email, callback) {
@@ -116,6 +133,8 @@
         self.publish("reverify_email_staged", { email: email });
       }
       else {
+        // XXX the tooltip should show something about being unable to reverify
+        // email
         tooltip.showTooltip("#could_not_add");
       }
       complete(callback, status.success);
@@ -184,6 +203,7 @@
     refreshEmailInfo: refreshEmailInfo,
     addSecondaryEmail: addSecondaryEmail,
     resetPassword: resetPassword,
+    transitionToSecondary: transitionToSecondary,
     reverifyEmail: reverifyEmail,
     cancelEvent: helpers.cancelEvent,
     animateClose: animateClose,

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -102,8 +102,6 @@
         self.publish("reset_password_staged", { email: email });
       }
       else {
-        // XXX the tooltip should talk about being unable to reset the
-        // password.
         tooltip.showTooltip("#could_not_add");
       }
       complete(callback, status.success);
@@ -118,7 +116,6 @@
         self.publish("transition_to_secondary_staged", { email: email });
       }
       else {
-        // XXX the tooltip should talk about being unable to set the password.
         tooltip.showTooltip("#could_not_add");
       }
       complete(callback, status.success);
@@ -133,8 +130,6 @@
         self.publish("reverify_email_staged", { email: email });
       }
       else {
-        // XXX the tooltip should show something about being unable to reverify
-        // email
         tooltip.showTooltip("#could_not_add");
       }
       complete(callback, status.success);

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -88,7 +88,7 @@ BrowserID.State = (function() {
       // staging request is throttled, the next time set_password is called,
       // these variables are needed to know which staging function to call.
       // See issue #2258.
-      self.newUserEmail = self.addEmailEmail = self.resetPasswordEmail = self.transitionNoPassword = null;
+      self.newUserEmail = self.addEmailEmail = self.transitionNoPassword = null;
 
       startAction(actionName, actionInfo);
     }
@@ -203,24 +203,20 @@ BrowserID.State = (function() {
        * 1) This is a new user
        * 2) A user is adding the first secondary address to an account that
        *    consists only of primary addresses
-       * 3) An existing user has forgotten their password and wants to reset it.
-       * 4) A primary address was downgraded to a secondary and the user
+       * 3) A primary address was downgraded to a secondary and the user
        *    has no password in the DB.
        *
        * #1 is taken care of by newUserEmail, #2 by addEmailEmail,
-       * #3 by resetPasswordEmail, and #4 by transitionNoPassword
+       * and #3 by transitionNoPassword
        */
       info = _.extend({ email: self.newUserEmail || self.addEmailEmail ||
-                        self.resetPasswordEmail || self.transitionNoPassword }, info);
+                        self.transitionNoPassword }, info);
 
       if(self.newUserEmail) {
         startAction(false, "doStageUser", info);
       }
       else if(self.addEmailEmail) {
         startAction(false, "doStageEmail", info);
-      }
-      else if(self.resetPasswordEmail) {
-        startAction(false, "doStageResetPassword", info);
       }
       else if (self.transitionNoPassword) {
         startAction(false, "doStageTransitionToSecondary", info);
@@ -446,13 +442,11 @@ BrowserID.State = (function() {
     });
 
     handleState("forgot_password", function(msg, info) {
-      // User has forgotten their password, let them reset it.  The response
-      // message from the forgot_password controller will be a set_password.
-      // the set_password handler needs to know the resetPasswordEmail so it
-      // knows how to trigger the reset_password_staged message.  At this
-      // point, the email confirmation screen will be shown.
-      self.resetPasswordEmail = info.email;
-      startAction(false, "doResetPassword", info);
+      // User has forgotten their password, let them reset it.  The user will
+      // be transitioned to the confirmation screen and must verify their email
+      // address. The new password will be entered on the main site after the
+      // user verifies their address.
+      startAction(false, "doStageResetPassword", info);
       complete(info.complete);
     });
 

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -199,7 +199,7 @@ BrowserID.State = (function() {
     });
 
     handleState("password_set", function(msg, info) {
-      /* A password can be set for one of three reasons - 
+      /* A password can be set for one of three reasons -
        * 1) This is a new user
        * 2) A user is adding the first secondary address to an account that
        *    consists only of primary addresses
@@ -223,7 +223,7 @@ BrowserID.State = (function() {
         startAction(false, "doStageResetPassword", info);
       }
       else if (self.transitionNoPassword) {
-        startAction(false, "doStageResetPassword", info);
+        startAction(false, "doStageTransitionToSecondary", info);
       }
     });
 

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -112,7 +112,14 @@ BrowserID.Modules.Actions = (function() {
     },
 
     doStageTransitionToSecondary: function(info) {
-      dialogHelpers.transitionToSecondary.call(this, info.email, info.password, info.ready);
+      dialogHelpers.transitionToSecondary.call(this, info.email,
+          info.password, info.ready);
+    },
+
+    doConfirmTransitionToSecondary: function(info) {
+      startRegCheckService.call(this, info,
+          "waitForTransitionToSecondaryComplete",
+          "transition_to_secondary_confirmed");
     },
 
     doAssertionGenerated: function(info) {

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -115,6 +115,10 @@ BrowserID.Modules.Actions = (function() {
       startRegCheckService.call(this, info, "waitForEmailReverifyComplete", "reverify_email_confirmed");
     },
 
+    doStageTransitionToSecondary: function(info) {
+      dialogHelpers.transitionToSecondary.call(this, info.email, info.password, info.ready);
+    },
+
     doAssertionGenerated: function(info) {
       // Clear onerror before the call to onsuccess - the code to onsuccess
       // calls window.close, which would trigger the onerror callback if we

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -95,12 +95,8 @@ BrowserID.Modules.Actions = (function() {
       startService("required_email", info);
     },
 
-    doResetPassword: function(info) {
-      startService("set_password", _.extend(info, { password_reset: true }), "reset_password");
-    },
-
     doStageResetPassword: function(info) {
-      dialogHelpers.resetPassword.call(this, info.email, info.password, info.ready);
+      dialogHelpers.resetPassword.call(this, info.email, info.ready);
     },
 
     doConfirmResetPassword: function(info) {

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -202,7 +202,7 @@ BrowserID.Modules.Authenticate = (function() {
     var email = getEmail();
     if (email) {
       var info = addressInfo || { email: email };
-      this.close("forgot_password", info, info );
+      this.publish("forgot_password", info, info );
     }
   }
 

--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -473,7 +473,7 @@ button.delete:active {
   display: none;
 }
 
-.enter_password .password_entry {
+.enter_password .password_entry, .needs_password .vpassword_entry {
   display: block;
 }
 

--- a/resources/static/pages/js/forgot.js
+++ b/resources/static/pages/js/forgot.js
@@ -26,7 +26,7 @@ BrowserID.forgot = (function() {
       else {
         var tooltipEls = {
           throttle: "#could_not_add",
-          invalid_user: "#not_registered",
+          invalid_email: "#not_registered",
           primary_address: "#primary_address"
         };
 

--- a/resources/static/pages/js/forgot.js
+++ b/resources/static/pages/js/forgot.js
@@ -19,6 +19,8 @@ BrowserID.forgot = (function() {
     dom.hide(".notification");
 
     var email = helpers.getAndValidateEmail("#email");
+    if (!email) return complete(oncomplete);
+
     user.requestPasswordReset(email, function onSuccess(info) {
       if (info.success) {
         pageHelpers.emailSent("waitForPasswordResetComplete", email, oncomplete);

--- a/resources/static/pages/js/forgot.js
+++ b/resources/static/pages/js/forgot.js
@@ -18,33 +18,25 @@ BrowserID.forgot = (function() {
   function submit(oncomplete) {
     dom.hide(".notification");
 
-    var email = helpers.getAndValidateEmail("#email"),
-        pass = dom.getInner("#password"),
-        vpass = dom.getInner("#vpassword"),
-        validPass = email && validation.passwordAndValidationPassword(pass, vpass);
+    var email = helpers.getAndValidateEmail("#email");
+    user.requestPasswordReset(email, function onSuccess(info) {
+      if (info.success) {
+        pageHelpers.emailSent("waitForPasswordResetComplete", email, oncomplete);
+      }
+      else {
+        var tooltipEls = {
+          throttle: "#could_not_add",
+          invalid_user: "#not_registered",
+          primary_address: "#primary_address"
+        };
 
-    if (email && validPass) {
-      user.requestPasswordReset(email, pass, function onSuccess(info) {
-        if (info.success) {
-          pageHelpers.emailSent("waitForPasswordResetComplete", email, oncomplete);
+        var tooltipEl = tooltipEls[info.reason];
+        if (tooltipEl) {
+          tooltip.showTooltip(tooltipEl);
         }
-        else {
-          var tooltipEls = {
-            throttle: "#could_not_add",
-            invalid_user: "#not_registered",
-            primary_address: "#primary_address"
-          };
-
-          var tooltipEl = tooltipEls[info.reason];
-          if (tooltipEl) {
-            tooltip.showTooltip(tooltipEl);
-          }
-          complete(oncomplete);
-        }
-      }, pageHelpers.getFailure(bid.Errors.requestPasswordReset, oncomplete));
-    } else {
-      complete(oncomplete);
-    }
+        complete(oncomplete);
+      }
+    }, pageHelpers.getFailure(bid.Errors.requestPasswordReset, oncomplete));
   }
 
   function back(oncomplete) {

--- a/resources/static/pages/js/reset_password.js
+++ b/resources/static/pages/js/reset_password.js
@@ -22,7 +22,7 @@ BrowserID.resetPassword = (function() {
   function showRegistrationInfo(info) {
     /*jshint validthis: true*/
     var self=this;
-    dom.setInner("#email", info.email);
+    dom.setInner(".email", info.email);
     dom.setInner(".website", self.redirectTo);
 
     if (self.uiTimeoutID) self.uiTimeoutID = clearTimeout(self.uiTimeoutID);

--- a/resources/static/pages/js/reset_password.js
+++ b/resources/static/pages/js/reset_password.js
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+BrowserID.resetPassword = (function() {
+  "use strict";
+
+  var ANIMATION_TIME=250,
+      bid = BrowserID,
+      user = bid.User,
+      storage = bid.Storage,
+      errors = bid.Errors,
+      pageHelpers = bid.PageHelpers,
+      dom = bid.DOM,
+      helpers = bid.Helpers,
+      complete = helpers.complete,
+      validation = bid.Validation,
+      tooltip = bid.Tooltip,
+      REDIRECT_SECONDS = 5,
+      sc;
+
+  function showRegistrationInfo(info) {
+    /*jshint validthis: true*/
+    var self=this;
+    dom.setInner("#email", info.email);
+    dom.setInner(".website", self.redirectTo);
+
+    if (self.uiTimeoutID) self.uiTimeoutID = clearTimeout(self.uiTimeoutID);
+    updateRedirectTimeout.call(this);
+
+    if (info.returnTo) {
+      dom.show(".siteinfo");
+    }
+  }
+
+  function updateRedirectTimeout() {
+    /*jshint validthis: true*/
+    dom.setInner("#redirectTimeout", this.secondsRemaining);
+  }
+
+  function countdownTimeout(onComplete) {
+    /*jshint validthis: true*/
+    var self=this;
+    function checkTime() {
+      if (self.secondsRemaining > 0) {
+        updateRedirectTimeout.call(self);
+        self.secondsRemaining--;
+        self.uiTimeoutID = setTimeout(checkTime.bind(self), 1000);
+      } else {
+        complete(onComplete);
+      }
+    }
+
+    checkTime();
+  }
+
+  function submit(oncomplete) {
+    /*jshint validthis: true*/
+    var self = this,
+        pass = dom.getInner("#password") || null,
+        vpass = dom.getInner("#vpassword") || null,
+        inputValid = ((!self.needsPassword || validation.passwordAndValidationPassword(pass, vpass))
+        // BEGIN TRANSITION CODE
+                   && (!self.mustAuth || validation.password(pass)));
+        // END TRANSITION CODE
+
+    if (inputValid) {
+      user.completePasswordReset(self.token, pass, function(info) {
+        dom.addClass("body", "complete");
+
+        var verified = info.valid;
+
+        if (verified) {
+          pageHelpers.replaceFormWithNotice("#congrats", function() {
+            // set the loggedIn status for the site.  This allows us to get
+            // a silent assertion without relying on the dialog to set the
+            // loggedIn status for the domain.  This is useful when the user
+            // closes the dialog OR if redirection happens before the dialog
+            // has had a chance to finish its business.
+            /*jshint newcap:false*/
+            storage.setLoggedIn(URLParse(self.redirectTo).originOnly(), self.email);
+
+            countdownTimeout.call(self, function() {
+              self.doc.location = self.redirectTo;
+              complete(oncomplete, verified);
+            });
+          });
+        }
+        else {
+          pageHelpers.showFailure(errors.cannotComplete, info, oncomplete);
+        }
+      }, function(info) {
+        if (info.network && info.network.status === 401) {
+          tooltip.showTooltip("#cannot_authenticate");
+          complete(oncomplete, false);
+        }
+        else {
+          pageHelpers.showFailure(errors.verifyEmail, info, oncomplete);
+        }
+      });
+    }
+    else {
+      complete(oncomplete, false);
+    }
+  }
+
+  function startVerification(oncomplete) {
+    /*jshint validthis: true*/
+    var self=this;
+    user.tokenInfo(self.token, function(info) {
+      if (info) {
+        self.redirectTo = info.returnTo || "https://login.persona.org/";
+        self.email = info.email;
+        showRegistrationInfo.call(self, info);
+
+        // BEGIN TRANSITION CODE
+        self.mustAuth = info.must_auth;
+        // END TRANSITION CODE
+        self.needsPassword = info.needs_password;
+
+        if (self.needsPassword) {
+          // These are users who are authenticating in a different browser or
+          // session than the initiator.
+          dom.addClass("body", "needs_password");
+          dom.focus("input[autofocus]");
+          complete(oncomplete, true);
+        }
+        // BEGIN TRANSITION CODE
+        // The transition code is to handle users who started the password
+        // reset flow under the old system where users entered their password
+        // in the dialog pre-verification. This can be removed once all of
+        // those links expire. (~ end of Mar 2013). See issue #1232
+        else if (self.mustAuth) {
+          // These are users who are authenticating in a different browser or
+          // session than the initiator.
+          dom.addClass("body", "enter_password");
+          dom.focus("input[autofocus]");
+          complete(oncomplete, true);
+        }
+        else {
+          // Easy case where user is in same browser and same session, just
+          // verify and be done with it all!
+          submit.call(self, oncomplete);
+        }
+        // END TRANSITION CODE
+      }
+      else {
+        // renderError is used directly instead of pageHelpers.showFailure
+        // because showFailure hides the title in the extended info.
+        self.renderError("error", errors.cannotConfirm);
+        complete(oncomplete, false);
+      }
+    }, pageHelpers.getFailure(errors.getTokenInfo, oncomplete));
+  }
+
+  var Module = bid.Modules.PageModule.extend({
+    start: function(options) {
+      var self=this;
+      self.checkRequired(options, "token");
+
+      self.token = options.token;
+      self.doc = options.document || document;
+
+      self.redirectTimeout = options.redirectTimeout;
+      if (typeof self.redirectTimeout === "undefined") {
+        self.redirectTimeout = REDIRECT_SECONDS * 1000;
+      }
+      self.secondsRemaining = self.redirectTimeout / 1000;
+
+
+      startVerification.call(self, options.ready);
+
+      sc.start.call(self, options);
+    },
+
+    submit: submit
+  });
+
+  sc = Module.sc;
+
+  return Module;
+}());

--- a/resources/static/pages/js/start.js
+++ b/resources/static/pages/js/start.js
@@ -166,7 +166,10 @@ $(function() {
         verifySecondaryAddress("verifyUser");
       }
       else if (path === "/reset_password") {
-        verifySecondaryAddress("completePasswordReset");
+        module = bid.resetPassword.create();
+        module.start({
+          token: token
+        });
       }
       else if (path === "/about") {
         module = bid.about.create();

--- a/resources/static/pages/js/start.js
+++ b/resources/static/pages/js/start.js
@@ -162,6 +162,9 @@ $(function() {
       else if (path === "/confirm") {
         verifySecondaryAddress("verifyEmail");
       }
+      else if (path === "/complete_transition") {
+        verifySecondaryAddress("completeTransitionToSecondary");
+      }
       else if (path === "/verify_email_address") {
         verifySecondaryAddress("verifyUser");
       }

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -119,6 +119,10 @@
     verificationSuccess: function(verificationMethod) {
       asyncTest(verificationMethod + " with valid token, no password required", function() {
         network[verificationMethod]("token", null, function(registered) {
+          var req = transport.getLastRequest();
+          var data = JSON.parse(req.data);
+          equal("pass" in data, false, "password not sent in request if not needed");
+
           ok(registered);
           start();
         }, testHelpers.unexpectedFailure);

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -33,8 +33,7 @@
   var stagingMethods = {
     createUser: true,
     addSecondaryEmail: true,
-    // XXX - This is going to have to change to not take a password.
-    requestPasswordReset: true,
+    requestPasswordReset: false,
     requestEmailReverify: false,
     requestTransitionToSecondary: true,
   };

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -79,9 +79,9 @@
   // the staging function name should be passed in as stageFuncName.
   // config can take two parameters:
   //   password - if the staging function requires a password, enter it.
-  //   invalid_reason - if a staging method requires that the email address
-  //      already exist, an attempt will be made to stage an address that
-  //      does not exist. This is the expected reason that the backend returns.
+  //   require_valid_email - if true, indicates that a staging method
+  //      requires that the email address already exist. An attempt will
+  //      be made to stage an address that does not exist.
   function testStageAddress(stageFuncName, config) {
     function getStagingMethodArgs(email, onComplete, password) {
         var args = [email, onComplete, testHelpers.unexpectedXHRFailure];
@@ -129,13 +129,13 @@
           config.password));
     });
 
-    if (config.invalid_reason) {
+    if (config.require_valid_email) {
       asyncTest(stageFuncName + " with unknown email - false status",
           function() {
 
         var onComplete = function(status) {
           equal(status.success, false, "failure for unknown user");
-          equal(status.reason, config.invalid_reason, "correct reason");
+          equal(status.reason, "invalid_email", "correct reason");
           start();
         };
 
@@ -329,7 +329,7 @@
     testResetPassword: {
       stageAddress: {
         stageFunction: "requestPasswordReset",
-        config: { invalid_reason: "invalid_user" }
+        config: { require_valid_email: true }
       },
       pollingFunction: "waitForPasswordResetComplete",
       cancelPollingFunction: "cancelWaitForPasswordResetComplete",
@@ -339,7 +339,7 @@
     testReverifyEmail: {
       stageAddress: {
         stageFunction: "requestEmailReverify",
-        config: { invalid_reason: "invalid_email" }
+        config: { require_valid_email: true }
       },
       pollingFunction: "waitForEmailReverifyComplete",
       cancelPollingFunction: "cancelWaitForEmailReverifyComplete"
@@ -350,7 +350,7 @@
         stageFunction: "requestTransitionToSecondary",
         config: {
           password: "password",
-          invalid_reason: "invalid_user"
+          require_valid_email: true
         }
       },
       pollingFunction: "waitForTransitionToSecondaryComplete",

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -487,7 +487,7 @@
     var returnTo = "http://samplerp.org";
     lib.setReturnTo(returnTo);
 
-    lib.requestPasswordReset("registered@testuser.com", "password", function(status) {
+    lib.requestPasswordReset("registered@testuser.com", function(status) {
       equal(status.success, true, "password reset for known user");
       equal(storage.getReturnTo(), returnTo, "RP URL is stored for verification");
 
@@ -496,7 +496,7 @@
   });
 
   asyncTest("requestPasswordReset with unknown email - false status, invalid_user", function() {
-    lib.requestPasswordReset("unregistered@testuser.com", "password", function(status) {
+    lib.requestPasswordReset("unregistered@testuser.com", function(status) {
       equal(status.success, false, "password not reset for unknown user");
       equal(status.reason, "invalid_user", "invalid_user is the reason");
       start();
@@ -505,7 +505,7 @@
 
   asyncTest("requestPasswordReset with throttle - false status, throttle", function() {
     xhr.useResult("throttle");
-    lib.requestPasswordReset("registered@testuser.com", "password", function(status) {
+    lib.requestPasswordReset("registered@testuser.com", function(status) {
       equal(status.success, false, "password not reset for throttle");
       equal(status.reason, "throttle", "password reset was throttled");
       start();
@@ -513,7 +513,7 @@
   });
 
   asyncTest("requestPasswordReset with XHR failure", function() {
-    failureCheck(lib.requestPasswordReset, "registered@testuser.com", "password");
+    failureCheck(lib.requestPasswordReset, "registered@testuser.com");
   });
 
   asyncTest("completePasswordReset with a good token", function() {

--- a/resources/static/test/cases/common/js/validation.js
+++ b/resources/static/test/cases/common/js/validation.js
@@ -207,7 +207,7 @@
     equal(tooltipShown, true, "empty password shows tooltip");
   });
 
-  testHelpers.testInvalidPasswordAndValidationPassword("validate" testInvalidPasswordAndValidationPassword);
+  testHelpers.testInvalidPasswordAndValidationPassword("passwordAndValidationPassword", testInvalidPasswordAndValidationPassword);
 
   test("passwordAndValidationPassword all valid", function() {
     var valid = validation.passwordAndValidationPassword("password", "password");

--- a/resources/static/test/cases/dialog/js/misc/helpers.js
+++ b/resources/static/test/cases/dialog/js/misc/helpers.js
@@ -204,7 +204,7 @@
       email: "registered@testuser.com"
     });
 
-    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", "password", function(reset) {
+    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", function(reset) {
       ok(reset, "password reset");
       start();
     });
@@ -213,7 +213,7 @@
 
   asyncTest("resetPassword throttled", function() {
     xhr.useResult("throttle");
-    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", "password", function(reset) {
+    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", function(reset) {
       equal(reset, false, "password not reset");
       start();
     });
@@ -223,7 +223,7 @@
     errorCB = expectedError;
 
     xhr.useResult("ajaxError");
-    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", "password", testHelpers.unexpectedSuccess);
+    dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", testHelpers.unexpectedSuccess);
   });
 
 

--- a/resources/static/test/cases/dialog/js/misc/helpers.js
+++ b/resources/static/test/cases/dialog/js/misc/helpers.js
@@ -26,7 +26,7 @@
     getErrorDialog: function(info) {
       return function() {
         errorCB && errorCB(info);
-      }
+      };
     }
   };
 
@@ -225,6 +225,36 @@
     xhr.useResult("ajaxError");
     dialogHelpers.resetPassword.call(controllerMock, "registered@testuser.com", "password", testHelpers.unexpectedSuccess);
   });
+
+
+  asyncTest("transitionToSecondary happy case", function() {
+    expectedMessage("transition_to_secondary_staged", {
+      email: "registered@testuser.com"
+    });
+
+    dialogHelpers.transitionToSecondary.call(controllerMock, "registered@testuser.com", "password", function(reset) {
+      ok(reset, "password reset");
+      start();
+    });
+  });
+
+
+  asyncTest("transitionToSecondary throttled", function() {
+    xhr.useResult("throttle");
+    dialogHelpers.transitionToSecondary.call(controllerMock, "registered@testuser.com", "password", function(reset) {
+      equal(reset, false, "password not reset");
+      start();
+    });
+  });
+
+  asyncTest("transitionToSecondary with XHR error", function() {
+    errorCB = expectedError;
+
+    xhr.useResult("ajaxError");
+    dialogHelpers.transitionToSecondary.call(controllerMock, "registered@testuser.com", "password", testHelpers.unexpectedSuccess);
+  });
+
+
 }());
 
 

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -492,7 +492,7 @@
     });
     equal(actions.called.doSetPassword, true, "doSetPassword called");
     mediator.publish("password_set");
-    equal(actions.called.doStageResetPassword, true, "doSetPassword called");
+    equal(actions.called.doStageTransitionToSecondary, true, "doStageTransitionToSecondary called");
   });
 
   function testReverifyEmailChosen(auth_level, info) {

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -144,32 +144,6 @@
     equal(actions.info.doAuthenticate.email, TEST_EMAIL, "authenticate called with the correct email");
   });
 
-  test("cancel new_user password_set flow, then forgot_password, password_set - email sent to forgot password email address", function() {
-    // This comes from issue #2231
-    // * Sign in (e.g. at http://translate.123done.org) with a wrong email adress (for example mistyped).
-    // * Click cancel
-    // * Enter your correct email (from an existing account)
-    // * Click 'Forgot your password?'
-    // * Enter a new password and send the form
-    //
-    //
-    //
-    // User types in an incorrect email address, the address is unknown to
-    // Persona who treats it as a new user.
-    mediator.publish("authenticate");
-    mediator.publish("new_user", { email: "incorrect@testuser.com" });
-    // The user is now looking at the set_password screen, they cancel out.
-    mediator.publish("cancel_state");
-    // The user has entered the correct email address but has forgot their
-    // password.
-    mediator.publish("forgot_password", { email: TEST_EMAIL });
-    // The user sets the password for the correct account.
-    mediator.publish("password_set");
-    // The email should be sent to the email specified in forgot_password
-    testActionStarted("doStageResetPassword", { email: TEST_EMAIL });
-  });
-
-
   test("password_set for new user - call doStageUser with correct email", function() {
     mediator.publish("new_user", { email: TEST_EMAIL });
     mediator.publish("password_set");
@@ -186,13 +160,6 @@
     mediator.publish("password_set");
 
     equal(actions.info.doStageEmail.email, TEST_EMAIL, "correct email sent to doStageEmail");
-  });
-
-  test("password_set for reset password - call doStageResetPassword with correct email", function() {
-    mediator.publish("forgot_password", { email: TEST_EMAIL });
-    mediator.publish("password_set");
-
-    equal(actions.info.doStageResetPassword.email, TEST_EMAIL, "correct email sent to doStageResetPassword");
   });
 
   test("start - RPInfo always started", function() {
@@ -309,18 +276,13 @@
     mediator.publish("authenticated", { email: TEST_EMAIL });
   });
 
-  test("forgot_password - call doResetPassword with correct options", function() {
+  test("forgot_password - call doStageResetPassword with correct options", function() {
     mediator.publish("start", { privacyPolicy: "priv.html", termsOfService: "tos.html" });
     mediator.publish("forgot_password", {
       email: TEST_EMAIL
     });
-    testActionStarted("doResetPassword", { email: TEST_EMAIL });
+    testActionStarted("doStageResetPassword", { email: TEST_EMAIL });
   });
-
-  asyncTest("multiple calls to password_set for forgot_password, simulate throttling - call doStageResetPassword with correct email for each", function() {
-    testStagingThrottledRetry("forgot_password", "doStageResetPassword");
-  });
-
 
   asyncTest("reset_password_staged to reset_password_confirmed - call doConfirmResetPassword then doEmailConfirmed", function() {
     testVerifyStagedAddress("reset_password_staged", "reset_password_confirmed", "doConfirmResetPassword");

--- a/resources/static/test/cases/dialog/js/modules/actions.js
+++ b/resources/static/test/cases/dialog/js/modules/actions.js
@@ -122,10 +122,6 @@
       "check_registration");
   });
 
-  asyncTest("doResetPassword - call the set_password controller with reset_password true", function() {
-    testActionStartsModule('doResetPassword', { email: TEST_EMAIL }, "set_password", "reset_password");
-  });
-
   asyncTest("doStageResetPassword - trigger reset_password_staged", function() {
     testStageAddress("doStageResetPassword", "reset_password_staged");
   });

--- a/resources/static/test/cases/dialog/js/modules/actions.js
+++ b/resources/static/test/cases/dialog/js/modules/actions.js
@@ -141,8 +141,16 @@
       "check_registration");
   });
 
-  asyncTest("doStageTransitionToSecondary - trigger transition_to_secondary_staged", function() {
-    testStageAddress("doStageTransitionToSecondary", "transition_to_secondary_staged");
+  asyncTest("doStageTransitionToSecondary - "
+                + "trigger transition_to_secondary_staged", function() {
+    testStageAddress("doStageTransitionToSecondary",
+        "transition_to_secondary_staged");
+  });
+
+  asyncTest("doConfirmTransitionToSecondary - "
+                + "start the check_registration service", function() {
+    testActionStartsModule("doConfirmTransitionToSecondary",
+        { email: TEST_EMAIL }, "check_registration");
   });
 
   asyncTest("doGenerateAssertion - start the generate_assertion service", function() {

--- a/resources/static/test/cases/dialog/js/modules/actions.js
+++ b/resources/static/test/cases/dialog/js/modules/actions.js
@@ -145,6 +145,10 @@
       "check_registration");
   });
 
+  asyncTest("doStageTransitionToSecondary - trigger transition_to_secondary_staged", function() {
+    testStageAddress("doStageTransitionToSecondary", "transition_to_secondary_staged");
+  });
+
   asyncTest("doGenerateAssertion - start the generate_assertion service", function() {
     testActionStartsModule('doGenerateAssertion', { email: TEST_EMAIL }, "generate_assertion");
   });
@@ -164,5 +168,6 @@
       }
     });
   });
+
 }());
 

--- a/resources/static/test/cases/pages/js/forgot.js
+++ b/resources/static/test/cases/pages/js/forgot.js
@@ -85,7 +85,6 @@
 
   asyncTest("submit with invalid email", function() {
     $("#email").val("invalid");
-    $("#password,#vpassword").val("password");
 
     xhr.useResult("invalid");
 
@@ -94,7 +93,6 @@
 
   asyncTest("submit with known secondary email, happy case - show email sent notice", function() {
     $("#email").val("registered@testuser.com");
-    $("#password,#vpassword").val("password");
 
     controller.submit(function() {
       ok($(".emailsent").is(":visible"), "email sent successfully");
@@ -104,7 +102,6 @@
 
   asyncTest("submit with known secondary email with leading/trailing whitespace - show email sent notice", function() {
     $("#email").val("   registered@testuser.com  ");
-    $("#password,#vpassword").val("password");
 
     controller.submit(function() {
       ok($(".emailsent").is(":visible"), "email sent successfully");
@@ -112,24 +109,14 @@
     });
   });
 
-  testHelpers.testInvalidPasswordAndValidationPassword("submit with", function(password, vpassword) {
-    $("#email").val("unregistered@testuser.com");
-    $("#password").val(password);
-    $("#vpassword").val(vpassword);
-
-    testEmailNotSent();
-  });
-
   asyncTest("submit with unknown secondary email", function() {
     $("#email").val("unregistered@testuser.com");
-    $("#password,#vpassword").val("password");
 
     testEmailNotSent();
   });
 
   asyncTest("submit with throttling", function() {
     $("#email").val("registered@testuser.com");
-    $("#password,#vpassword").val("password");
 
     xhr.useResult("throttle");
     testEmailNotSent();
@@ -137,7 +124,6 @@
 
   asyncTest("submit with XHR Error", function() {
     $("#email").val("testuser@testuser.com");
-    $("#password,#vpassword").val("password");
 
     xhr.useResult("ajaxError");
     testEmailNotSent({

--- a/resources/static/test/cases/pages/js/reset_password.js
+++ b/resources/static/test/cases/pages/js/reset_password.js
@@ -26,7 +26,7 @@
   module("pages/js/reset_password", {
     setup: function() {
       testHelpers.setup();
-      bid.Renderer.render("#page_head", "site/verify_reset_password", {});
+      bid.Renderer.render("#page_head", "site/reset_password", {});
       $(document.body).append($('<div id=redirectTimeout>'));
       $(".siteinfo,.password_entry").hide();
     },

--- a/resources/static/test/cases/pages/js/reset_password.js
+++ b/resources/static/test/cases/pages/js/reset_password.js
@@ -66,7 +66,7 @@
     testHelpers.testErrorVisible();
   }
 
-  function testInvalidPasswordAndAuthenticationPassword(password, vpassword) {
+  function testInvalidPasswordAndValidationPassword(password, vpassword) {
     $("#password").val(password);
     $("#vpassword").val(vpassword);
 
@@ -189,8 +189,8 @@
     });
   });
 
-  testHelpers.testInvalidPasswordAndAuthenticationPassword(
-      testInvalidPasswordAndAuthenticationPassword);
+  testHelpers.testInvalidPasswordAndValidationPassword(
+      testInvalidPasswordAndValidationPassword);
 
   asyncTest("needsPassword: bad password", function() {
     $("#password,#vpassword").val("password");

--- a/resources/static/test/cases/pages/js/reset_password.js
+++ b/resources/static/test/cases/pages/js/reset_password.js
@@ -66,9 +66,11 @@
     testHelpers.testErrorVisible();
   }
 
-  function testNeedsPasswordCannotSubmit() {
-    xhr.useResult("needsPassword");
+  function testInvalidPasswordAndAuthenticationPassword(password, vpassword) {
+    $("#password").val(password);
+    $("#vpassword").val(vpassword);
 
+    xhr.useResult("needsPassword");
     createController(config, function() {
       controller.submit(function(status) {
         equal(status, false, "correct status");
@@ -187,33 +189,8 @@
     });
   });
 
-  asyncTest("needsPassword - missing password", function() {
-    $("#password").val();
-    $("#vpassword").val("password");
-    testNeedsPasswordCannotSubmit();
-  });
-
-  asyncTest("needsPassword - too short of a password", function() {
-    $("#password,#vpassword").val(testHelpers.generateString(bid.PASSWORD_MIN_LENGTH - 1));
-    testNeedsPasswordCannotSubmit();
-  });
-
-  asyncTest("needsPassword - too long of a password", function() {
-    $("#password,#vpassword").val(testHelpers.generateString(bid.PASSWORD_MAX_LENGTH + 1));
-    testNeedsPasswordCannotSubmit();
-  });
-
-  asyncTest("needsPassword - missing vpassword", function() {
-    $("#password").val("password");
-    $("#vpassword").val();
-    testNeedsPasswordCannotSubmit();
-  });
-
-  asyncTest("needsPassword - password mismatch", function() {
-    $("#password").val("password");
-    $("#vpassword").val("password1");
-    testNeedsPasswordCannotSubmit();
-  });
+  testHelpers.testInvalidPasswordAndAuthenticationPassword(
+      testInvalidPasswordAndAuthenticationPassword);
 
   asyncTest("needsPassword: bad password", function() {
     $("#password,#vpassword").val("password");

--- a/resources/static/test/cases/pages/js/reset_password.js
+++ b/resources/static/test/cases/pages/js/reset_password.js
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  "use strict";
+
+  var bid = BrowserID,
+      storage = bid.Storage,
+      xhr = bid.Mocks.xhr,
+      WindowMock = bid.Mocks.WindowMock,
+      dom = bid.DOM,
+      pageHelpers = bid.PageHelpers,
+      testHelpers = bid.TestHelpers,
+      testHasClass = testHelpers.testHasClass,
+      testVisible = testHelpers.testVisible,
+      testNotVisible = testHelpers.testNotVisible,
+      testElementTextEquals = testHelpers.testElementTextEquals,
+      testDocumentRedirected = testHelpers.testDocumentRedirected,
+      validToken = true,
+      controller,
+      config = {
+        token: "token"
+      },
+      doc;
+
+  module("pages/js/reset_password", {
+    setup: function() {
+      testHelpers.setup();
+      bid.Renderer.render("#page_head", "site/verify_reset_password", {});
+      $(document.body).append($('<div id=redirectTimeout>'));
+      $(".siteinfo,.password_entry").hide();
+    },
+    teardown: function() {
+      $('#redirectTimeout').remove();
+      testHelpers.teardown();
+    }
+  });
+
+  function createController(options, callback) {
+    controller = BrowserID.resetPassword.create();
+    // defaults, but options can override
+    options = _.extend({
+      document: new WindowMock().document,
+      redirectTimeout: 0,
+      ready: callback
+    }, options || {});
+    doc = options.document;
+    controller.start(options);
+  }
+
+  function testMustAuthCannotSubmit() {
+    xhr.useResult("mustAuth");
+    createController(config, function() {
+      controller.submit(function() {
+        testHelpers.testTooltipVisible();
+        start();
+      });
+    });
+  }
+
+  function testEmail() {
+    equal(dom.getInner("#email"), "testuser@testuser.com", "correct email shown");
+  }
+
+  function testCannotConfirm() {
+    testHelpers.testErrorVisible();
+  }
+
+  function testNeedsPasswordCannotSubmit() {
+    xhr.useResult("needsPassword");
+
+    createController(config, function() {
+      controller.submit(function(status) {
+        equal(status, false, "correct status");
+        testHelpers.testTooltipVisible();
+        start();
+      });
+    });
+  }
+
+
+  test("start with missing token", function() {
+    var error;
+    try {
+      createController({});
+    } catch(e) {
+      error = e;
+    }
+
+    equal(error.message, "missing config option: token", "correct error thrown");
+  });
+
+  // START TRANSITION CODE
+  //
+  // The transition code is for users who have started the reset password flow
+  // under the old system where they set their password in the dialog. If this
+  // is the case, the user does not have to enter their password now unless the
+  // user started the transaction in a different browser.
+  asyncTest("valid token, no password necessary - verify user and show site info, user is redirected to saved URL", function() {
+    var returnTo = "https://test.domain/path";
+    storage.setReturnTo(returnTo);
+
+    createController(config, function() {
+      testVisible("#congrats");
+      testHasClass("body", "complete");
+      testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
+      testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
+      equal(storage.getLoggedIn("https://test.domain"), "testuser@testuser.com", "logged in status set");
+      start();
+    });
+  });
+
+  asyncTest("valid token, no password necessary, no saved site info - verify user, user is redirected to login.persona.org", function() {
+    var returnTo = "https://login.persona.org/";
+
+    createController(config, function() {
+      testEmail();
+      testNotVisible(".siteinfo", "siteinfo is not visible without having it");
+      testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
+      testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
+      start();
+    });
+  });
+
+  asyncTest("mustAuth: missing password", function() {
+    $("#password").val();
+
+    testMustAuthCannotSubmit();
+  });
+
+  asyncTest("mustAuth: good password", function() {
+    $("#password").val("password");
+
+    xhr.useResult("mustAuth");
+    createController(config, function() {
+      xhr.useResult("valid");
+      testHasClass("body", "enter_password");
+      controller.submit(function(status) {
+        equal(status, true, "correct status");
+        testHasClass("body", "complete");
+        start();
+      });
+    });
+  });
+
+  asyncTest("mustAuth: bad password", function() {
+    $("#password").val("password");
+
+    xhr.useResult("mustAuth");
+    createController(config, function() {
+      xhr.useResult("badPassword");
+      controller.submit(function(status) {
+        equal(status, false, "correct status");
+        testHelpers.testTooltipVisible();
+        start();
+      });
+    });
+  });
+
+  asyncTest("mustAuth: good password bad token", function() {
+    $("#password").val("password");
+
+    xhr.useResult("invalid");
+    createController(config, function() {
+      testCannotConfirm();
+      start();
+    });
+  });
+
+
+  // END TRANSITION CODE
+
+  asyncTest("invalid token - show cannot confirm error", function() {
+    xhr.useResult("invalid");
+
+    createController(config, function() {
+      testCannotConfirm();
+      start();
+    });
+  });
+
+  asyncTest("valid token with xhr error - show error screen", function() {
+    xhr.useResult("ajaxError");
+    createController(config, function() {
+      testHelpers.testErrorVisible();
+      start();
+    });
+  });
+
+  asyncTest("needsPassword - missing password", function() {
+    $("#password").val();
+    $("#vpassword").val("password");
+    testNeedsPasswordCannotSubmit();
+  });
+
+  asyncTest("needsPassword - too short of a password", function() {
+    $("#password,#vpassword").val(testHelpers.generateString(bid.PASSWORD_MIN_LENGTH - 1));
+    testNeedsPasswordCannotSubmit();
+  });
+
+  asyncTest("needsPassword - too long of a password", function() {
+    $("#password,#vpassword").val(testHelpers.generateString(bid.PASSWORD_MAX_LENGTH + 1));
+    testNeedsPasswordCannotSubmit();
+  });
+
+  asyncTest("needsPassword - missing vpassword", function() {
+    $("#password").val("password");
+    $("#vpassword").val();
+    testNeedsPasswordCannotSubmit();
+  });
+
+  asyncTest("needsPassword - password mismatch", function() {
+    $("#password").val("password");
+    $("#vpassword").val("password1");
+    testNeedsPasswordCannotSubmit();
+  });
+
+  asyncTest("needsPassword: bad password", function() {
+    $("#password,#vpassword").val("password");
+
+    xhr.useResult("mustAuth");
+    createController(config, function() {
+      xhr.useResult("badPassword");
+      controller.submit(function(status) {
+        equal(status, false, "correct status");
+        testHelpers.testTooltipVisible();
+        start();
+      });
+    });
+  });
+
+  asyncTest("needsPassword - XHR error", function() {
+    $("#password,#vpassword").val("password");
+    xhr.useResult("needsPassword");
+
+    createController(config, function() {
+      xhr.useResult("ajaxError");
+      controller.submit(function() {
+        testHelpers.testErrorVisible();
+        start();
+      });
+    });
+  });
+
+
+  asyncTest("needsPassword - happy case", function() {
+    $("#password,#vpassword").val("password");
+    xhr.useResult("needsPassword");
+
+    createController(config, function() {
+      xhr.useResult("valid");
+      controller.submit(function(status) {
+        equal(status, true, "correct status");
+        testHasClass("body", "complete");
+        start();
+      });
+    });
+  });
+}());

--- a/resources/static/test/mocks/xhr.js
+++ b/resources/static/test/mocks/xhr.js
@@ -105,6 +105,26 @@ BrowserID.Mocks.xhr = (function() {
       "post /wsapi/complete_user_creation badPassword": 401,
       "post /wsapi/complete_user_creation invalid": { success: false },
       "post /wsapi/complete_user_creation ajaxError": undefined,
+
+      "post /wsapi/stage_transition unknown_secondary": { success: true },
+      "post /wsapi/stage_transition valid": { success: true },
+      "post /wsapi/stage_transition invalid": { success: false },
+      "post /wsapi/stage_transition throttle": 429,
+      "post /wsapi/stage_transition ajaxError": undefined,
+
+      "post /wsapi/complete_transition valid": { success: true },
+      "post /wsapi/complete_transition badPassword": 401,
+      "post /wsapi/complete_transition invalid": { success: false },
+      "post /wsapi/complete_transition ajaxError": undefined,
+
+      "get /wsapi/transition_status?email=registered%40testuser.com pending": { status: "pending" },
+      "get /wsapi/transition_status?email=registered%40testuser.com complete": { status: "complete", userid: 4 },
+      "get /wsapi/transition_status?email=registered%40testuser.com valid": { status: "complete", userid: 4 },
+      "get /wsapi/transition_status?email=registered%40testuser.com mustAuth": { status: "mustAuth" },
+      "get /wsapi/transition_status?email=registered%40testuser.com noRegistration": { status: "noRegistration" },
+      "get /wsapi/transition_status?email=registered%40testuser.com ajaxError": undefined,
+
+
       "post /wsapi/logout valid": { success: true },
       "post /wsapi/logout not_authenticated": 400,
       "post /wsapi/logout ajaxError": 401,

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -63,6 +63,7 @@ BrowserID.TestHelpers = (function() {
 
       transport.setDelay(0);
       transport.setContextInfo("auth_level", undefined);
+      transport.setContextInfo("has_password", false);
       transport.useResult("valid");
 
       network.init({ cookiesEnabledOverride: true });

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -389,7 +389,7 @@ BrowserID.TestHelpers = (function() {
       });
     },
 
-    testInvalidPasswordAndAuthenticationPassword: function(msg, testInvalidPassword) {
+    testInvalidPasswordAndValidationPassword: function(msg, testInvalidPassword) {
       if (!testInvalidPassword) {
         testInvalidPassword = msg;
         msg = "";

--- a/resources/views/forgot.ejs
+++ b/resources/views/forgot.ejs
@@ -46,38 +46,6 @@
                       <%- gettext('Cannot reset the password of that address.') %>
                     </div>
                 </li>
-
-                <li>
-                    <label for="password"><%= format(gettext("Create a new password to use with %s."), ["Persona"]) %></label>
-                    <input id="password" placeholder="<%- gettext('Password') %>" type="password" maxlength="80" autofocus />
-
-                    <div id="password_required" class="tooltip" for="password">
-                        <%- gettext('Password is required.') %>
-                    </div>
-
-                    <div class="tooltip" id="password_length" for="password">
-                        <%- gettext('Password must be between 8 and 80 characters long.') %>
-                    </div>
-
-                    <div id="could_not_add" class="tooltip" for="password">
-                        <%- gettext('We just sent an email to that address! If you really want to send another, wait a minute or two and try again.') %>
-                    </div>
-                </li>
-
-                <li>
-                    <label for="vpassword"><%- gettext('Verify Password') %></label>
-                    <input id="vpassword" placeholder="<%- gettext('Verify Password') %>" type="password" maxlength="80">
-
-                    <div id="password_required" class="tooltip" for="vpassword">
-                      <%- gettext('Verification password is required.') %>
-                    </div>
-
-                    <div class="tooltip" id="passwords_no_match" for="vpassword">
-                      <%- gettext('These passwords don\'t match!') %>
-                    </div>
-
-                </li>
-
             </ul>
 
             <div class="submit cf forminputs">

--- a/resources/views/reset_password.ejs
+++ b/resources/views/reset_password.ejs
@@ -14,7 +14,7 @@
             <ul class="inputs">
                 <li>
                     <label for="email"><%= gettext('Email Address') %></label>
-                    <input class="youraddress" id="email" placeholder="<%= gettext('Your Email') %>" type="email" value="" disabled="disabled" maxlength="254" />
+                    <input class="email" id="email" placeholder="<%= gettext('Your Email') %>" type="email" value="" disabled="disabled" maxlength="254" />
                 </li>
 
                 <li class="password_entry vpassword_entry">
@@ -37,7 +37,7 @@
                     <label for="vpassword"><%= gettext('Verify Password') %></label>
                     <input id="vpassword" placeholder="<%= gettext('Verify Password') %>" type="password" maxlength="80" />
 
-                    <div id="password_required" class="tooltip" for="vpassword">
+                    <div id="vpassword_required" class="tooltip" for="vpassword">
                       <%= gettext('Verification password is required.') %>
                     </div>
 
@@ -57,15 +57,15 @@
 
         <div id="congrats">
             <p>
-              <%= gettext('<strong class="email">Your address</strong> has been verified!') %>
+              <%- gettext('<strong class="email">Your address</strong> has been verified!') %>
             </p>
 
             <p>
-              <%= format(gettext('Your new address is set up and ready to go. You will be redirected to %s'), ["<strong class='website'></strong>"]) %>
+              <%- format(gettext('Your new address is set up and ready to go. You will be redirected to %s'), ["<strong class='website'></strong>"]) %>
             </p>
 
             <p id="redirection">
-              <%= format(gettext("Redirecting in %s seconds"), ["<span id='redirectTimeout'></span>" ]) %>
+              <%- format(gettext("Redirecting in %s seconds"), ["<span id='redirectTimeout'></span>" ]) %>
             </p>
         </div>
     </div>

--- a/resources/views/reset_password.ejs
+++ b/resources/views/reset_password.ejs
@@ -1,0 +1,75 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<div id="hAlign">
+    <div id="vAlign">
+        <form id="signUpForm" class="cf password_entry vpassword_entry">
+            <p class="hint siteinfo">
+              <%= gettext('Finish signing into:') %> <strong class="website"></strong>
+            </p>
+
+            <h1><%= gettext('Reset Password') %></h1>
+
+            <ul class="inputs">
+                <li>
+                    <label for="email"><%= gettext('Email Address') %></label>
+                    <input class="youraddress" id="email" placeholder="<%= gettext('Your Email') %>" type="email" value="" disabled="disabled" maxlength="254" />
+                </li>
+
+                <li class="password_entry vpassword_entry">
+                    <!-- BEGIN TRANSITION CODE -->
+                    <label for="password" class="password_entry"><%= gettext('Password') %></label>
+                    <!-- END TRANSITION CODE -->
+                    <label for="password" class="vpassword_entry"><%= format(gettext('Create a new password to use with %s'), ["Persona"]) %></label>
+                    <input id="password" placeholder="<%= gettext('Your Password') %>" type="password" autofocus maxlength=80 />
+
+                    <div class="tooltip" id="password_required" for="password">
+                      <%= gettext('Password is required.') %>
+                    </div>
+
+                    <div class="tooltip" id="password_length" for="password">
+                      <%= gettext('Password must be between 8 and 80 characters long.') %>
+                    </div>
+                </li>
+
+                <li class="vpassword_entry">
+                    <label for="vpassword"><%= gettext('Verify Password') %></label>
+                    <input id="vpassword" placeholder="<%= gettext('Verify Password') %>" type="password" maxlength="80" />
+
+                    <div id="password_required" class="tooltip" for="vpassword">
+                      <%= gettext('Verification password is required.') %>
+                    </div>
+
+                    <div class="tooltip" id="passwords_no_match" for="vpassword">
+                      <%= gettext('These passwords don\'t match!') %>
+                    </div>
+
+                </li>
+
+          </ul>
+
+            <div class="submit cf password_entry vpassword_entry">
+                <button><%= gettext('finish') %></button>
+            </div>
+
+        </form>
+
+        <div id="congrats">
+            <p>
+              <%= gettext('<strong class="email">Your address</strong> has been verified!') %>
+            </p>
+
+            <p>
+              <%= format(gettext('Your new address is set up and ready to go. You will be redirected to %s'), ["<strong class='website'></strong>"]) %>
+            </p>
+
+            <p id="redirection">
+              <%= format(gettext("Redirecting in %s seconds"), ["<span id='redirectTimeout'></span>" ]) %>
+            </p>
+        </div>
+    </div>
+</div>
+
+<%- partial('partial/noscript-warning') %>
+

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -168,6 +168,7 @@
 
     <script src="/pages/js/page_helpers.js"></script>
     <script src="/pages/js/verify_secondary_address.js"></script>
+    <script src="/pages/js/reset_password.js"></script>
     <script src="/pages/js/forgot.js"></script>
     <script src="/pages/js/manage_account.js"></script>
     <script src="/pages/js/signin.js"></script>
@@ -209,6 +210,7 @@
     <script src="cases/pages/js/browserid.js"></script>
     <script src="cases/pages/js/page_helpers.js"></script>
     <script src="cases/pages/js/verify_secondary_address.js"></script>
+    <script src="cases/pages/js/reset_password.js"></script>
     <script src="cases/pages/js/forgot.js"></script>
     <script src="cases/pages/js/signin.js"></script>
     <script src="cases/pages/js/manage_account.js"></script>

--- a/tests/forgotten-pass-test.js
+++ b/tests/forgotten-pass-test.js
@@ -179,7 +179,6 @@ suite.addBatch({
   "reset password on first account": {
     topic: wsapi.post('/wsapi/stage_reset', {
       email: 'first@fakeemail.com',
-      pass: 'secondfakepass',
       site:'https://otherfakesite.com'
     }),
     "works": function(err, r) {
@@ -211,7 +210,7 @@ suite.addBatch({
       assert.equal(r.code, 200);
       var body = JSON.parse(r.body);
       assert.strictEqual(body.success, true);
-      assert.strictEqual(body.must_auth, false);
+      assert.strictEqual(body.needs_password, true);
     }
   }
 });
@@ -252,7 +251,10 @@ suite.addBatch({
 suite.addBatch({
   "complete password reset": {
     topic: function() {
-      wsapi.post('/wsapi/complete_reset', { token: token }).call(this);
+      wsapi.post('/wsapi/complete_reset', {
+        pass: 'secondfakepass',
+        token: token
+      }).call(this);
     },
     "account created": function(err, r) {
       assert.equal(r.code, 200);
@@ -331,7 +333,6 @@ suite.addBatch({
   "reset password on first account": {
     topic: wsapi.post('/wsapi/stage_reset', {
       email: 'first@fakeemail.com',
-      pass: 'secondfakepass',
       site:'https://otherfakesite.com'
     }),
     "works": function(err, r) {
@@ -371,7 +372,7 @@ suite.addBatch({
       var body = JSON.parse(r.body);
       assert.strictEqual(body.success, true);
       assert.strictEqual(body.email, 'first@fakeemail.com');
-      assert.strictEqual(body.must_auth, true);
+      assert.strictEqual(body.needs_password, true);
     }
   }
 });
@@ -507,7 +508,6 @@ suite.addBatch({
       var body = JSON.parse(r.body);
       assert.strictEqual(body.success, true);
       assert.strictEqual(body.email, 'second@fakeemail.com');
-      assert.strictEqual(body.must_auth, false);
     }
   }
 });

--- a/tests/primary-secondary-transition-test.js
+++ b/tests/primary-secondary-transition-test.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* This tests excercises address_info and attempt to excercise all
+ * possible response values from it.  */
+
+require('./lib/test_env.js');
+
+const assert =
+require('assert'),
+vows = require('vows'),
+start_stop = require('./lib/start-stop.js'),
+wsapi = require('./lib/wsapi.js'),
+db = require('../lib/db.js'),
+primary = require('./lib/primary.js');
+config = require('../lib/configuration.js'),
+bcrypt = require('bcrypt'),
+primary = require('./lib/primary.js'),
+secondary = require('./lib/secondary.js'),
+util = require('util'),
+path = require('path');
+
+var suite = vows.describe('password-length');
+
+const TEST_DOMAIN = "example.domain",
+      TEST_EMAIL = "test@" + TEST_DOMAIN,
+      TEST_ORIGIN = 'http://127.0.0.1:10002';
+
+const SECONDARY_TEST_EMAIL = "test@example.com";
+
+// an explicitly disabled domain
+process.env['SHIMMED_PRIMARIES'] =
+  util.format("disabled.domain|http://127.0.0.1:10005|%s", path.join(__dirname, 'data',
+    'disabled.domain', '.well-known', 'browserid'));
+
+var primaryUser = new primary({
+  email: TEST_EMAIL,
+  domain: TEST_DOMAIN
+});
+
+var token;
+
+// disable vows (often flakey?) async error behavior
+suite.options.error = false;
+
+start_stop.addStartupBatches(suite);
+
+// set up address for transition
+suite.addBatch({
+  "creating a secondary user": {
+     topic: function() {
+       secondary.create({ email: "foo@example.com" }, this.callback);
+     },
+    "works": function(e, r) {
+      assert.isNull(e);
+    },
+    "setting type to primary": {
+      topic: function() {
+        db.updateEmailLastUsedAs("foo@example.com", 'primary', this.callback);
+      },
+      "succeeds": function(e) {
+        assert.isNull(e);
+      },
+      "removing the user's password": {
+        topic: function() {
+          var self = this;
+          db.emailToUID('foo@example.com', function(err, uid) {
+            if (err) return self.callback(err);
+            db.updatePassword(uid, null, false, self.callback);
+          });
+        },
+        "works": function(err) {
+          assert(!err);
+        },
+        "and calling address info": {
+          topic: wsapi.get('/wsapi/address_info', {
+            email: "foo@example.com"
+          }),
+          "shows 'transition_no_password'": function(err, r) {
+            assert.isNull(err);
+            var r = JSON.parse(r.body);
+            assert.equal(r.type, "secondary");
+            assert.equal(r.state, "transition_no_password");
+          }
+        }
+      }
+    }
+  }
+});
+
+suite.addBatch({
+  "transition status": {
+    topic: wsapi.get('/wsapi/transition_status', { email: 'foo@example.com' } ),
+    "returns 'complete' before transition": function(err, r) {
+      assert.strictEqual(r.code, 200);
+      assert.strictEqual(JSON.parse(r.body).status, "complete");
+    }
+  }
+});
+
+// Run the "forgot_email" flow with first address.
+suite.addBatch({
+  "stage transition": {
+    topic: wsapi.post('/wsapi/stage_transition', {
+      email: 'foo@example.com',
+      pass: 'testpass',
+      site:'https://otherfakesite.com'
+    }),
+    "works": function(err, r) {
+      assert.strictEqual(r.code, 200);
+    }
+  }
+});
+
+// wait for the token
+suite.addBatch({
+  "a token": {
+    topic: function() {
+      start_stop.waitForToken(this.callback);
+    },
+    "is obtained": function (err, t) {
+      assert.isNull(err);
+      assert.strictEqual(typeof t, 'string');
+      token = t;
+    }
+  }
+});
+
+suite.addBatch({
+  "given a token, getting an email": {
+    topic: function() {
+      wsapi.get('/wsapi/email_for_token', { token: token }).call(this);
+    },
+    "returns success": function(err, r) {
+      assert.equal(r.code, 200);
+      var body = JSON.parse(r.body);
+      assert.strictEqual(body.success, true);
+      assert.strictEqual(body.must_auth, false);
+    }
+  }
+});
+
+suite.addBatch({
+  "transition status": {
+    topic: wsapi.get('/wsapi/transition_status', { email: 'foo@example.com' } ),
+    "returns 'pending' before calling complete": function(err, r) {
+      assert.strictEqual(r.code, 200);
+      assert.strictEqual(JSON.parse(r.body).status, "pending");
+    }
+  }
+});
+
+// now let's complete the re-registration of first email address
+suite.addBatch({
+  "complete transition": {
+    topic: function() {
+      wsapi.post('/wsapi/complete_transition', {
+        token: token
+      }).call(this);
+    },
+    "password set": function(err, r) {
+      assert.equal(r.code, 200);
+      assert.strictEqual(JSON.parse(r.body).success, true);
+    },
+    "transition status": {
+      topic: wsapi.get('/wsapi/transition_status', { email: 'foo@example.com' } ),
+      "returns 'complete' before calling reset": function(err, r) {
+        assert.strictEqual(r.code, 200);
+        assert.strictEqual(JSON.parse(r.body).status, "complete");
+      }
+    }
+  }
+});
+
+// now we should be able to sign in with the password
+suite.addBatch({
+  "secondary account": {
+    topic: wsapi.post('/wsapi/authenticate_user', {
+      email: 'foo@example.com',
+      pass: 'testpass',
+      ephemeral: false
+    }),
+    "should work": function(err, r) {
+      assert.strictEqual(JSON.parse(r.body).success, true);
+    }
+  }
+});
+
+start_stop.addShutdownBatches(suite);
+
+// run or export the suite.
+if (process.argv[1] === __filename) suite.run();
+else suite.export(module);


### PR DESCRIPTION
I'm combining PR #2936 and PR #2961 

These address issue #1232 and issue #2937 

It sucks to conflate these two things, but because the first PR introduces a regression (makes it so that a user cannot use an email address if the provider disables), I don't think it can be merged independantly.
