### PR TITLE
remove WinChan from the communication_iframe, it is not used

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -146,7 +146,6 @@ exports.resources = {
   '/production/communication_iframe.js': [
     '/common/js/browserid.js',
     '/common/js/lib/jschannel.js',
-    '/common/js/lib/winchan.js',
     '/common/js/lib/tinyscore.js',
     '/common/js/lib/bidbundle.js',
     '/build/code_version.js',


### PR DESCRIPTION
@lloyd, do you know why winchan.js was in communication_iframe? I do not see anywhere that it is used. After taking it out, IE8 signs in as expected.

fixes #3109
