### PR TITLE
Instead of using a CSS fadein to show the change password fields, use display: none and display: block.

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -305,20 +305,11 @@ button.delete:active {
 }
 
 .showedit {
-  -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-  opacity: 0;
-  visibility:hidden;
-  -webkit-transition: all 500ms;
-  -moz-transition: all 500ms;
-  -ms-transition: all 500ms;
-  -o-transition: all 500ms;
-  transition: all 500ms;
+  display: none;
 }
 
 .edit .showedit {
-  -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-  opacity: 1;
-  visibility:visible;
+  display: block;
 }
 
 #changePassword{


### PR DESCRIPTION
This fixes the following problems:
- Fields not shown in IE8 until mouse movement [#3034]
- Jagged text in IE8 [#2296]
- Able to focus hidden password fields in Android 2.3 Stock Browser [#1837]

And hopefully (untested):
- Password fields not shown in Android 4.2.1 Stock Browser [#3005]
