### PR TITLE
Refactor network.js & user.js to move user related context to user.js

### DIFF
--- a/resources/static/common/js/modules/development.js
+++ b/resources/static/common/js/modules/development.js
@@ -83,7 +83,7 @@ BrowserID.Modules.Development = (function() {
   }
 
   function forceIsThisYourComputer() {
-    storage.usersComputer.forceAsk(network.userid());
+    storage.usersComputer.forceAsk(user.userid());
   }
 
   function close() {

--- a/resources/static/common/js/modules/development.js
+++ b/resources/static/common/js/modules/development.js
@@ -9,7 +9,7 @@ BrowserID.Modules.Development = (function() {
       dom = bid.DOM,
       renderer = bid.Renderer,
       storage = bid.Storage,
-      network = bid.Network,
+      user = bid.User,
       clickCount = 0;
 
 

--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -27,7 +27,7 @@ BrowserID.Modules.InteractionData = (function() {
 
   var bid = BrowserID,
       model = bid.Models.InteractionData,
-      network = bid.Network,
+      user = bid.User,
       storage = bid.Storage,
       complete = bid.Helpers.complete,
       dom = bid.DOM,
@@ -157,7 +157,7 @@ BrowserID.Modules.InteractionData = (function() {
     if (lastSessionsKPIs && lastSessionsKPIs.orphaned) {
       var events = lastSessionsKPIs.event_stream || [];
       if (hasEvent(events, MediatorToKPINameTable.user_staged)) {
-        network.checkAuth(function(auth) {
+        user.checkAuthentication(function(auth) {
           if (!!auth) {
             lastSessionsKPIs.orphaned = false;
             model.setCurrent(lastSessionsKPIs);

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -5,14 +5,12 @@ BrowserID.Network = (function() {
   "use strict";
   /*globals require:true*/
 
-  var jwcrypto = require("./lib/jwcrypto"),
-      bid = BrowserID,
+  var bid = BrowserID,
       complete = bid.Helpers.complete,
       context,
       server_time,
       domain_key_creation_time,
       code_version,
-      time_until_delay,
       mediator = bid.Mediator,
       xhr = bid.XHR,
       post = xhr.post,
@@ -27,9 +25,6 @@ BrowserID.Network = (function() {
     };
     domain_key_creation_time = result.domain_key_creation_time;
     code_version = result.code_version;
-
-    // seed the PRNG
-    jwcrypto.addEntropy(result.random_seed);
   }
 
   function withContext(cb, onFailure) {

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -138,29 +138,10 @@ BrowserID.Network = (function() {
       });
     },
 
-    /**
-     * Check whether a user is currently logged in.
-     * @method checkAuth
-     * @param {function} [onComplete] - called with one
-     * boolean parameter, whether the user is authenticated.
-     * @param {function} [onFailure] - called on XHR failure.
-     */
-    checkAuth: function(onComplete, onFailure) {
-      withContext(function() {
-        try {
-          complete(onComplete, context.auth_level);
-        } catch(e) {
-          complete(onFailure, e.toString());
-        }
-      }, onFailure);
-    },
-
-    withContext: function(onComplete, onFailure) {
-      withContext(onComplete, onFailure);
-    },
+    withContext: withContext,
 
     setContext: function(field, value) {
-      context[field] = value;
+      if (context) context[field] = value;
     },
 
     /**

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -11,27 +11,13 @@ BrowserID.Network = (function() {
       context,
       server_time,
       domain_key_creation_time,
-      auth_status,
       code_version,
-      userid,
       time_until_delay,
       mediator = bid.Mediator,
       xhr = bid.XHR,
       post = xhr.post,
       get = xhr.get,
       storage = bid.Storage;
-
-  function setUserID(uid) {
-    userid = uid;
-
-    // TODO - Get this out of here and put it into user!
-
-    // when session context returns with an authenticated user, update localstorage
-    // to indicate we've seen this user on this device
-    if (userid) {
-      storage.usersComputer.setSeen(userid);
-    }
-  }
 
   function onContextChange(msg, result) {
     context = result;
@@ -40,9 +26,7 @@ BrowserID.Network = (function() {
       local: (new Date()).getTime()
     };
     domain_key_creation_time = result.domain_key_creation_time;
-    auth_status = result.auth_level;
     code_version = result.code_version;
-    setUserID(result.userid);
 
     // seed the PRNG
     jwcrypto.addEntropy(result.random_seed);
@@ -58,28 +42,7 @@ BrowserID.Network = (function() {
   function clearContext() {
     xhr.clearContext();
     var undef;
-    context = server_time = auth_status = userid = undef;
-  }
-
-  function handleAuthenticationResponse(type, onComplete, onFailure, status) {
-    try {
-      var authenticated = status.success;
-
-      if (typeof authenticated !== 'boolean') throw status;
-
-      // now update the userid which is set once the user is authenticated.
-      // this is used to key off client side state, like whether this user has
-      // confirmed ownership of this device
-      setUserID(status.userid);
-
-      // at this point we know the authentication status of the
-      // session, let's set it to perhaps save a network request
-      // (to fetch session context).
-      auth_status = authenticated && type;
-      complete(onComplete, authenticated);
-    } catch (e) {
-      onFailure("unexpected server response: " + e);
-    }
+    context = server_time = undef;
   }
 
   function stageAddressForVerification(data, wsapiName, onComplete, onFailure) {
@@ -99,12 +62,6 @@ BrowserID.Network = (function() {
     });
   }
 
-  function handleAddressVerifyCheckResponse(onComplete, status, textStatus, jqXHR) {
-    if (status.status === 'complete' && status.userid)
-      setUserID(status.userid);
-    complete(onComplete, status.status);
-  }
-
   function completeAddressVerification(wsapiName, token, password, onComplete, onFailure) {
       var data = {
         token: token
@@ -116,12 +73,7 @@ BrowserID.Network = (function() {
       post({
         url: wsapiName,
         data: data,
-        success: function(status, textStatus, jqXHR) {
-          // If the user has successfully completed an address verification,
-          // they are authenticated to the password status.
-          if (status.success) auth_status = "password";
-          complete(onComplete, status.success);
-        },
+        success: onComplete,
         error: onFailure
       });
 
@@ -160,7 +112,7 @@ BrowserID.Network = (function() {
           pass: password,
           ephemeral: !storage.usersComputer.confirmed(email)
         },
-        success: handleAuthenticationResponse.curry("password", onComplete, onFailure),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -181,7 +133,7 @@ BrowserID.Network = (function() {
           assertion: assertion,
           ephemeral: !storage.usersComputer.confirmed(email)
         },
-        success: handleAuthenticationResponse.curry("assertion", onComplete, onFailure),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -196,7 +148,7 @@ BrowserID.Network = (function() {
     checkAuth: function(onComplete, onFailure) {
       withContext(function() {
         try {
-          complete(onComplete, auth_status);
+          complete(onComplete, context.auth_level);
         } catch(e) {
           complete(onFailure, e.toString());
         }
@@ -205,6 +157,10 @@ BrowserID.Network = (function() {
 
     withContext: function(onComplete, onFailure) {
       withContext(onComplete, onFailure);
+    },
+
+    setContext: function(field, value) {
+      context[field] = value;
     },
 
     /**
@@ -224,23 +180,13 @@ BrowserID.Network = (function() {
     logout: function(onComplete, onFailure) {
       post({
         url: "/wsapi/logout",
-        success: function() {
-          // assume the logout request is successful and
-          // log the user out.  There is no need to reset the
-          // CSRF token.
-          // FIXME: we should return a confirmation that the
-          // user was successfully logged out.
-          auth_status = false;
-          setUserID(undefined);
-          complete(onComplete);
-        },
+        success: onComplete,
         error: function(info, xhr, textStatus) {
           if (info.network.status === 400) {
-            auth_status = false;
             complete(onComplete);
           }
           else {
-            onFailure && onFailure(info);
+            complete(onFailure, info);
           }
         }
       });
@@ -296,7 +242,7 @@ BrowserID.Network = (function() {
     checkUserRegistration: function(email, onComplete, onFailure) {
       get({
         url: "/wsapi/user_creation_status?email=" + encodeURIComponent(email),
-        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -357,7 +303,7 @@ BrowserID.Network = (function() {
     checkPasswordReset: function(email, onComplete, onFailure) {
       get({
         url: "/wsapi/password_reset_status?email=" + encodeURIComponent(email),
-        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -392,7 +338,7 @@ BrowserID.Network = (function() {
     checkEmailReverify: function(email, onComplete, onFailure) {
       get({
         url: "/wsapi/email_reverify_status?email=" + encodeURIComponent(email),
-        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -435,12 +381,7 @@ BrowserID.Network = (function() {
           oldpass: oldPassword,
           newpass: newPassword
         },
-        success: function(status) {
-          // successful change of password will upgrade a session to password
-          // level auth
-          if (status) auth_status = "password";
-          complete(onComplete, status.success);
-        },
+        success: onComplete,
         error: onFailure
       });
     },
@@ -507,7 +448,7 @@ BrowserID.Network = (function() {
     checkEmailRegistration: function(email, onComplete, onFailure) {
       get({
         url: "/wsapi/email_addition_status?email=" + encodeURIComponent(email),
-        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        success: onComplete,
         error: onFailure
       });
     },
@@ -599,28 +540,10 @@ BrowserID.Network = (function() {
       get({
         url: "/wsapi/list_emails",
         success: function(emails) {
-          // TODO - Put this into user.js or storage.js when emails are synced/saved to
-          // storage.
-          // update our local storage map of email addresses to user ids
-          if (userid) {
-            storage.updateEmailToUserIDMapping(userid, emails.emails);
-          }
-
-          onComplete && onComplete(emails.emails);
+          complete(onComplete, emails.emails);
         },
         error: onFailure
       });
-    },
-
-    /**
-     * TODO - move this into user.
-     * Return the user's userid, which will an integer if the user
-     * is authenticated, undefined otherwise.
-     *
-     * @method userid
-     */
-    userid: function() {
-      return userid;
     },
 
     /**
@@ -721,18 +644,11 @@ BrowserID.Network = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     prolongSession: function(onComplete, onFailure) {
-      Network.checkAuth(function(authenticated) {
-        if(authenticated) {
-          post({
-            url: "/wsapi/prolong_session",
-            success: onComplete,
-            error: onFailure
-          });
-        }
-        else {
-          complete(onFailure, "user not authenticated");
-        }
-      }, onFailure);
+      post({
+        url: "/wsapi/prolong_session",
+        success: onComplete,
+        error: onFailure
+      });
     },
 
     /**
@@ -743,18 +659,12 @@ BrowserID.Network = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     usedAddressAsPrimary: function(email, onComplete, onFailure) {
-      Network.checkAuth(function authChecked(authenticated) {
-        if (authenticated) {
-          post({
-            url: "/wsapi/used_address_as_primary",
-            data: { email: email },
-            success: onComplete,
-            error: onFailure
-          });
-        } else {
-          complete(onFailure, "user not authenticated");
-        }
-      }, onFailure);
+      post({
+        url: "/wsapi/used_address_as_primary",
+        data: { email: email },
+        success: onComplete,
+        error: onFailure
+      });
     },
 
     /**
@@ -796,7 +706,7 @@ BrowserID.Network = (function() {
     checkTransitionToSecondary: function(email, onComplete, onFailure) {
       get({
         url: "/wsapi/transition_status?email=" + encodeURIComponent(email),
-        success: handleAddressVerifyCheckResponse.curry(onComplete),
+        success: onComplete,
         error: onFailure
       });
     }

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1352,19 +1352,21 @@ BrowserID.User = (function() {
      * @param {function} onFailure - called on XHR failure.
      */
     setComputerOwnershipStatus: function(userOwnsComputer, onComplete, onFailure) {
-      var userID = network.userid();
-      if (typeof userID !== "undefined") {
-        if (userOwnsComputer) {
-          storage.usersComputer.setConfirmed(userID);
-          network.prolongSession(onComplete, onFailure);
+      network.withContext(function() {
+        var userID = network.userid();
+        if (typeof userID !== "undefined") {
+          if (userOwnsComputer) {
+            storage.usersComputer.setConfirmed(userID);
+            network.prolongSession(onComplete, onFailure);
+          }
+          else {
+            storage.usersComputer.setDenied(userID);
+            complete(onComplete);
+          }
+        } else {
+          complete(onFailure, "user is not authenticated");
         }
-        else {
-          storage.usersComputer.setDenied(userID);
-          complete(onComplete);
-        }
-      } else {
-        complete(onFailure, "user is not authenticated");
-      }
+      }, onFailure);
     },
 
     /**
@@ -1372,12 +1374,14 @@ BrowserID.User = (function() {
      * @method isUsersComputer
      */
     isUsersComputer: function(onComplete, onFailure) {
-      var userID = network.userid();
-      if (typeof userID !== "undefined") {
-        complete(onComplete, storage.usersComputer.confirmed(userID));
-      } else {
-        complete(onFailure, "user is not authenticated");
-      }
+      network.withContext(function() {
+        var userID = network.userid();
+        if (typeof userID !== "undefined") {
+          complete(onComplete, storage.usersComputer.confirmed(userID));
+        } else {
+          complete(onFailure, "user is not authenticated");
+        }
+      }, onFailure);
     },
 
     /**
@@ -1385,16 +1389,18 @@ BrowserID.User = (function() {
      * @method shouldAskIfUsersComputer
      */
     shouldAskIfUsersComputer: function(onComplete, onFailure) {
-      var userID = network.userid();
-      if (typeof userID !== "undefined") {
-        // A user should never be asked if they completed an email
-        // registration/validation in this dialog session.
-        var shouldAsk = storage.usersComputer.shouldAsk(userID)
-                        && !registrationComplete;
-        complete(onComplete, shouldAsk);
-      } else {
-        complete(onFailure, "user is not authenticated");
-      }
+      network.withContext(function() {
+        var userID = network.userid();
+        if (typeof userID !== "undefined") {
+          // A user should never be asked if they completed an email
+          // registration/validation in this dialog session.
+          var shouldAsk = storage.usersComputer.shouldAsk(userID)
+                          && !registrationComplete;
+          complete(onComplete, shouldAsk);
+        } else {
+          complete(onFailure, "user is not authenticated");
+        }
+      }, onFailure);
     },
 
     /**

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -304,6 +304,10 @@ BrowserID.User = (function() {
 
 
   function onContextChange(msg, context) {
+    // seed the PRNG
+    prepareDeps();
+    jwcrypto.addEntropy(context.random_seed);
+
     setAuthenticationStatus(context.auth_level, context.userid);
   }
 

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -163,6 +163,9 @@ BrowserID.User = (function() {
         // completed verification. See issue #1682
         // https://github.com/mozilla/browserid/issues/1682
         User.authenticate(stagedEmail, stagedPassword, function(authenticated) {
+          // The address verification poll does not send back a userid if
+          // the status is mustAuth. use the userid set in onContextChange.
+          resp.userid = userid;
           resp.status = authenticated ? "complete" : "mustAuth";
           completeVerification(resp);
         }, onFailure);
@@ -183,7 +186,7 @@ BrowserID.User = (function() {
         // status is to ask the backend. Clear the current context and ask
         // the backend for an updated session_context.
         clearContext();
-        network.checkAuth(function(authStatus) {
+        User.checkAuthentication(function(authStatus) {
           if (resp.status === "complete" && authStatus !== "password")
             resp.status = "mustAuth";
 
@@ -359,6 +362,7 @@ BrowserID.User = (function() {
 
   User = {
     init: function(config) {
+      config = config || {};
       mediator.subscribe('context_info', onContextChange);
 
       if (config.provisioning) {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -10,6 +10,7 @@ BrowserID.User = (function() {
       network = bid.Network,
       storage = bid.Storage,
       helpers = bid.Helpers,
+      mediator = bid.Mediator,
       User,
       pollTimeout,
       provisioning = bid.Provisioning,
@@ -20,7 +21,9 @@ BrowserID.User = (function() {
       POLL_DURATION = 3000,
       pollDuration = POLL_DURATION,
       stagedEmail,
-      stagedPassword;
+      stagedPassword,
+      userid,
+      auth_status;
 
   function prepareDeps() {
     /*globals require:true*/
@@ -98,19 +101,6 @@ BrowserID.User = (function() {
     });
   }
 
-  function setAuthenticationStatus(authenticated) {
-    if (window.$) {
-      // TODO get this out of here!
-      // jQuery is not included in the communication_iframe
-      var func = authenticated ? 'addClass' : 'removeClass';
-      $('body')[func]('authenticated');
-    }
-
-    if (!authenticated) {
-      storage.clear();
-    }
-  }
-
   function stageAddressVerification(email, password, stagingStrategy, onComplete, onFailure) {
     // These are saved for the addressVerificationPoll.  If there is
     // a stagedEmail or stagedPassword when the poll completes, try to
@@ -137,12 +127,16 @@ BrowserID.User = (function() {
     User.tokenInfo(token, function(info) {
       var invalidInfo = { valid: false };
       if (info) {
-        completeFunc(token, password, function (valid) {
+        completeFunc(token, password, function (resp) {
+          var valid = resp.success;
           var result = invalidInfo;
 
           if (valid) {
             result = _.extend({ valid: valid }, info);
             storage.setReturnTo("");
+            // If the user has successfully completed an address verification,
+            // they are authenticated to the password status.
+            auth_status = "password";
           }
 
           complete(onComplete, result);
@@ -160,7 +154,7 @@ BrowserID.User = (function() {
    * the user must enter their password.
    */
   function addressVerificationPoll(checkFunc, email, onSuccess, onFailure) {
-    function userVerified(completionStatus) {
+    function userVerified(resp) {
       if (stagedEmail && stagedPassword) {
         // The user has set their email and password as part of the
         // staging flow. Log them in now just to make sure their
@@ -169,8 +163,8 @@ BrowserID.User = (function() {
         // completed verification. See issue #1682
         // https://github.com/mozilla/browserid/issues/1682
         User.authenticate(stagedEmail, stagedPassword, function(authenticated) {
-          completionStatus = authenticated ? "complete" : "mustAuth";
-          completeVerification(completionStatus);
+          resp.status = authenticated ? "complete" : "mustAuth";
+          completeVerification(resp);
         }, onFailure);
 
         stagedEmail = stagedPassword = null;
@@ -188,17 +182,17 @@ BrowserID.User = (function() {
         // a password reset, the only reliable way to know the user's auth
         // status is to ask the backend. Clear the current context and ask
         // the backend for an updated session_context.
-        network.clearContext();
+        clearContext();
         network.checkAuth(function(authStatus) {
-          if (completionStatus === "complete" && authStatus !== "password")
-            completionStatus = "mustAuth";
+          if (resp.status === "complete" && authStatus !== "password")
+            resp.status = "mustAuth";
 
-          completeVerification(completionStatus);
+          completeVerification(resp);
         }, onFailure);
       }
     }
 
-    function completeVerification(status) {
+    function completeVerification(resp) {
       // As soon as the registration comes back as complete, we should
       // ensure that the stagedOnBehalfOf is cleared so there is no stale
       // data.
@@ -209,18 +203,20 @@ BrowserID.User = (function() {
       // they just completed a registration.
       registrationComplete = true;
 
-      if (status === "complete") {
+      if (resp.status === "complete") {
+        setAuthenticationStatus("password", resp.userid);
         User.syncEmails(function() {
-          complete(onSuccess, status);
+          complete(onSuccess, resp.status);
         }, onFailure);
       }
       else {
-        complete(onSuccess, status);
+        complete(onSuccess, resp.status);
       }
     }
 
     function poll() {
-      checkFunc(email, function(status) {
+      checkFunc(email, function(resp) {
+        var status = resp.status;
         // registration status checks the status of the last initiated registration,
         // it's possible return values are:
         //   'complete' - registration has been completed
@@ -228,7 +224,7 @@ BrowserID.User = (function() {
         //   'mustAuth' - user must authenticate
         //   'noRegistration' - no registration is in progress
         if (status === "complete" || status === "mustAuth") {
-          userVerified(status);
+          userVerified(resp);
         }
         else if (status === 'pending') {
           pollTimeout = setTimeout(poll, pollDuration);
@@ -304,8 +300,67 @@ BrowserID.User = (function() {
   }
 
 
+  function onContextChange(msg, context) {
+    setAuthenticationStatus(context.auth_level, context.userid);
+  }
+
+  function withContext(onSuccess, onFailure) {
+    network.withContext(onSuccess, onFailure);
+  }
+
+  function clearContext() {
+    var und;
+    userid = auth_status = und;
+    network.clearContext();
+  }
+
+  function setAuthenticationStatus(auth_level, user_id) {
+    if (window.$) {
+      // TODO get this out of here!
+      // jQuery is not included in the communication_iframe
+      var func = !!auth_level ? 'addClass' : 'removeClass';
+      $('body')[func]('authenticated');
+    }
+
+    auth_status = auth_level;
+    userid = auth_level && user_id;
+
+    // Keep the network.js copy of context up to date with any changes.
+    // context should really be put into its own module so there is only
+    // a single copy of it anywhere.
+    network.setContext("auth_level", auth_level);
+    network.setContext("userid", user_id);
+
+    if (!!auth_status && userid) {
+      // when session context returns with an authenticated user, update
+      // localStorage to indicate we've seen this user on this device
+      storage.usersComputer.setSeen(userid);
+    }
+    else {
+      storage.clear();
+    }
+  }
+
+  function handleAuthenticationResponse(type, onComplete, onFailure, status) {
+    var authenticated = status.success;
+    if (typeof authenticated !== 'boolean') {
+      return onFailure("unexpected server response: " + authenticated);
+    }
+
+    setAuthenticationStatus(authenticated && type, status.userid);
+    if (authenticated) {
+      User.syncEmails(function() {
+        complete(onComplete, authenticated);
+      }, onFailure);
+    } else {
+      complete(onComplete, authenticated);
+    }
+  }
+
   User = {
     init: function(config) {
+      mediator.subscribe('context_info', onContextChange);
+
       if (config.provisioning) {
         provisioning = config.provisioning;
       }
@@ -322,7 +377,7 @@ BrowserID.User = (function() {
       User.resetCaches();
       registrationComplete = false;
       pollDuration = POLL_DURATION;
-      stagedEmail = stagedPassword = null;
+      stagedEmail = stagedPassword = userid = auth_status = null;
     },
 
     resetCaches: function() {
@@ -382,6 +437,19 @@ BrowserID.User = (function() {
     getReturnTo: function() {
       return this.returnTo;
     },
+
+    /**
+     * Return the user's userid, which will an integer if the user
+     * is authenticated, undefined otherwise.
+     *
+     * @method userid
+     */
+    userid: function() {
+      return userid;
+    },
+
+    withContext: withContext,
+    clearContext: clearContext,
 
     /**
      * Create a user account - this creates an user account that must be verified.
@@ -494,22 +562,22 @@ BrowserID.User = (function() {
 
       function complete(info) {
         primaryAuthCache[email] = info;
-        onComplete && _.defer(onComplete.curry(info));
+        onComplete && _.defer(function() {
+          onComplete(info);
+        });
       }
 
       if (primaryAuthCache[email]) {
         // If we have the info in our cache, we most definitely do not have to
         // ask for it.
-        complete(primaryAuthCache[email]);
-        return;
+        return complete(primaryAuthCache[email]);
       }
       else if (idInfo && idInfo.cert) {
         // If we already have the info in storage, we know the user has a valid
         // cert with their IdP, we say they are authenticated and pass back the
         // appropriate info.
         var userInfo = _.extend({authenticated: true}, idInfo, info);
-        complete(userInfo);
-        return;
+        return complete(userInfo);
       }
 
       provisioning(
@@ -612,7 +680,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on error.
      */
     canSetPassword: function(onComplete, onFailure) {
-      network.withContext(function(ctx) {
+      withContext(function(ctx) {
         complete(onComplete, ctx.has_password);
       }, onFailure);
     },
@@ -628,7 +696,12 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - called on XHR failure.
      */
     changePassword: function(oldpassword, newpassword, onComplete, onFailure) {
-      network.changePassword(oldpassword, newpassword, onComplete, onFailure);
+      network.changePassword(oldpassword, newpassword, function(resp) {
+        // successful change of password will upgrade a session to password
+        // level auth
+        if (resp.success) setAuthenticationStatus("password", userid);
+        complete(onComplete, resp.success);
+      }, onFailure);
     },
 
     /**
@@ -836,6 +909,11 @@ BrowserID.User = (function() {
         var issued_identities = User.getStoredEmailKeypairs();
 
         network.listEmails(function(server_emails) {
+          // update our local storage map of email addresses to user ids
+          if (userid) {
+            storage.updateEmailToUserIDMapping(userid, server_emails);
+          }
+
           // lists of emails
           var client_emails = _.keys(issued_identities);
 
@@ -862,18 +940,15 @@ BrowserID.User = (function() {
      * Check whether the current user is authenticated.  Calls the callback
      * with false if cookies are disabled.
      * @method checkAuthentication
-     * @param {function} [onComplete] - Called when check is complete with one
-     * boolean parameter, authenticated.  authenticated will be true if user is
+     * @param {function} [onComplete] - Called with user's auth level if
      * authenticated, false otw.
      * @param {function} [onFailure] - Called on error.
      */
     checkAuthentication: function(onComplete, onFailure) {
       network.cookiesEnabled(function(cookiesEnabled) {
         if (cookiesEnabled) {
-          network.checkAuth(function(authenticated) {
-            setAuthenticationStatus(authenticated);
-            if (!authenticated) authenticated = false;
-            complete(onComplete, authenticated);
+          withContext(function() {
+            complete(onComplete, auth_status || false);
           }, onFailure);
         }
         else {
@@ -915,17 +990,9 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on error.
      */
     authenticate: function(email, password, onComplete, onFailure) {
-      network.authenticate(email, password, function(authenticated) {
-        setAuthenticationStatus(authenticated);
-
-        if (authenticated) {
-          User.syncEmails(function() {
-            onComplete && onComplete(authenticated);
-          }, onFailure);
-        } else if (onComplete) {
-          onComplete(authenticated);
-        }
-      }, onFailure);
+      network.authenticate(email, password,
+          handleAuthenticationResponse.curry("password", onComplete,
+              onFailure), onFailure);
     },
 
     /**
@@ -939,17 +1006,9 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on error.
      */
     authenticateWithAssertion: function(email, assertion, onComplete, onFailure) {
-      network.authenticateWithAssertion(email, assertion, function(authenticated) {
-        setAuthenticationStatus(authenticated);
-
-        if (authenticated) {
-          User.syncEmails(function() {
-            complete(onComplete, authenticated);
-          }, onFailure);
-        } else {
-          complete(onComplete, authenticated);
-        }
-      }, onFailure);
+      network.authenticateWithAssertion(email, assertion,
+          handleAuthenticationResponse.curry("assertion", onComplete,
+              onFailure), onFailure);
 
     },
 
@@ -994,28 +1053,29 @@ BrowserID.User = (function() {
       }
 
       if (addressCache[email]) {
-        complete(addressCache[email]);
+        return complete(addressCache[email]);
       }
-      else {
-        network.addressInfo(email, function(info) {
-          // update the email with the normalized email if it is available.
-          // The normalized email is stored in the cache.
-          var normalizedEmail = info.normalizedEmail || email;
-          info.email = normalizedEmail;
-          info = User.checkEmailIssuer(normalizedEmail, info);
-          if (info.type === "primary") {
+
+      network.addressInfo(email, function(info) {
+        // update the email with the normalized email if it is available.
+        // The normalized email is stored in the cache.
+        var normalizedEmail = info.normalizedEmail || email;
+        info.email = normalizedEmail;
+        info = User.checkEmailIssuer(normalizedEmail, info);
+        if (info.type === "primary") {
+          withContext(function() {
             User.isUserAuthenticatedToPrimary(normalizedEmail, info,
                 function(authed) {
               info.authed = authed;
               info.idpName = getIdPName(info);
               complete(info);
             }, onFailure);
-          }
-          else {
-            complete(info);
-          }
-        }, onFailure);
-      }
+          }, onFailure);
+        }
+        else {
+          complete(info);
+        }
+      }, onFailure);
     },
     /**
      * Checks for outdated certificates and clears them from storage.
@@ -1037,7 +1097,7 @@ BrowserID.User = (function() {
         // issuer MUST have changed... clear certs
         if ("transition_to_primary" === info.state && identity.cert) {
           clearCert(email, identity);
-	} else {
+        } else {
 
           var prevIssuer;
           try {
@@ -1080,7 +1140,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on error.
      */
     passwordNeededToAddSecondaryEmail: function(onComplete, onFailure) {
-      network.withContext(function(ctx) {
+      withContext(function(ctx) {
         complete(onComplete, !ctx.has_password);
       }, onFailure);
     },
@@ -1145,10 +1205,10 @@ BrowserID.User = (function() {
     syncEmailKeypair: function(email, onComplete, onFailure) {
       prepareDeps();
       // jwcrypto depends on a random seed being set to generate a keypair.
-      // The seed is set with a call to network.withContext.  Ensure the
+      // The seed is set with a call to withContext.  Ensure the
       // random seed is set before continuing or else the seed may not be set,
       // the key never created, and the onComplete callback never called.
-      network.withContext(function() {
+      withContext(function() {
         jwcrypto.generateKeypair({algorithm: "DS", keysize: bid.KEY_LENGTH}, function(err, keypair) {
           certifyEmailKeypair(email, keypair, onComplete, onFailure);
         });
@@ -1352,15 +1412,14 @@ BrowserID.User = (function() {
      * @param {function} onFailure - called on XHR failure.
      */
     setComputerOwnershipStatus: function(userOwnsComputer, onComplete, onFailure) {
-      network.withContext(function() {
-        var userID = network.userid();
-        if (typeof userID !== "undefined") {
+      withContext(function() {
+        if (typeof userid !== "undefined") {
           if (userOwnsComputer) {
-            storage.usersComputer.setConfirmed(userID);
+            storage.usersComputer.setConfirmed(userid);
             network.prolongSession(onComplete, onFailure);
           }
           else {
-            storage.usersComputer.setDenied(userID);
+            storage.usersComputer.setDenied(userid);
             complete(onComplete);
           }
         } else {
@@ -1374,10 +1433,9 @@ BrowserID.User = (function() {
      * @method isUsersComputer
      */
     isUsersComputer: function(onComplete, onFailure) {
-      network.withContext(function() {
-        var userID = network.userid();
-        if (typeof userID !== "undefined") {
-          complete(onComplete, storage.usersComputer.confirmed(userID));
+      withContext(function() {
+        if (typeof userid !== "undefined") {
+          complete(onComplete, storage.usersComputer.confirmed(userid));
         } else {
           complete(onFailure, "user is not authenticated");
         }
@@ -1389,12 +1447,11 @@ BrowserID.User = (function() {
      * @method shouldAskIfUsersComputer
      */
     shouldAskIfUsersComputer: function(onComplete, onFailure) {
-      network.withContext(function() {
-        var userID = network.userid();
-        if (typeof userID !== "undefined") {
+      withContext(function() {
+        if (typeof userid !== "undefined") {
           // A user should never be asked if they completed an email
           // registration/validation in this dialog session.
-          var shouldAsk = storage.usersComputer.shouldAsk(userID)
+          var shouldAsk = storage.usersComputer.shouldAsk(userid)
                           && !registrationComplete;
           complete(onComplete, shouldAsk);
         } else {
@@ -1408,9 +1465,13 @@ BrowserID.User = (function() {
      * @method usedAddressAsPrimary
      */
     usedAddressAsPrimary: function(email, onComplete, onFailure) {
-      network.usedAddressAsPrimary(email, onComplete, onFailure);
+      User.checkAuthentication(function(authenticated) {
+        if (authenticated) {
+          network.usedAddressAsPrimary(email, onComplete, onFailure);
+        }
+        else complete(onFailure, "user is not authenticated");
+      }, onFailure);
     }
-
   };
 
   // Set origin to default to the current domain.  Other contexts that use user.js,

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -14,6 +14,8 @@
   storage.setDefaultValues();
 
   network.init();
+  user.init();
+
 
   // Do not check to see if cookies are supported in the iframe.  Just
   // optimistically try to work by running network requests.  There are

--- a/resources/static/dialog/js/start.js
+++ b/resources/static/dialog/js/start.js
@@ -6,6 +6,7 @@
   var bid = BrowserID,
       moduleManager = bid.module,
       modules = bid.Modules,
+      user = bid.User,
       network = bid.Network,
       mediator = bid.Mediator,
       xhr = bid.XHR;
@@ -13,6 +14,7 @@
   // A request that takes more than 10 seconds is considered delayed.
   xhr.init({ time_until_delay: 10 * 1000 });
   network.init();
+  user.init();
 
   var hash = window.location.hash || "",
       continuation = hash.indexOf("#AUTH_RETURN") > -1;

--- a/resources/static/pages/js/manage_account.js
+++ b/resources/static/pages/js/manage_account.js
@@ -8,7 +8,6 @@ BrowserID.manageAccount = (function() {
 
   var bid = BrowserID,
       user = bid.User,
-      network = bid.Network,
       errors = bid.Errors,
       dom = bid.DOM,
       storage = bid.Storage,
@@ -181,7 +180,7 @@ BrowserID.manageAccount = (function() {
   }
 
   function displayChangePassword(oncomplete) {
-    network.withContext(function(ctx) {
+    user.withContext(function(ctx) {
       dom[ctx.has_password ? "addClass" : "removeClass"]("body", "canSetPassword");
       complete(oncomplete);
     });

--- a/resources/static/pages/js/signin.js
+++ b/resources/static/pages/js/signin.js
@@ -8,7 +8,6 @@ BrowserID.signIn = (function() {
   var bid = BrowserID,
       dom = bid.DOM,
       user = bid.User,
-      network = bid.Network,
       helpers = bid.Helpers,
       errors = bid.Errors,
       pageHelpers = bid.PageHelpers,
@@ -36,7 +35,7 @@ BrowserID.signIn = (function() {
     // primary user who is authenticated with the primary.
     user.provisionPrimaryUser(email, info, function(status, provInfo) {
       if (status === "primary.verified") {
-        network.authenticateWithAssertion(email, provInfo.assertion, function(status) {
+        user.authenticateWithAssertion(email, provInfo.assertion, function(status) {
           userAuthenticated();
           complete(callback);
         }, pageHelpers.getFailure(errors.authenticateWithAssertion, callback));

--- a/resources/static/pages/js/start.js
+++ b/resources/static/pages/js/start.js
@@ -71,6 +71,7 @@ $(function() {
 
   xhr.init({ time_until_delay: 10 * 1000 });
   network.init();
+  user.init();
 
   $(".display_always,.display_auth,.display_nonauth").hide();
 

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -123,7 +123,7 @@
           var data = JSON.parse(req.data);
           equal("pass" in data, false, "password not sent in request if not needed");
 
-          ok(registered);
+          ok(registered.success);
           start();
         }, testHelpers.unexpectedFailure);
       });
@@ -140,7 +140,7 @@
     verificationPasswordRequired: function(verificationMethod) {
       asyncTest(verificationMethod + " with valid token, password required", function() {
         network[verificationMethod]("token", "password", function(registered) {
-          ok(registered);
+          ok(registered.success);
           start();
         }, testHelpers.unexpectedFailure);
       });
@@ -150,7 +150,7 @@
         transport.useResult("invalid");
 
         network[verificationMethod]("token", "password", function(registered) {
-          equal(registered, false);
+          equal(registered.success, false);
           start();
         }, testHelpers.unexpectedFailure);
       });
@@ -187,7 +187,7 @@
         transport.useResult("pending");
 
         network[checkMethod]("registered@testuser.com", function(status) {
-          equal(status, "pending");
+          equal(status.status, "pending");
           start();
         }, testHelpers.unexpectedFailure);
       });
@@ -200,7 +200,7 @@
         network.checkAuth(function(auth_status) {
           equal(!!auth_status, false, "user not yet authenticated");
           network[checkMethod]("registered@testuser.com", function(status) {
-            equal(status, "mustAuth");
+            equal(status.status, "mustAuth");
             network.checkAuth(function(auth_status) {
               equal(!!auth_status, false, "user not yet authenticated");
               start();
@@ -215,7 +215,7 @@
         network.withContext(function() {
           transport.useResult("complete");
           network[checkMethod]("registered@testuser.com", function(status) {
-            equal(status, "complete");
+            equal(status.status, "complete");
             start();
           }, testHelpers.unexpectedFailure);
         });
@@ -238,16 +238,16 @@
 
 
   asyncTest("authenticate with valid user", function() {
-    network.authenticate(TEST_EMAIL, "testuser", function onSuccess(authenticated) {
-      equal(authenticated, true, "valid authentication");
+    network.authenticate(TEST_EMAIL, "testuser", function onSuccess(status) {
+      equal(status.success, true, "valid authentication");
       start();
     }, testHelpers.unexpectedXHRFailure);
   });
 
   asyncTest("authenticate with invalid user", function() {
     transport.useResult("invalid");
-    network.authenticate(TEST_EMAIL, "invalid", function onSuccess(authenticated) {
-      equal(authenticated, false, "invalid authentication");
+    network.authenticate(TEST_EMAIL, "invalid", function onSuccess(status) {
+      equal(status.success, false, "invalid authentication");
       start();
     }, testHelpers.unexpectedXHRFailure);
   });
@@ -258,7 +258,7 @@
 
   asyncTest("authenticateWithAssertion with valid email/assertioni, returns true status", function() {
     network.authenticateWithAssertion(TEST_EMAIL, "test_assertion", function(status) {
-      equal(status, true, "user authenticated, status set to true");
+      equal(status.success, true, "user authenticated, status set to true");
       start();
     }, testHelpers.unexpectedXHRFailure);
   });
@@ -267,7 +267,7 @@
     transport.useResult("invalid");
 
     network.authenticateWithAssertion(TEST_EMAIL, "test_assertion", function(status) {
-      equal(status, false, "user not authenticated, status set to false");
+      equal(status.success, false, "user not authenticated, status set to false");
       start();
     }, testHelpers.unexpectedXHRFailure);
   });
@@ -567,7 +567,7 @@
 
   asyncTest("changePassword happy case, expect complete callback with true status", function() {
     network.changePassword("oldpassword", "newpassword", function onComplete(status) {
-      equal(status, true, "calls onComplete with true status");
+      equal(status.success, true, "calls onComplete with true status");
       start();
     }, testHelpers.unexpectedFailure);
   });
@@ -576,7 +576,7 @@
     transport.useResult("incorrectPassword");
 
     network.changePassword("oldpassword", "newpassword", function onComplete(status) {
-      equal(status, false, "calls onComplete with false status");
+      equal(status.success, false, "calls onComplete with false status");
       start();
     }, testHelpers.unexpectedFailure);
   });
@@ -634,11 +634,6 @@
     }, testHelpers.unexpectedXHRFailure);
   });
 
-  asyncTest("prolongSession with unauthenticated user - call failure", function() {
-    transport.useResult("unauthenticated");
-    network.prolongSession(testHelpers.unexpectedSuccess, testHelpers.expectedXHRFailure);
-  });
-
   asyncTest("prolongSession with XHR Failure - call failure", function() {
     transport.useResult("ajaxError");
     network.prolongSession(testHelpers.unexpectedSuccess, testHelpers.expectedXHRFailure);
@@ -666,12 +661,6 @@
         start();
       }, testHelpers.unexpectedXHRFailure);
     });
-  });
-
-  asyncTest("usedAddressAsPrimary success - call success", function () {
-    network.usedAddressAsPrimary(TEST_EMAIL,
-                                 testHelpers.unexpectedSuccess,
-                                 testHelpers.expectedXHRFailure);
   });
 
   asyncTest("usedAddressAsPrimary success - call no-op", function () {

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -7,13 +7,14 @@
   var bid = BrowserID,
       mediator = bid.Mediator,
       transport = bid.Mocks.xhr,
+      user = bid.User,
+      network = bid.Network,
       testHelpers = bid.TestHelpers,
       TEST_EMAIL = "testuser@testuser.com",
       TEST_PASSWORD = "password",
       failureCheck = testHelpers.failureCheck,
       testObjectValuesEqual = testHelpers.testObjectValuesEqual;
 
-  var network = BrowserID.Network;
 
   module("common/js/network", {
     setup: function() {
@@ -197,11 +198,11 @@
       asyncTest(checkMethod + " mustAuth", function() {
         transport.useResult("mustAuth");
 
-        network.checkAuth(function(auth_status) {
+        user.checkAuthentication(function(auth_status) {
           equal(!!auth_status, false, "user not yet authenticated");
           network[checkMethod]("registered@testuser.com", function(status) {
             equal(status.status, "mustAuth");
-            network.checkAuth(function(auth_status) {
+            user.checkAuthentication(function(auth_status) {
               equal(!!auth_status, false, "user not yet authenticated");
               start();
             }, testHelpers.unexpectedFailure);
@@ -275,84 +276,6 @@
   asyncTest("authenticateWithAssertion with XHR failure", function() {
     failureCheck(network.authenticateWithAssertion, TEST_EMAIL, "test_assertion");
   });
-
-  asyncTest("checkAuth: simulate a delayed request - xhr_delay and xhr_complete both triggered", function() {
-    transport.setContextInfo("auth_level", "assertion");
-    transport.setDelay(200);
-    network.init({
-      time_until_delay: 100
-    });
-
-    var delayInfo;
-    mediator.subscribe("xhr_delay", function(msg, delay_info) {
-      delayInfo = delay_info;
-    });
-
-    var completeInfo;
-    mediator.subscribe("xhr_complete", function(msg, complete_info) {
-      completeInfo = complete_info;
-    });
-
-    network.checkAuth(function onSuccess(authenticated) {
-      equal(authenticated, "assertion", "we have an authentication");
-      equal(delayInfo.network.url, "/wsapi/session_context", "delay info correct");
-      equal(completeInfo.network.url, "/wsapi/session_context", "complete info correct");
-      start();
-    }, testHelpers.unexpectedXHRFailure);
-  });
-
-  asyncTest("checkAuth: immediate success return - no xhr_delay triggered", function() {
-    transport.setContextInfo("auth_level", "assertion");
-
-    transport.setDelay(50);
-    network.init({
-      time_until_delay: 100
-    });
-
-    mediator.subscribe("xhr_delay", function(msg, delay_info) {
-      ok(false, "unexpected call to xhr_delay");
-    });
-
-    network.checkAuth(function onSuccess(authenticated) {
-      // a wait to happen to give xhr_delay a chance to return
-      setTimeout(start, 150);
-    }, testHelpers.unexpectedXHRFailure);
-  });
-
-  asyncTest("checkAuth with valid authentication", function() {
-    transport.setContextInfo("auth_level", "assertion");
-    network.checkAuth(function onSuccess(authenticated) {
-      // a wait to happen to give xhr_delay a chance to return
-      equal(authenticated, "assertion", "we have an authentication");
-      start();
-    }, testHelpers.unexpectedXHRFailure);
-  });
-
-  asyncTest("checkAuth with invalid authentication", function() {
-    transport.useResult("invalid");
-    transport.setContextInfo("auth_level", undefined);
-
-    network.checkAuth(function onSuccess(authenticated) {
-      equal(authenticated, undefined, "we are not authenticated");
-      start();
-    }, testHelpers.unexpectedXHRFailure);
-  });
-
-
-
-  asyncTest("checkAuth with XHR failure", function() {
-    transport.useResult("ajaxError");
-    transport.setContextInfo("auth_level", undefined);
-
-    // Do not convert this to failureCheck, we do this manually because
-    // checkAuth does not make an XHR request.  Since it does not make an XHR
-    // request, we do not test whether the app is notified of an XHR failure
-    network.checkAuth(function onSuccess() {
-      ok(true, "checkAuth does not make an ajax call, all good");
-      start();
-    }, testHelpers.unexpectedFailure);
-  });
-
 
   asyncTest("logout", function() {
     network.logout(function onSuccess() {

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -31,6 +31,8 @@
   module("common/js/user", {
     setup: function() {
       testHelpers.setup();
+      xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
     },
     teardown: function() {
       testHelpers.teardown();
@@ -155,6 +157,7 @@
   }
 
   function testAddressVerificationPoll(authLevel, xhrResultName, pollFuncName, expectedResult) {
+    lib.clearContext();
     storage.setReturnTo(testOrigin);
     xhr.useResult(xhrResultName);
 
@@ -1223,7 +1226,7 @@
 
   asyncTest("setComputerOwnershipStatus with true, isUsersComputer - mark the computer as the users, prolongs the user's session", function() {
     lib.authenticate(TEST_EMAIL, "password", function() {
-      storage.usersComputer.clear(network.userid());
+      storage.usersComputer.clear(lib.userid());
       lib.setComputerOwnershipStatus(true, function() {
         lib.isUsersComputer(function(usersComputer) {
           equal(usersComputer, true, "user is marked as owner of computer");
@@ -1235,7 +1238,7 @@
 
   asyncTest("setComputerOwnershipStatus with false, isUsersComputer - mark the computer as not the users", function() {
     lib.authenticate(TEST_EMAIL, "password", function() {
-      storage.usersComputer.clear(network.userid());
+      storage.usersComputer.clear(lib.userid());
       lib.setComputerOwnershipStatus(false, function() {
         lib.isUsersComputer(function(usersComputer) {
           equal(usersComputer, false, "user is marked as not an owner");
@@ -1246,6 +1249,8 @@
   });
 
   asyncTest("setComputerOwnershipStatus with unauthenticated user - call onFailure", function() {
+    xhr.setContextInfo("auth_status", false);
+    xhr.setContextInfo("userid", undefined);
     lib.setComputerOwnershipStatus(false,
       testHelpers.unexpectedSuccess,
       testHelpers.expectedXHRFailure
@@ -1264,7 +1269,7 @@
 
   asyncTest("shouldAskIfUsersComputer with user who has been asked - call onSuccess with false", function() {
     lib.authenticate(TEST_EMAIL, "password", function() {
-      storage.usersComputer.setConfirmed(network.userid());
+      storage.usersComputer.setConfirmed(lib.userid());
       lib.shouldAskIfUsersComputer(function(shouldAsk) {
         equal(shouldAsk, false, "user has been asked already, do not ask again");
         start();
@@ -1274,7 +1279,7 @@
 
   asyncTest("shouldAskIfUsersComputer with user who has not been asked and has not verified email this dialog session - call onSuccess with true", function() {
     lib.authenticate(TEST_EMAIL, "password", function() {
-      storage.usersComputer.forceAsk(network.userid());
+      storage.usersComputer.forceAsk(lib.userid());
       lib.shouldAskIfUsersComputer(function(shouldAsk) {
         equal(shouldAsk, true, "user has not verified an email this dialog session and should be asked");
         start();
@@ -1288,7 +1293,7 @@
       xhr.useResult("complete");
 
       lib.waitForEmailValidation(TEST_EMAIL, function() {
-        storage.usersComputer.forceAsk(network.userid());
+        storage.usersComputer.forceAsk(lib.userid());
         lib.shouldAskIfUsersComputer(function(shouldAsk) {
           equal(shouldAsk, false, "user has verified an email this dialog session and should be asked");
           start();
@@ -1317,4 +1322,30 @@
       }, testHelpers.unexpectedXHRFailure);
     });
   });
+
+  asyncTest("changePassword success - user's auth_level updated to password", function() {
+    xhr.setContextInfo("auth_level", "assertion");
+    lib.changePassword("oldpassword", "newpassword", function(changed) {
+      equal(change, true);
+      lib.checkAuthentication(function(auth_level) {
+        equal(auth_level, "password");
+        start();
+      }, testHelpers.unexpectedXHRFailure);
+    }, testHelpers.unexpectedXHRFailure);
+    start();
+  });
+
+  asyncTest("changePassword with incorrect password - user's auth_level not updated", function() {
+    xhr.setContextInfo("auth_level", "assertion");
+    xhr.useResult("incorrectPassword");
+    lib.changePassword("oldpassword", "newpassword", function(changed) {
+      equal(change, false);
+      lib.checkAuthentication(function(auth_level) {
+        equal(auth_level, "assertion");
+        start();
+      }, testHelpers.unexpectedXHRFailure);
+    }, testHelpers.unexpectedXHRFailure);
+    start();
+  });
+
 }());

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -512,7 +512,7 @@
     provisioning.setStatus(provisioning.AUTHENTICATED);
     lib.createPrimaryUser({email: "unregistered@testuser.com"}, function(status) {
       equal(status, "primary.verified", "primary user is already verified, correct status");
-      network.checkAuth(function(authenticated) {
+      lib.checkAuthentication(function(authenticated) {
         equal(authenticated, "assertion", "after provisioning user, user should be automatically authenticated to Persona");
         start();
       });
@@ -1326,26 +1326,24 @@
   asyncTest("changePassword success - user's auth_level updated to password", function() {
     xhr.setContextInfo("auth_level", "assertion");
     lib.changePassword("oldpassword", "newpassword", function(changed) {
-      equal(change, true);
+      equal(changed, true);
       lib.checkAuthentication(function(auth_level) {
         equal(auth_level, "password");
         start();
       }, testHelpers.unexpectedXHRFailure);
     }, testHelpers.unexpectedXHRFailure);
-    start();
   });
 
   asyncTest("changePassword with incorrect password - user's auth_level not updated", function() {
     xhr.setContextInfo("auth_level", "assertion");
     xhr.useResult("incorrectPassword");
     lib.changePassword("oldpassword", "newpassword", function(changed) {
-      equal(change, false);
+      equal(changed, false);
       lib.checkAuthentication(function(auth_level) {
         equal(auth_level, "assertion");
         start();
       }, testHelpers.unexpectedXHRFailure);
     }, testHelpers.unexpectedXHRFailure);
-    start();
   });
 
 }());

--- a/resources/static/test/cases/dialog/js/misc/helpers.js
+++ b/resources/static/test/cases/dialog/js/misc/helpers.js
@@ -38,6 +38,8 @@
       user.init({
         provisioning: provisioning
       });
+      xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
     },
 
     teardown: function() {

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -116,14 +116,14 @@
     machine.start({controller: actions});
   }
 
-  function setContextInfo(auth_status) {
+  function setContextInfo(auth_level) {
     // Make sure there is context info for network.
     var serverTime = (new Date().getTime()) - 10;
     mediator.publish("context_info", {
       server_time: serverTime,
       domain_key_creation_time: serverTime,
       code_version: "ABCDEF",
-      auth_status: auth_status || "password",
+      auth_level: auth_level || "password",
       userid: 1,
       random_seed: "ABCDEFGH"
     });
@@ -397,7 +397,7 @@
 
   asyncTest("email_valid_and_ready, need to ask user whether it's their computer - redirect to is_this_your_computer", function() {
     setContextInfo("password");
-    storage.usersComputer.forceAsk(network.userid());
+    storage.usersComputer.forceAsk(user.userid());
     mediator.subscribe("is_this_your_computer", function() {
       ok(true, "redirect to is_this_your_computer");
       start();

--- a/resources/static/test/cases/dialog/js/modules/is_this_your_computer.js
+++ b/resources/static/test/cases/dialog/js/modules/is_this_your_computer.js
@@ -18,6 +18,8 @@
   module("dialog/js/modules/is_this_your_computer", {
     setup: function() {
       testHelpers.setup();
+      xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
     },
 
     teardown: function() {

--- a/resources/static/test/cases/dialog/js/modules/pick_email.js
+++ b/resources/static/test/cases/dialog/js/modules/pick_email.js
@@ -30,6 +30,8 @@
   module("dialog/js/modules/pick_email", {
     setup: function() {
       testHelpers.setup();
+      xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
     },
 
     teardown: function() {

--- a/resources/static/test/cases/dialog/js/modules/primary_user_provisioned.js
+++ b/resources/static/test/cases/dialog/js/modules/primary_user_provisioned.js
@@ -8,7 +8,6 @@
       bid = BrowserID,
       storage = bid.Storage,
       user = bid.User,
-      network = bid.Network,
       testHelpers = bid.TestHelpers,
       register = testHelpers.register,
       xhr = bid.Mocks.xhr,
@@ -83,7 +82,7 @@
 
   asyncTest("start controller with `add: false` authenticates user", function() {
     register("primary_user_ready", function(msg, info) {
-      network.checkAuth(function(status) {
+      user.checkAuthentication(function(status) {
         equal(status, "assertion", "status is correct");
         start();
       });

--- a/resources/static/test/cases/pages/js/manage_account.js
+++ b/resources/static/test/cases/pages/js/manage_account.js
@@ -24,6 +24,8 @@
       testHelpers.setup();
       bid.Renderer.render("#page_head", "site/index", {});
       xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
+      xhr.setContextInfo("has_password", true);
       mocks.document.location = "";
     },
     teardown: function() {
@@ -44,7 +46,7 @@
       equal($("#old_password").val(), "", "old_password field is cleared");
       equal($("#new_password").val(), "", "new_password field is cleared");
       testHelpers.testTooltipNotVisible();
-      network.checkAuth(function(authLevel) {
+      user.checkAuthentication(function(authLevel) {
         equal(authLevel, "password", "after password change, user authenticated to password level");
         start();
       }, testHelpers.unexpectedXHRFailure);
@@ -261,7 +263,6 @@
   });
 
   asyncTest("changePassword with user authenticated to password level, incorrect old password - tooltip", function() {
-    xhr.setContextInfo("auth_level", "password");
     testPasswordChangeFailure("incorrectpassword", "newpassword", "incorrect old password, expected failure", "incorrectPassword");
   });
 
@@ -272,8 +273,6 @@
   });
 
   asyncTest("changePassword with user authenticated to password level, happy case", function() {
-    xhr.setContextInfo("auth_level", "password");
-
     testPasswordChangeSuccess("oldpassword", "newpassword", "proper completion, no need to authenticate");
   });
 

--- a/resources/static/test/cases/pages/js/signin.js
+++ b/resources/static/test/cases/pages/js/signin.js
@@ -5,7 +5,6 @@
   "use strict";
 
   var bid = BrowserID,
-      network = bid.Network,
       user = bid.User,
       xhr = bid.Mocks.xhr,
       WinChanMock = bid.Mocks.WinChan,
@@ -213,7 +212,7 @@
     $("#email").val("registered@testuser.com");
 
     controller.emailSubmit(function() {
-      network.checkAuth(function(status) {
+      user.checkAuthentication(function(status) {
         equal(status, "assertion", "user is authenticated with an assertion");
         equal(docMock.location, "/", "user signed in, page redirected");
         start();
@@ -357,7 +356,7 @@
         user.resetCaches();
 
         controller.primaryAuthComplete(null, "yar", function() {
-          network.checkAuth(function(status) {
+          user.checkAuthentication(function(status) {
             equal(status, "assertion", "user is authenticated with an assertion");
             equal(docMock.location, "/", "user signed in, page redirected");
             start();

--- a/resources/static/test/mocks/xhr.js
+++ b/resources/static/test/mocks/xhr.js
@@ -280,6 +280,10 @@ BrowserID.Mocks.xhr = (function() {
         response(request.success);
       }
       else if (!(typeofResponse === "number" || typeofResponse === "undefined")) {
+        if (typeofResponse === "object") {
+          response = _.extend({}, response);
+        }
+
         if (request.success) {
           if (delay) {
             // simulate response delay


### PR DESCRIPTION
It always frustrated me that so much user related context bled into network.js This is an effort to clean that up by moving a lot of the user related context from network.js into user.js This allowed a lot of simplification to occur of many network calls because there is only one place to take care of user related stuff.

Many direct calls to network.js were removed and replaced with equivalent calls to user.js. user.js should be the one low level interface to rule them all. This lays the groundwork for a future simplification of context by moving it into its own module.

Note, no Selenium tests were modified in this. They all continue to pass.
