### PR TITLE
Allow Selenium tests to run on ephemeral instances.

### DIFF
--- a/automation-tests/config/tests-to-ignore.js
+++ b/automation-tests/config/tests-to-ignore.js
@@ -5,17 +5,26 @@
 // These are tests to ignore
 // XXX extract duplication if this file gets significantly longer
 
-exports.dev = [
-  "public-terminals.js",
-  "remove-email.js"
-];
-exports.stage = [
-  "frontend-qunit-test.js",
-  "public-terminals.js",
-  "remove-email.js"
-];
-exports.prod = [
-  "frontend-qunit-test.js",
-  "public-terminals.js",
-  "remove-email.js"
-];
+var testsToIgnore = {
+  dev: [
+    "public-terminals.js",
+    "remove-email.js"
+  ],
+
+
+  stage: [
+    "frontend-qunit-test.js",
+    "public-terminals.js",
+    "remove-email.js"
+  ],
+
+  prod: [
+    "frontend-qunit-test.js",
+    "public-terminals.js",
+    "remove-email.js"
+  ]
+};
+
+module.exports = function(env) {
+  return testsToIgnore[env] || testsToIgnore.dev;
+};

--- a/automation-tests/lib/test-finder.js
+++ b/automation-tests/lib/test-finder.js
@@ -7,7 +7,7 @@ const path              = require('path'),
       fs                = require('fs'),
       test_root_path    = path.join(__dirname, "..", "tests"),
       env               = process.env['PERSONA_ENV'] || 'dev',
-      tests_to_ignore   = require('../config/tests-to-ignore')[env],
+      tests_to_ignore   = require('../config/tests-to-ignore')(env),
       glob              = require('minimatch');
 
 exports.find = function(pattern, root, tests) {


### PR DESCRIPTION
@6a68 - Since you made the original per-environment ignore list, can you review this to see if I preserve the original intention?

In tests-to-ignore.js, return the ignored tests for the requested environment, use dev by default.

fixes #2993 
