### PR TITLE
Enable the remove-email test, it is stable.

### DIFF
--- a/automation-tests/config/tests-to-ignore.js
+++ b/automation-tests/config/tests-to-ignore.js
@@ -7,21 +7,17 @@
 
 var testsToIgnore = {
   dev: [
-    "public-terminals.js",
-    "remove-email.js"
+    "public-terminals.js"
   ],
-
 
   stage: [
     "frontend-qunit-test.js",
-    "public-terminals.js",
-    "remove-email.js"
+    "public-terminals.js"
   ],
 
   prod: [
     "frontend-qunit-test.js",
-    "public-terminals.js",
-    "remove-email.js"
+    "public-terminals.js"
   ]
 };
 


### PR DESCRIPTION
@jrgm or @6a68, mind reviewing?

The remove-email test seems perfectly capable now that the rest of the tests are passing.

```
➜  automation-tests git:(remove-email-test) ✗ ./scripts/run-all.js -t remove-email -e insensitive -p 8 -i 15
ignoring public-terminals.js
adding remove-email.js
Running 15 suite(s) on 1 platform(s), 8 at a time against https://insensitive.personatest.org
>>>>>>>>..................................................................................................................<>......<>.<>.<>.<>........<>.<>.<..................................................................................................<.<.<.<..<...<.<

255/255 tests passed
➜  automation-tests git:(remove-email-test) ✗ 
```
