### PR TITLE
fix frontend qunit selenium tests - they cannot run against stage or prod

### DIFF
--- a/automation-tests/config/tests-to-ignore.js
+++ b/automation-tests/config/tests-to-ignore.js
@@ -3,8 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // These are tests to ignore
+// XXX extract duplication if this file gets significantly longer
 
-exports.tests_to_ignore = [
+exports.dev = [
+  "public-terminals.js",
+  "remove-email.js"
+];
+exports.stage = [
+  "frontend-qunit-test.js",
+  "public-terminals.js",
+  "remove-email.js"
+];
+exports.prod = [
+  "frontend-qunit-test.js",
   "public-terminals.js",
   "remove-email.js"
 ];

--- a/automation-tests/lib/test-finder.js
+++ b/automation-tests/lib/test-finder.js
@@ -6,7 +6,8 @@
 const path              = require('path'),
       fs                = require('fs'),
       test_root_path    = path.join(__dirname, "..", "tests"),
-      tests_to_ignore   = require('../config/tests-to-ignore').tests_to_ignore,
+      env               = process.env['PERSONA_ENV'] || 'dev',
+      tests_to_ignore   = require('../config/tests-to-ignore').env,
       glob              = require('minimatch');
 
 exports.find = function(pattern, root, tests) {

--- a/automation-tests/lib/test-finder.js
+++ b/automation-tests/lib/test-finder.js
@@ -7,7 +7,7 @@ const path              = require('path'),
       fs                = require('fs'),
       test_root_path    = path.join(__dirname, "..", "tests"),
       env               = process.env['PERSONA_ENV'] || 'dev',
-      tests_to_ignore   = require('../config/tests-to-ignore').env,
+      tests_to_ignore   = require('../config/tests-to-ignore')[env],
       glob              = require('minimatch');
 
 exports.find = function(pattern, root, tests) {


### PR DESCRIPTION
Because frontend tests are disabled on prod and stage, we cannot actually run them in those environments.  It is, however, useful to run frontend tests via selenium in ephemeral and dev environments as it allows us to excercise the tests on all browsers.

Previously, @jrgm had it so that tests would be run against dev when targeting stage or prod.  I broke that, this fixes it by just disabling them when they cannot be run anyway.
