### PR TITLE
upgrade toobusy - we run on win32 again

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -299,7 +299,7 @@
     "0.0.1": "320b5a52d83abb5978d81a3e887d4aefb15a6164"
   },
   "toobusy": {
-    "0.1.1": "267a16542980be4bab0acfbae22f594a6b52d323"
+    "0.2.2": "80edb87f2af7aa4c62958292ba65e89c839cb6f1"
   },
   "traverse": {
     "0.6.3": "a053ffa1b6179b9240ea16d74bfd604bd6b6e41b"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "rimraf": "2.0.2",
         "semver": "1.0.12",
         "temp": "0.4.0",
-        "toobusy": "0.1.1",
+        "toobusy": "0.2.2",
         "uglify-js": "1.0.6",
         "uglifycss": "0.0.5",
         "underscore": "1.3.1",


### PR DESCRIPTION
the delta between toobusy is not high (only toobusy.cc is really relevant): https://github.com/lloyd/node-toobusy/compare/v0.1.1...v0.2.2?w=1

@seanmonstar - verify you can install with this?
