### PR TITLE
issue 3067 - don't require caller to have curry on Function prototype

### DIFF
--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -142,8 +142,12 @@
    * @param {function} callback
    */
   internal.logout = function(origin, callback) {
+    function complete(status) {
+      callback && callback(status);
+    }
+
     user.setOrigin(origin);
-    user.logout(callback, callback.curry(null));
+    user.logout(callback, complete.curry(null));
   };
 
   /**
@@ -152,7 +156,11 @@
    * @param {function} callback
    */
   internal.logoutEverywhere = function(callback) {
-    user.logoutUser(callback, callback.curry(null));
+    function complete(success) {
+      callback && callback(status);
+    }
+
+    user.logoutUser(callback, complete.curry(null));
   };
 
 }());


### PR DESCRIPTION
Follow the pattern of using a `complete` function within the `internal_api` callbacks so that use of `curry` is confined to the dialog.

This is important in a context like b2g or desktop firefox, where callbacks are handed from the browser to the `internal_api`; they should not need to modify the Function prototype.
