### PR TITLE
KPI testing: added interaction_data activity to load_gen

### DIFF
--- a/bin/load_gen
+++ b/bin/load_gen
@@ -102,8 +102,10 @@ var activity = {
     probability: (1.0 / (40 * 56))
   },
   "interaction_data" : {
-    // post interaction data to KPI server, use the proposed sample rate
-    probability: .01
+    // post interaction data to KPI server
+    // All non-include_only activities have the potential
+    // to send interaction_data, multiply by sample rate
+    probability: (9 / 40.0) * .1
   }
 };
 

--- a/bin/load_gen
+++ b/bin/load_gen
@@ -100,6 +100,10 @@ var activity = {
   "change_pass": {
     // users change their passwords once every two months
     probability: (1.0 / (40 * 56))
+  },
+  "interaction_data" : {
+    // post interaction data to KPI server, use the proposed sample rate
+    probability: .01
   }
 };
 

--- a/lib/load_gen/activities/interaction_data.js
+++ b/lib/load_gen/activities/interaction_data.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * this file is the "interaction_data" activity, which simulates 
+ * the load of the client passing on interaction data for kpi metrics */
+
+var client = require('../../wsapi_client.js');
+
+var blob = { data:
+  {"event_stream":[["window.dom_loading",972],["window.channel_established",2720],["screen.rp_info",2721],["xhr_complete.GET/wsapi/session_context",2723,294],["screen.authenticate",3032],["user.can_interact",3053],["xhr_complete.POST/wsapi/interaction_data",3025,271],["xhr_complete.GET/wsapi/address_info",8656,603],["authenticate.enter_password",9548],["authenticate.enter_password",9554],["authenticate.enter_password",9560],["authenticate.password_submitted",15381],["xhr_complete.POST/wsapi/authenticate_user",15381,1545],["xhr_complete.GET/wsapi/list_emails",16930,255],["authenticate.password_success",17195],["screen.is_this_your_computer",17199],["xhr_complete.POST/wsapi/prolong_session",19812,245],["generate_assertion",20064],["screen.generate_assertion",20065],["xhr_complete.POST/wsapi/cert_key",20140,3580],["assertion_generated",23761],["window.unload",25564]],"sample_rate":1,"timestamp":1361407200000,"lang":"en","new_account":false,"screen_size":{"width":1680,"height":1050},"number_emails":1,"number_sites_signed_in":1,"number_sites_remembered":1,"orphaned":false,"user_agent":{"os":"Macintosh","browser":"Firefox","version":18}}
+};
+
+exports.startFunc = function(cfg, cb) {
+
+    client.post(cfg, '/wsapi/interaction_data', {}, blob, function(err, r) {
+        if (err) {
+            cb(err);
+        } else if (!r || r.code !== 200) {
+            cb("for interaction_data post response code is not 200: " + (r ? r.code : "no response"));
+        } else {
+            cb();
+        }
+    });
+};

--- a/lib/load_gen/activities/interaction_data.js
+++ b/lib/load_gen/activities/interaction_data.js
@@ -8,19 +8,52 @@
 
 var client = require('../../wsapi_client.js');
 
-var blob = { data:
-  {"event_stream":[["window.dom_loading",972],["window.channel_established",2720],["screen.rp_info",2721],["xhr_complete.GET/wsapi/session_context",2723,294],["screen.authenticate",3032],["user.can_interact",3053],["xhr_complete.POST/wsapi/interaction_data",3025,271],["xhr_complete.GET/wsapi/address_info",8656,603],["authenticate.enter_password",9548],["authenticate.enter_password",9554],["authenticate.enter_password",9560],["authenticate.password_submitted",15381],["xhr_complete.POST/wsapi/authenticate_user",15381,1545],["xhr_complete.GET/wsapi/list_emails",16930,255],["authenticate.password_success",17195],["screen.is_this_your_computer",17199],["xhr_complete.POST/wsapi/prolong_session",19812,245],["generate_assertion",20064],["screen.generate_assertion",20065],["xhr_complete.POST/wsapi/cert_key",20140,3580],["assertion_generated",23761],["window.unload",25564]],"sample_rate":1,"timestamp":1361407200000,"lang":"en","new_account":false,"screen_size":{"width":1680,"height":1050},"number_emails":1,"number_sites_signed_in":1,"number_sites_remembered":1,"orphaned":false,"user_agent":{"os":"Macintosh","browser":"Firefox","version":18}}
+var blob = { data: 
+  { "event_stream":[["window.dom_loading",972],
+                    ["window.channel_established",2720],
+                    ["screen.rp_info",2721],
+                    ["xhr_complete.GET/wsapi/session_context",2723,294],
+                    ["screen.authenticate",3032],["user.can_interact",3053],
+                    ["xhr_complete.POST/wsapi/interaction_data",3025,271],
+                    ["xhr_complete.GET/wsapi/address_info",8656,603],
+                    ["authenticate.enter_password",9548],
+                    ["authenticate.enter_password",9554],
+                    ["authenticate.enter_password",9560],
+                    ["authenticate.password_submitted",15381],
+                    ["xhr_complete.POST/wsapi/authenticate_user",15381,1545],
+                    ["xhr_complete.GET/wsapi/list_emails",16930,255],
+                    ["authenticate.password_success",17195],
+                    ["screen.is_this_your_computer",17199],
+                    ["xhr_complete.POST/wsapi/prolong_session",19812,245],
+                    ["generate_assertion",20064],
+                    ["screen.generate_assertion",20065],
+                    ["xhr_complete.POST/wsapi/cert_key",20140,3580],
+                    ["assertion_generated",23761],
+                    ["window.unload",25564]],
+    "sample_rate":1,
+    "timestamp":1361407200000,
+    "lang":"en",
+    "new_account":false,
+    "screen_size":{"width":1680,"height":1050},
+    "number_emails":1,
+    "number_sites_signed_in":1,
+    "number_sites_remembered":1,
+    "orphaned":false,
+    "user_agent":{"os":"Macintosh","browser":"Firefox","version":18}}
 };
 
 exports.startFunc = function(cfg, cb) {
 
-    client.post(cfg, '/wsapi/interaction_data', {}, blob, function(err, r) {
-        if (err) {
-            cb(err);
-        } else if (!r || r.code !== 200) {
-            cb("for interaction_data post response code is not 200: " + (r ? r.code : "no response"));
-        } else {
-            cb();
-        }
-    });
+  client.post(cfg, '/wsapi/interaction_data', {}, blob, function(err, r) {
+    if (err) {
+      cb(err);
+    } else if (!r || r.code !== 200) {
+      cb("for interaction_data post response code is not 200: " + (r ? r.code : "no response"));
+    } else if (r.body !== '{"success":true}' ){
+      cb("interaction_data post not successful");
+    } else {
+      cb();
+    }
+  });
+  
 };


### PR DESCRIPTION
Perhaps don't merge this just yet, but first attempt at adding capability for load testing kpi data push
