### PR TITLE
Fix the escaped HTML in the cookies_disabled screen.

### DIFF
--- a/resources/static/common/js/error-messages.js
+++ b/resources/static/common/js/error-messages.js
@@ -56,7 +56,7 @@ BrowserID.Errors = (function(){
 
     cookiesDisabled: {
       title: gettext("Persona requires cookies to remember you."),
-      message: format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" target='_blank' href='" + enableCookiesURL + "'"])
+      noescape_message: format(gettext("Please close this window, <a %s>enable cookies</a> and try again"), [" id='enable_cookies' target='_blank' href='" + enableCookiesURL + "'"])
 
     },
 

--- a/resources/static/dialog/views/generic.ejs
+++ b/resources/static/dialog/views/generic.ejs
@@ -4,4 +4,9 @@
 
   <h2 <% if(typeof id !== "undefined") { %>id="<%= id %>"<% } %>><%= title %></h2>
 
-  <p><%= message %></p>
+  <% if (typeof message !== "undefined") { %>
+    <p><%= message %></p>
+  <% } else if (typeof noescape_message !== "undefined") { %>
+    <p><%- noescape_message %></p>
+  <% } %>
+

--- a/resources/static/test/cases/common/js/modules/cookie_check.js
+++ b/resources/static/test/cases/common/js/modules/cookie_check.js
@@ -35,6 +35,9 @@
       ready: function(status) {
         equal(status, false, "cookies are disabled, false status");
         testHelpers.testErrorVisible();
+        // make sure the message is not escaped. If it is escaped, the anchor
+        // will not be found. see issue #2979
+        ok($("#enable_cookies").length);
         start();
       }
     });


### PR DESCRIPTION
fixes #2979
