### PR TITLE
Added logging of KPI Backend response

### DIFF
--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -60,7 +60,6 @@ var store = function (kpi_json, cb) {
         }
       };
       kpi_req = http.request(options);
-      logger.debug("Using proxy for KPI");
     } else {
       options = {
             hostname: db_url.host,
@@ -78,15 +77,22 @@ var store = function (kpi_json, cb) {
       
       var protocol = (db_url.scheme === 'https') ? https : http;
       kpi_req = protocol.request(options);
-      logger.debug("Not using proxy for KPI");
     }
+    
+    kpi_req.on('response', function(res) {
+      if (res.statusCode !== 201) {
+        logger.warn('KPI Backend (or proxy) response code is not 201: ' + res.statusCode);
+      } else {
+        logger.info('interaction data successfully posted to KPI Backend');
+      }  
+    });
     
     kpi_req.on('error', function (e) {
       // TODO statsd counter
       logger.error('KPI Backend request error: ' + e.message);
     });
 
-    logger.debug("sending request to KPI backend" + config.get('kpi_backend_db_url'));
+    logger.debug("sending request to KPI backend: " + config.get('kpi_backend_db_url'));
     kpi_req.write(post_data);
     kpi_req.end();
 


### PR DESCRIPTION
This should fix #3100, @shane-tomlinson could you review?

@jrgm asked if the simulated write to backend could be turned off in production -- is that already handled by using logger.debug?
