### PR TITLE
Disable ejs escaping of already-escaped fields. Fixes #3007.

### DIFF
--- a/resources/static/dialog/views/rp_info.ejs
+++ b/resources/static/dialog/views/rp_info.ejs
@@ -8,7 +8,7 @@
 
 
 <% if(siteName) { %>
-  <h2 id="rp_name"><%= siteName %></h2>
+  <h2 id="rp_name"><%- siteName %></h2>
 <% } %>
 
 <% if(siteName) { %>


### PR DESCRIPTION
We already escape rp info [inside dialog.js](https://github.com/mozilla/browserid/blob/dev/resources/static/dialog/js/modules/dialog.js#L250), but our buddy [ejs](https://github.com/visionmedia/ejs#features) was double-escaping because we used `<%=`, not `<%-`, in our tags. Whoops!

TODO: is this potentially a problem elsewhere in the codebase? There's a funky asymmetry between relying on ejs to escape templated stuff, and relying on our js to escape stuff inserted by js. Should I look deeper before calling this double-escaping escapade donezo?
