### PR TITLE
Use the newest connect-fonts-opensans which correctly uses the PostScript name of every font.

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -84,7 +84,7 @@
     "0.0.9-alpha8": "3d4c983e5b93a8a0e7793e9ef606c4f8413d113f"
   },
   "connect-fonts-opensans": {
-    "0.0.3-alpha3": "963560d917a4a4cf64f74e5e1c4ac47b5b449be6"
+    "0.0.3-beta1": "3a48105408514e7ef9fc2f4d1c784be0e102e744"
   },
   "connect-logger-statsd": {
     "0.0.1": "e1e350f0f6dc538a50a1868b4008806c45c409ea"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "validator": "0.4.9",
         "winston": "0.6.2",
         "connect-fonts": "0.0.9-alpha8",
-        "connect-fonts-opensans": "0.0.3-alpha3"
+        "connect-fonts-opensans": "0.0.3-beta1"
     },
     "optionalDependencies": {
         "node-statsd": "https://github.com/downloads/lloyd/node-statsd/0509f85.tgz"


### PR DESCRIPTION
In OSX, local fonts are searched for by their Postscript names instead of their True Type Font names.
