### PR TITLE
Dynamically shrink footer text to fit on one line.

### DIFF
--- a/resources/static/dialog/js/misc/screen_size_hacks.js
+++ b/resources/static/dialog/js/misc/screen_size_hacks.js
@@ -118,6 +118,18 @@
         boundingRectEl.css("top", favIconHeight + "px");
     }
 
+    // this can be used to keep the footer text on one line, #3129.
+    function resizeFooterText(cb) {
+      function shrinkFooter() {
+        var footerText = $('#footerText');
+        if (footerText.width() < $('footer').width()) return;
+        var newFontSize = parseInt(footerText.css('fontSize'), 10) - 1 + 'px';
+        footerText.css('fontSize', newFontSize);
+        setTimeout(shrinkFooter); // let UI loop run before measuring again
+      }
+      shrinkFooter();
+    }
+
     // The mobile breakpoint is 640px in the CSS.  If the max-width is changed
     // there, it must be changed here as well.
     if($(window).width() > 640) {
@@ -126,7 +138,7 @@
     else {
       mobileHacks();
     }
-
+    resizeFooterText();
     scrollableEl.css("position", "");
   }
 

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -48,7 +48,7 @@
       </div>
 
       <footer>
-<%- format(gettext('<strong>Persona.</strong> Simplified sign-in, built by a non-profit. <a %s>Learn more&rarr;</a>'), [" href='/about' target='_blank'"]) %>
+<span id="footerText"><%- format(gettext('<strong>Persona.</strong> Simplified sign-in, built by a non-profit. <a %s>Learn more&rarr;</a>'), [" href='/about' target='_blank'"]) %></span>
       </footer>
 
 


### PR DESCRIPTION
Fixes #3129--now updated. @shane-tomlinson, mind taking another look?

orig description:

Not done yet--I'm not quite sure where I can plug this into the dialog startup flow such that it **always** runs when the dialog loads, but is in run in a context where we can loop with setTimeout (so that the UI can redraw the footer text between measurements).

@shane-tomlinson any thoughts on a good place to put this code?

here's a fiddle showing the resize thingy in action: http://jsfiddle.net/vFM2v/
