### PR TITLE
disable request throttling when running under travis, as travis boxes ARE toobusy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ notifications:
     - jrgm@mozilla.com
 
 env:
- - WHAT_TESTS=front MYSQL_USER=root
- - WHAT_TESTS=back_mysql MYSQL_USER=root
- - WHAT_TESTS=back
+ - WHAT_TESTS=front MYSQL_USER=root DISABLE_REQUEST_THROTTLING=true
+ - WHAT_TESTS=back_mysql MYSQL_USER=root DISABLE_REQUEST_THROTTLING=true
+ - WHAT_TESTS=back DISABLE_REQUEST_THROTTLING=true
 
 mysql:
   adapter: mysql2

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -187,7 +187,8 @@ var conf = module.exports = convict({
   },
   disable_request_throttling: {
     doc: "Disable 'server too busy' responses when servers are too busy.",
-    format: 'boolean = false'
+    format: 'boolean = false',
+    env: 'DISABLE_REQUEST_THROTTLING'
   },
   certificate_validity_ms: {
     doc: "For how long shall certificates issued by BrowserID be valid?",


### PR DESCRIPTION
An unexpected side affect of merging toobusy was that under travis our tests started occasionally failing.  I believe this is because travis boxes are running at high load.

Increasing the delta between test and prod environments is not great, but I don't see a better solution.  
