### PR TITLE
Add separate selenium config for local runs, including multiple FF channels. Fixes #3118, #3138.

### DIFF
--- a/automation-tests/config/local-platforms.js
+++ b/automation-tests/config/local-platforms.js
@@ -11,6 +11,16 @@ const platforms = {
     browserName: 'firefox',
     version: ''
   },
+  /* if you wish to add a second firefox, give it a unique name and specify
+     the path to the binary, which will vary across systems.
+
+  "firefox-nightly": {
+    platform: 'ANY',
+    browserName: 'firefox',
+    version: '',
+    firefox_binary: '/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin'
+  },
+  */
   "chrome": {
     platform: 'ANY',
     browserName: 'chrome',

--- a/automation-tests/config/local-platforms.js
+++ b/automation-tests/config/local-platforms.js
@@ -1,0 +1,43 @@
+//
+// By default, we assume local platforms just have default locations.
+//
+// You must have installed ChromeDriver to use Chrome.
+// Ditto for all Webdrivers except Firefox.
+// see the Webdriver wiki for more: https://code.google.com/p/selenium/w/list
+//
+const platforms = {
+  "firefox": {
+    platform: 'ANY',
+    browserName: 'firefox',
+    version: ''
+  },
+  "chrome": {
+    platform: 'ANY',
+    browserName: 'chrome',
+    version: ''
+  },
+  "opera": {
+    platform: 'ANY',
+    browserName: 'opera',
+    version: ''
+  },
+  "safari": {
+    platform: 'ANY',
+    browserName: 'safari',
+    version: ''
+  },
+  "ie": {
+    platform: 'ANY',
+    browserName: 'internet explorer',
+    version: ''
+  }
+};
+
+// see https://code.google.com/p/selenium/wiki/DesiredCapabilities for other opts
+const defaultCapabilities = {
+  javascriptEnabled: true
+};
+
+exports.platforms = platforms;
+exports.defaultCapabilities = defaultCapabilities;
+exports.defaultPlatform = "firefox";

--- a/automation-tests/config/local-platforms.js
+++ b/automation-tests/config/local-platforms.js
@@ -13,6 +13,8 @@ const platforms = {
   },
   /* if you wish to add a second firefox, give it a unique name and specify
      the path to the binary, which will vary across systems.
+     --> This won't work for other browsers, only FF.
+     --> The example shows a Mac path, but you could insert a Linux or Win path too.
 
   "firefox-nightly": {
     platform: 'ANY',

--- a/automation-tests/scripts/run-all.js
+++ b/automation-tests/scripts/run-all.js
@@ -14,7 +14,8 @@
  * should be tested.
  */
 
-const sauce_platforms = require('../config/sauce-platforms');
+const sauce_platforms = require('../config/sauce-platforms'),
+  local_platforms = require('../config/local-platforms');
 
 const outputFormats = ["console", "json", "xunit"];
 
@@ -62,10 +63,14 @@ if (args.h) {
   process.exit(0);
 }
 
+// switch between sauce and local platform list depending on results of
+// parsing args.local or seeing PERSONA_NO_SAUCE in env vars
+var config_platforms = process.env.PERSONA_NO_SAUCE ? local_platforms : sauce_platforms;
+
 // optimist only runs "check" if an option is defined. Since we are checking if
 // an option is not defined, its check has to be outside of the option.
-if (!args.platform && !process.env.PERSONA_NO_SAUCE) {
-  args.platform = process.env.PERSONA_BROWSER || sauce_platforms.defaultPlatform;
+if (!args.platform) {
+  args.platform = process.env.PERSONA_BROWSER || config_platforms.defaultPlatform;
 }
 // all is a supported alias "match everything"
 if (args.platform === 'all') args.platform = "*";
@@ -86,7 +91,7 @@ const path = require('path'),
       vows_path = path.join(__dirname, "../node_modules/.bin/vows"),
       vows_args = [(args.output === 'xunit') ? "--xunit" : "--json", "-i"],
       result_extension = process.env.RESULT_EXTENSION || "xml",
-      supported_platforms = sauce_platforms.platforms,
+      supported_platforms = config_platforms.platforms,
       start_time = new Date().getTime(),
       glob = require('minimatch');
 


### PR DESCRIPTION
Selecting the --local option, or setting PERSONA_NO_SAUCE=1 in the
  environment, will now switch to a different config file. The set of
  supported platforms will be totally generic.

Example:

``` bash
]$ ./scripts/run-all.js --local --list-platforms
5 platforms configured:
  * firefox
  * chrome
  * opera
  * safari
  * ie
]$ ./scripts/run-all.js --list-platforms
9 platforms configured:
  * win7_firefox_16
  * linux_firefox_16
  * osx_firefox_14
  * win7_chrome
  * winxp_ie_8
  * win7_ie_9
  * win8_ie_10
  * linux_opera_12
  * osx_safari_5
```

Updated to include an example of how to specify an additional firefox platform locally. Specifying multiple channels for chrome is a bit tougher--I couldn't figure out the syntax in 30 min of twiddling--but we really only need multiple firefoxen to close out the bug :-)
