### PR TITLE
We should log expiration issues. A root cause of Issue #2985

### DIFF
--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -45,7 +45,13 @@ BrowserID.User = (function() {
 
           // or if it was issued before the last time the domain key
           // was updated, it's invalid
-          if (!cert.payload.iat || cert.payload.iat < creationTime) {
+          if (!cert.payload.iat) {
+            helpers.log('Data Format ERROR: expected cert to have iat ' +
+              'property, but found none, marking expired');
+            return true;
+          } else if (cert.payload.iat < creationTime) {
+            helpers.log('Certificate issued ' + cert.payload.iat +
+              ' is before creation time ' + creationTime + ', marking expired');
             return true;
           }
 


### PR DESCRIPTION
We don't give the IdP developer any feedback when we see expired or certs without an iat field.

See Issue #2985 for details.
