### PR TITLE
Cleanup config/sauce-platorms.js to use documented names, in prep for upgrading browser version numbers

### DIFF
--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -10,12 +10,12 @@ const platforms = {
     version:'16'
   },
   "linux_firefox_16": {
-    platform: 'LINUX',
+    platform: 'Linux',
     browserName: 'firefox',
     version: '16'
   },
   "osx_firefox_14": {
-    platform: 'MAC',
+    platform: 'Mac 10.6',
     browserName:'firefox',
     version:'14'
   },
@@ -27,8 +27,8 @@ const platforms = {
   },
 
   // IE
-  "xp_ie_8": {
-    platform:'XP',
+  "winxp_ie_8": {
+    platform:'Windows 2003',
     browserName: 'internet explorer',
     version:'8'
   },
@@ -45,7 +45,7 @@ const platforms = {
 
   // Opera
   "linux_opera_12": {
-    platform: 'LINUX',
+    platform: 'Linux',
     browserName: 'opera',
     version: '12'
   },

--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -1,28 +1,33 @@
 // platforms supported by sauce that we test
 const platforms = {
+  // Firefox
+  "vista_firefox_16": {
+    platform:'VISTA',
+    browserName:'firefox',
+    version:'16'
+  },
   "linux_firefox_16": {
     platform: 'LINUX',
     browserName: 'firefox',
     version: '16'
-  },
-  "linux_opera_12": {
-    platform: 'LINUX',
-    browserName: 'opera',
-    version: '12'
   },
   "osx_firefox_14": {
     platform: 'MAC',
     browserName:'firefox',
     version:'14'
   },
+
+  // Chrome
   "vista_chrome": {
     platform:'VISTA',
     browserName:'chrome'
   },
-  "vista_firefox_16": {
-    platform:'VISTA',
-    browserName:'firefox',
-    version:'16'
+
+  // IE
+  "xp_ie_8": {
+    platform:'XP',
+    browserName: 'internet explorer',
+    version:'8'
   },
   "vista_ie_9": {
     platform:'VISTA',
@@ -34,11 +39,15 @@ const platforms = {
     browserName: 'internet explorer',
     version: '10'
   },
-  "xp_ie_8": {
-    platform:'XP',
-    browserName: 'internet explorer',
-    version:'8'
+
+  // Opera
+  "linux_opera_12": {
+    platform: 'LINUX',
+    browserName: 'opera',
+    version: '12'
   },
+
+  // Safari
   "osx_safari_5": {
     platform:'Mac 10.6',
     browserName: 'safari',

--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -1,8 +1,11 @@
-// platforms supported by sauce that we test
+//
+// Platforms supported by sauce that we test. See
+// https://saucelabs.com/docs/browsers for available versions and OS.
+//
 const platforms = {
   // Firefox
-  "vista_firefox_16": {
-    platform:'VISTA',
+  "win7_firefox_16": {
+    platform:'Windows 2008',
     browserName:'firefox',
     version:'16'
   },
@@ -18,8 +21,8 @@ const platforms = {
   },
 
   // Chrome
-  "vista_chrome": {
-    platform:'VISTA',
+  "win7_chrome": {
+    platform:'Windows 2008',
     browserName:'chrome'
   },
 
@@ -29,8 +32,8 @@ const platforms = {
     browserName: 'internet explorer',
     version:'8'
   },
-  "vista_ie_9": {
-    platform:'VISTA',
+  "win7_ie_9": {
+    platform:'Windows 2008',
     browserName:'internet explorer',
     version:'9'
   },
@@ -74,4 +77,4 @@ const defaultCapabilities = {
 
 exports.platforms = platforms;
 exports.defaultCapabilities = defaultCapabilities;
-exports.defaultPlatform = "vista_firefox_16";
+exports.defaultPlatform = "win7_firefox_16";

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -165,7 +165,7 @@ function setSessionOpts(opts) {
                     ' not found in list of available platforms');
   }
   // Default to *nothing* locally (server's choice), and chrome/VISTA for sauce
-  var defaultPlatform = process.env.PERSONA_NO_SAUCE ? 'any' : { browserName: 'chrome', platform: 'VISTA' };
+  var defaultPlatform = process.env.PERSONA_NO_SAUCE ? 'any' : { browserName: 'chrome', platform: 'Windows 2008' };
   var platform = requestedPlatform ? saucePlatforms.platforms[requestedPlatform] : defaultPlatform;
   // add platform, browserName, version to session opts
   _.extend(sessionOpts, platform);


### PR DESCRIPTION
This may not be the right time to make this change (i.e., get the selenium tests stabilized first). On the other hand, we probably don't want to "fix" something that is only broken on a version we do not support, when the currently shipping version didn't need any help.

Anyways, in looking at this, the platform names we are using don't line up with names documented at https://saucelabs.com/docs/browsers. In particular, VISTA is not a real name, and actually means 'Windows 7' (a.k.a, 'Windows 2008' or 'Windows NT 6.1').

So this PR doesn't change any of the versions that we are currently testing against; version changes can happen after this PR. 

This just normalizes the platform names to what is documented. Version upgrades can happen later. 

You can check the net effect of these changes by dropping https://gist.github.com/jrgm/5075399 into automation-tests/tests and looking at /tmp/useragent.txt before and after and see that the UAs have not changed at all (especially that the IE UA for "VISTA" was always 'NT 6.1').
