### PR TITLE
add P3P headers to endpoints IE might care about

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -25,6 +25,7 @@ heartbeat = require('../lib/heartbeat.js'),
 logger = require('../lib/logging.js').logger,
 shutdown = require('../lib/shutdown'),
 primary = require('../lib/primary'),
+addP3PHeader = require('../lib/p3p.js'),
 forward = require('../lib/http_forward.js'),
 toobusy = require('../lib/busy_middleware.js');
 
@@ -94,6 +95,10 @@ if (config.get('scheme') == 'https') {
     next();
     });
 }
+
+// Add P3P headers to please IE8
+app.use(addP3PHeader);
+
 
 // #4 - prevent framing of everything.  content underneath that needs to be
 // framed must explicitly remove the x-frame-options

--- a/bin/router
+++ b/bin/router
@@ -21,6 +21,7 @@ config = require('../lib/configuration.js'),
 heartbeat = require('../lib/heartbeat.js'),
 logger = require('../lib/logging.js').logger,
 forward = require('../lib/http_forward').forward,
+addP3PHeader = require('../lib/p3p.js'),
 shutdown = require('../lib/shutdown'),
 toobusy = require('../lib/busy_middleware.js');
 
@@ -100,6 +101,9 @@ if (config.get('scheme') == 'https') {
     });
 }
 
+// Add P3P headers to please IE8
+app.use(addP3PHeader);
+
 // redirect requests to the "verifier" processes
 if (config.get('verifier_url')) {
   var verifier_url = urlparse(config.get('verifier_url')).validate().normalize();
@@ -174,7 +178,6 @@ app.use(function(req, res, next) {
 shutdown.handleTerminationSignals(app, function() {
   toobusy.shutdown();
 });
-
 
 var bindTo = config.get('bind_to');
 app.listen(bindTo.port, bindTo.host, function(conn) {

--- a/bin/static
+++ b/bin/static
@@ -30,6 +30,7 @@ heartbeat = require('../lib/heartbeat.js'),
 logger = require('../lib/logging.js').logger,
 views = require('../lib/static/views.js'),
 toobusy = require('../lib/busy_middleware.js'),
+addP3PHeader = require('../lib/p3p.js'),
 shutdown = require('../lib/shutdown.js');
 
 var app = undefined;
@@ -80,6 +81,10 @@ if (statsd_config && statsd_config.enabled) {
     prefix: statsd_config.prefix || "browserid.static."
   }));
 }
+
+// Add P3P headers to please IE8
+app.use(addP3PHeader);
+
 // #4 - prevent framing of everything.  content underneath that needs to be
 // framed must explicitly remove the x-frame-options
 app.use(function(req, resp, next) {

--- a/lib/http_forward.js
+++ b/lib/http_forward.js
@@ -48,7 +48,7 @@ exports.forward = function(dest, req, res, cb) {
     res.statusCode = pres.statusCode;
 
     // forward necessary headers
-    ['Content-Type', 'Content-Length', 'Set-Cookie', 'Vary', 'Cache-Control', 'ETag', 'X-Frame-Options', 'Location', 'Access-Control-Allow-Origin']
+    ['Content-Type', 'Content-Length', 'Set-Cookie', 'Vary', 'Cache-Control', 'ETag', 'X-Frame-Options', 'Location', 'Access-Control-Allow-Origin', 'P3P']
       .forEach(function (header) {
         if (pres.headers.hasOwnProperty(header.toLowerCase())) {
           res.setHeader(header, pres.headers[header.toLowerCase()]);

--- a/lib/p3p.js
+++ b/lib/p3p.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var useragent = require('useragent'),
+  policy = 'CP="This is not a P3P policy, but Mozilla deeply cares about ' +
+             'your privacy. See http://www.mozilla.org/persona/privacy-policy ' +
+             'for more."';
+
+// add 'P3P' headers so that IE8, with default security settings, will allow
+// us to set third-party cookies. Only add the headers in that case, saving
+// bytes for all the other browsers. #2340
+module.exports = function(req, res, next) {
+  var browser = useragent.parse(req.headers['user-agent']);
+  if (browser.family === 'IE') {
+    res.on('header', function() {
+      res.setHeader('P3P', policy);
+    });
+  }
+  next();
+};

--- a/lockdown.json
+++ b/lockdown.json
@@ -190,6 +190,7 @@
   },
   "lru-cache": {
     "1.0.6": "aa50f97047422ac72543bda177a9c9d018d98452",
+    "2.2.4": "6c658619becf14031d0d0b594b16042ce4dc063d",
     "2.3.0": "1cee12d5a9f28ed1ee37e9c332b8888e6b85412a"
   },
   "mailcomposer": {
@@ -224,7 +225,7 @@
     "0.6.0": "41e64712dbd947aa9d9f466b5c0b5ee020bbcbbb"
   },
   "node-statsd": {
-    "0.0.2": "*"
+    "0.0.2": "ba96c26d4ec22b4f9501bb332fdf740db5a40ee7"
   },
   "nodemailer": {
     "0.3.21": "d9637a1d585f36fd30362c3036ce0692656fe771"
@@ -344,6 +345,9 @@
   },
   "urlparse": {
     "0.0.1": "d171ec4681fcd0d8bd00b64345637d89a9700876"
+  },
+  "useragent": {
+    "2.0.3": "f62b5a939271182eb7fa56c3b60593b866e595ed"
   },
   "validator": {
     "0.4.9": "0f2421e35abe4321054383ed5cc154264a984a94"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "uglifycss": "0.0.5",
     "underscore": "1.3.1",
     "urlparse": "0.0.1",
+    "useragent": "2.0.3",
     "validator": "0.4.9",
     "winston": "0.6.2",
     "connect-fonts": "0.0.9-alpha8",


### PR DESCRIPTION
Reopened. @shane-tomlinson or @lloyd, mind taking a look?

I split this off from the main blob of third-party cookie discussion.

Add P3P headers to IE family browsers (a little searching suggests IE9 and, presumably, IE10 also care about this header).

Do I need to add tests to confirm this header is appended if the user-agent header contains an IE-like string?
