### PR TITLE
don't require that an IdP supply a specific text string to indicate that the user is not authenticated

### DIFF
--- a/example/primary/provision.html
+++ b/example/primary/provision.html
@@ -19,7 +19,7 @@
     $.get('/api/whoami')
       .success(function(who) {
         if (user != who) {
-          return navigator.id.raiseProvisioningFailure('user is not authenticated as target user');
+          return navigator.id.raiseProvisioningFailure('not authed');
         }
 
         // Awesome!  The user is authenticated as who we want to provision.  let's

--- a/resources/static/common/js/modules/page_module.js
+++ b/resources/static/common/js/modules/page_module.js
@@ -123,7 +123,10 @@ BrowserID.Modules.PageModule = (function() {
     getErrorDialog: function(action, onerror) {
       var self=this;
       return function(lowLevelInfo) {
-        self.renderError("error", $.extend({
+        // do a deep extension so that any action.messages defined in
+        // lowLevelInfo are added to the action without overwriting the
+        // action's title.
+        self.renderError("error", $.extend(true, {
           action: action
         }, lowLevelInfo), onerror);
       };

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -449,7 +449,6 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - called on failure
      */
     provisionPrimaryUser: function(email, info, onComplete, onFailure) {
-
       User.primaryUserAuthenticationInfo(email, info, function(authInfo) {
         if (authInfo.authenticated) {
           persistEmailKeypair(email, authInfo.keypair, authInfo.cert,
@@ -529,14 +528,16 @@ BrowserID.User = (function() {
           complete(userInfo);
         },
         function(error) {
-          if (error.code === "primaryError" && error.msg === "user is not authenticated as target user") {
+          // issue #2339 - in case an error is raised we don't care
+          // about the specific error code.
+          if (error.code === "primaryError") {
             var userInfo = _.extend({
               authenticated: false
             }, info);
             complete(userInfo);
           }
           else {
-            onFailure(info);
+            onFailure($.extend(info, { detailedError: error }));
           }
         }
       );

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -537,7 +537,7 @@ BrowserID.User = (function() {
             complete(userInfo);
           }
           else {
-            onFailure($.extend(info, { detailedError: error }));
+            onFailure($.extend(info, { action: { message: error }}));
           }
         }
       );

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -121,6 +121,12 @@ BrowserID.State = (function() {
       startAction(false, "doRPInfo", info);
 
       if (info.email && info.type === "primary") {
+        // this case is where a users is returning to the dialog from
+        // authentication with a primary.  Elsewhere in
+        // code we key off of whether .primaryVerificationInfo is
+        // set to behave differently the first time the dialog is
+        // loaded vs. when a user returns to the dialog after auth with
+        // primary.
         self.primaryVerificationInfo = info;
         redirectToState("primary_user", info);
       }
@@ -284,6 +290,14 @@ BrowserID.State = (function() {
         idpName: info.idpName || URLParse(info.auth_url).host
       });
 
+      // If .primaryVerificationInfo is set, that means the user is
+      // returning to the dialog after authentication with their IdP.
+      // When provisioning fails and:
+      // 1. it's the first provisioning attempt - we send the user to
+      //    authentication with their IdP
+      // 2. it's the second provisioning attempt - we sent the user back
+      //    to the proper screen to pick a new email address.
+      // related to issue #2339
       if (self.primaryVerificationInfo) {
         self.primaryVerificationInfo = null;
         if (info.add) {

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -78,7 +78,13 @@ BrowserID.Modules.Authenticate = (function() {
     else {
       showHint("addressInfo");
       user.addressInfo(email, onAddressInfo,
-        self.getErrorDialog(errors.addressInfo));
+                       function(info) {
+                         var ai = errors.addressInfo;
+                         if (info.detailedError) {
+                           ai = $.extend(ai, { message: info.detailedError });
+                         }
+                         self.getErrorDialog(ai)();
+                       });
     }
 
     function onAddressInfo(info) {

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -78,13 +78,7 @@ BrowserID.Modules.Authenticate = (function() {
     else {
       showHint("addressInfo");
       user.addressInfo(email, onAddressInfo,
-                       function(info) {
-                         var ai = errors.addressInfo;
-                         if (info.detailedError) {
-                           ai = $.extend(ai, { message: info.detailedError });
-                         }
-                         self.getErrorDialog(ai)();
-                       });
+          self.getErrorDialog(errors.addressInfo));
     }
 
     function onAddressInfo(info) {

--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -42,10 +42,10 @@
     <ul class="moreInfo">
       <% if (typeof action !== "undefined") { %>
         <li>
-          <strong id="action">Action: </strong><%= action.title %>
+          <strong id="action">Action: </strong><span id="errorTitle"><%= action.title %></span>
 
           <% if (action.message) { %>
-            <p>
+            <p id="errorMessage">
               <%= (typeof action.message === 'string') ? action.message
                                                        : JSON.stringify(action.message, null, "  ") %>
             </p>

--- a/resources/static/dialog/views/error.ejs
+++ b/resources/static/dialog/views/error.ejs
@@ -46,7 +46,8 @@
 
           <% if (action.message) { %>
             <p>
-              <%= action.message %>
+              <%= (typeof action.message === 'string') ? action.message
+                                                       : JSON.stringify(action.message, null, "  ") %>
             </p>
           <% } %>
         </li>

--- a/resources/static/test/cases/common/js/modules/page_module.js
+++ b/resources/static/test/cases/common/js/modules/page_module.js
@@ -12,6 +12,7 @@
       testElementExists = testHelpers.testElementExists,
       testElementDoesNotExist = testHelpers.testElementDoesNotExist,
       testElementFocused = testHelpers.testElementFocused,
+      testErrorVisible = testHelpers.testErrorVisible,
       FORM_CONTENTS_SELECTOR = "#formWrap .contents",
       DELAY_CONTENTS_SELECTOR = "#delay .contents",
       DELAY_SHOWN_SELECTOR = "body.delay",
@@ -106,20 +107,24 @@
   asyncTest("getErrorDialog gets a function that can be used to render an error message", function() {
     createController();
 
-    // This is the medium level info.
+    var title = "error title";
+    var message = "extended error message";
+
+    // Call getErrorDialog with the "action" info.
     var func = controller.getErrorDialog({
-      title: "medium level info error title",
-      message: "medium level info error message"
+      title: title
     }, function() {
-      ok(true, "onerror callback called when returned function is called");
-      var html = el.find("#error .contents").html();
-      // XXX underpowered test, we don't actually check the contents.
-      ok(html.length, "when function is run, error text is loaded");
+      testErrorVisible();
+      equal($("#errorTitle").text().trim(), title);
+      equal($("#errorMessage").text().trim(), message);
       start();
     });
 
-    equal(typeof func, "function", "a function was returned from getErrorDialog");
-    func();
+    equal(typeof func, "function");
+
+    // action.message can be defined when calling getErrorDialog or when
+    // calling the returned function.
+    func({ action: { message: message }});
   });
 
   test("form is not submitted when 'submit_disabled' class is added to body", function() {

--- a/resources/static/test/cases/common/js/modules/page_module.js
+++ b/resources/static/test/cases/common/js/modules/page_module.js
@@ -107,16 +107,25 @@
   asyncTest("getErrorDialog gets a function that can be used to render an error message", function() {
     createController();
 
-    var title = "error title";
-    var message = "extended error message";
+    function escape(text) {
+      var escaped = _.escape(text);
+      // underscore escapes `/` whereas ejs does not
+      return escaped.replace(/&#x2F;/g, '/');
+    }
+
+    // Because these can come from the IdP, they must be escaped when displayed
+    // or else the IdP could XSS users
+    var title = "<span>error title</span>";
+    var message = "<span>extended error message</span>";
 
     // Call getErrorDialog with the "action" info.
     var func = controller.getErrorDialog({
       title: title
     }, function() {
       testErrorVisible();
-      equal($("#errorTitle").text().trim(), title);
-      equal($("#errorMessage").text().trim(), message);
+      // make sure the text is escaped before IdPs start XSSing users.
+      equal($("#errorTitle").html().trim(), escape(title));
+      equal($("#errorMessage").html().trim(), escape(message));
       start();
     });
 

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -525,17 +525,18 @@
     }, testHelpers.unexpectedXHRFailure);
   });
 
-  asyncTest("createPrimaryUser with primary, unknown provisioning failure, expect XHR failure callback", function() {
+  asyncTest("createPrimaryUser with primary, unknown provisioning failure - expect primary.verify", function() {
     xhr.useResult("primary");
+
     provisioning.setFailure({
       code: "primaryError",
       msg: "some error"
     });
 
-    lib.createPrimaryUser({email: "unregistered@testuser.com"},
-      testHelpers.unexpectedSuccess,
-      testHelpers.expectedXHRFailure
-    );
+    lib.createPrimaryUser({email: "unregistered@testuser.com"}, function(status) {
+      equal(status, "primary.verify", "primary must verify with primary, correct status");
+      start();
+    }, testHelpers.expectedXHRFailure);
   });
 
   asyncTest("provisionPrimaryUser authenticated with IdP, expect primary.verified", function() {


### PR DESCRIPTION
this is for issue #2339.  As part of the fix I wanted to ensure that errors not originating from the primary got shown under extended error information in the dialog.

Note to reviewer: I am not convinced my method of propagating error information is How We Do It.  Please review.
