### PR TITLE
Kpi live

### DIFF
--- a/bin/proxy
+++ b/bin/proxy
@@ -20,10 +20,11 @@ var addy = config.has('bind_to.host') ? config.get('bind_to.host') : "127.0.0.1"
 forward.setTimeout(config.get('declaration_of_support_timeout_ms'));
 
 const allowed = /^https:\/\/[a-zA-Z0-9\.\-_]+\/\.well-known\/browserid(\?.*)?$/;
+const allowed_kpi = /^https:\/\/[a-zA-Z0-9\.\-_]+\/wsapi\/interaction_data(\?.*)?$/;
 
 var server = http.createServer(function (req, res) {
   var url = req.url;
-  if (!allowed.test(url)) {
+  if (!allowed.test(url) && !allowed_kpi.test(url) ) {
     res.writeHead(400);
     res.end('You can\'t get there from here');
     return;

--- a/bin/proxy
+++ b/bin/proxy
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// I proxy requests.  That's what I do.
+// I proxy outgoing requests in dev/testing environments (not production).  That's what I do.
 
 require('../lib/baseExceptions').addExceptionHandler();
 

--- a/config/aws.json
+++ b/config/aws.json
@@ -21,7 +21,7 @@
   },
   "proxy": { "bind_to": { "port": 10006 } },
   "router": { "bind_to": { "port": 8080 } },
-  "kpi_backend_db_url" : "https://kpiggybank.hacksign.in/wsapi/interaction_data",
+  "kpi_backend_db_url" : "https://kpiggybank-stage.personatest.org/wsapi/interaction_data",
   // whether to show the development menu.
   "enable_development_menu": true,
   // explicitly undefine public_static_url, as the configuration will then fallback to

--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -5,6 +5,7 @@
 const coarse = require('../coarse_user_agent_parser'),
       config = require('../configuration.js'),
       http = require('http'),
+      https = require('https'),
       logger = require('../logging.js').logger,
       querystring = require('querystring'),
       und = require('underscore'),
@@ -57,7 +58,8 @@ var store = function (kpi_json, cb) {
       options.port = db_url.port;
     }
 
-    kpi_req = http.request(options);
+    protocol = (db_url.scheme == 'https') ? https : http;
+    kpi_req = protocol.request(options);
     kpi_req.on('error', function (e) {
       // TODO statsd counter
       logger.error('KPI Backend request error: ' + e.message);

--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -26,7 +26,8 @@ exports.i18n = false;
 var store = function (kpi_json, cb) {
   var options,
       db_url,
-      kpi_req;
+      kpi_req,
+      http_proxy;
 
   // Out of concern for the user's privacy, round the server timestamp
   // off to the nearest 10-minute mark.
@@ -44,22 +45,42 @@ var store = function (kpi_json, cb) {
     });
 
     db_url = urlparse(config.get('kpi_backend_db_url'));
-    options = {
-          hostname: db_url.host,
-          path: db_url.path,
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Content-Length': post_data.length
-          }
-    };
 
-    if (db_url.port) {
-      options.port = db_url.port;
+    http_proxy = config.has('http_proxy') ? config.get('http_proxy') : null;
+    
+    if (http_proxy && http_proxy.port && http_proxy.host) {
+      options = {
+        host: http_proxy.host,
+        port: http_proxy.port,
+        path: db_url,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': post_data.length
+        }
+      };
+      kpi_req = http.request(options);
+      logger.debug("Using proxy for KPI");
+    } else {
+      options = {
+            hostname: db_url.host,
+            path: db_url.path,
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              'Content-Length': post_data.length
+            }
+      };
+      
+      if (db_url.port) {
+        options.port = db_url.port;
+      }
+      
+      var protocol = (db_url.scheme === 'https') ? https : http;
+      kpi_req = protocol.request(options);
+      logger.debug("Not using proxy for KPI");
     }
-
-    protocol = (db_url.scheme == 'https') ? https : http;
-    kpi_req = protocol.request(options);
+    
     kpi_req.on('error', function (e) {
       // TODO statsd counter
       logger.error('KPI Backend request error: ' + e.message);
@@ -68,6 +89,7 @@ var store = function (kpi_json, cb) {
     logger.debug("sending request to KPI backend" + config.get('kpi_backend_db_url'));
     kpi_req.write(post_data);
     kpi_req.end();
+
   } else {
     cb(false);
   }


### PR DESCRIPTION
For sending kpi data to kpiggybank, use https, use the new staging url, and use the http_proxy for outbound requests.

We haven't load tested this yet, but shouldn't be harmful if not turned on.
