### PR TITLE
Simplify the storage.js interface

### DIFF
--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1374,7 +1374,7 @@ BrowserID.User = (function() {
       //      might have fewer race conditions and do fewer network requests.
       User.checkAuthenticationAndSync(function(authenticated) {
         if (authenticated) {
-          var loggedInEmail = storage.getLoggedIn(origin);
+          var loggedInEmail = storage.site.get(origin, "logged_in");
           if (loggedInEmail !== siteSpecifiedEmail) {
             if (loggedInEmail) {
               User.getAssertion(loggedInEmail, origin, function(assertion) {
@@ -1403,7 +1403,7 @@ BrowserID.User = (function() {
     logout: function(onComplete, onFailure) {
       User.checkAuthentication(function(authenticated) {
         if (authenticated) {
-          storage.setLoggedIn(origin, false);
+          storage.site.remove(origin, "logged_in");
         }
 
         if (onComplete) {

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -104,7 +104,7 @@
     // logout have been called before. This allows the user to be force logged
     // out.
     if (loggedInUser !== null) {
-      storage.setLoggedIn(remoteOrigin, false);
+      storage.site.remove(remoteOrigin, "logged_in");
       loggedInUser = null;
       chan.notify({ method: 'logout' });
     }

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -477,7 +477,7 @@ BrowserID.State = (function() {
     handleState("assertion_generated", function(msg, info) {
       self.success = true;
       if (info.assertion !== null) {
-        storage.setLoggedIn(user.getOrigin(), self.email);
+        storage.site.set(user.getOrigin(), "logged_in", self.email);
 
         startAction("doAssertionGenerated", { assertion: info.assertion, email: self.email });
       }

--- a/resources/static/dialog/js/modules/generate_assertion.js
+++ b/resources/static/dialog/js/modules/generate_assertion.js
@@ -20,8 +20,6 @@ BrowserID.Modules.GenerateAssertion = (function() {
       }
 
       dialogHelpers.getAssertion.call(self, email, options.ready);
-      // TODO, this is not needed here, it is done in the state machine.
-      storage.setLoggedIn(user.getOrigin(), options.email);
       sc.start.call(self, options);
     }
   });

--- a/resources/static/pages/js/page_helpers.js
+++ b/resources/static/pages/js/page_helpers.js
@@ -13,18 +13,20 @@ BrowserID.PageHelpers = (function() {
       helpers = bid.Helpers,
       dom = bid.DOM,
       ANIMATION_SPEED = 250,
-      origStoredEmail;
+      origStoredEmail,
+      origin = "https://login.persona.org",
+      storageKey = "sign_in_email";
 
   function setStoredEmail(email) {
-    storage.signInEmail.set(email);
+    storage.site.set(origin, storageKey, email);
   }
 
   function clearStoredEmail() {
-    storage.signInEmail.remove();
+    storage.site.remove(origin, storageKey);
   }
 
   function getStoredEmail() {
-    return storage.signInEmail.get() || "";
+    return storage.site.get(origin, storageKey) || "";
   }
 
   function onEmailChange(event) {

--- a/resources/static/pages/js/reset_password.js
+++ b/resources/static/pages/js/reset_password.js
@@ -78,7 +78,8 @@ BrowserID.resetPassword = (function() {
             // closes the dialog OR if redirection happens before the dialog
             // has had a chance to finish its business.
             /*jshint newcap:false*/
-            storage.setLoggedIn(URLParse(self.redirectTo).originOnly(), self.email);
+            storage.site.set(URLParse(self.redirectTo).originOnly(),
+                "logged_in", self.email);
 
             countdownTimeout.call(self, function() {
               self.doc.location = self.redirectTo;

--- a/resources/static/pages/js/verify_secondary_address.js
+++ b/resources/static/pages/js/verify_secondary_address.js
@@ -74,7 +74,8 @@ BrowserID.verifySecondaryAddress = (function() {
             // closes the dialog OR if redirection happens before the dialog
             // has had a chance to finish its business.
             /*jshint newcap:false*/
-            storage.setLoggedIn(URLParse(self.redirectTo).originOnly(), self.email);
+            storage.site.set(URLParse(self.redirectTo).originOnly(),
+                "logged_in", self.email);
 
             countdownTimeout.call(self, function() {
               self.doc.location = self.redirectTo;

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -160,24 +160,17 @@
     equal(storage.getReturnTo(), "http://some.domain/path", "setReturnTo/getReturnTo working as expected");
   });
 
-  test("signInEmail.set/.get/.remove - set, get, and remove the signInEmail", function() {
-    storage.signInEmail.set("testuser@testuser.com");
-    equal(storage.signInEmail.get(), "testuser@testuser.com", "correct email gotten");
-    storage.signInEmail.remove();
-    equal(typeof storage.signInEmail.get(), "undefined", "after remove, signInEmail is empty");
-  });
-
-  test("setLoggedIn, getLoggedIn, loggedInCount", function() {
+  test("site.set->logged_in, site.get->logged_in, loggedInCount", function() {
     var email = "testuser@testuser.com";
     storage.addEmail(email, {});
-    storage.setLoggedIn(TEST_ORIGIN, email);
-    equal(storage.getLoggedIn(TEST_ORIGIN), email, "correct email");
-    storage.setLoggedIn("http://another.domain", email);
+    storage.site.set(TEST_ORIGIN, "logged_in", email);
+    storage.site.set("http://another.domain", "logged_in", email);
+
     equal(storage.loggedInCount(), 2, "correct logged in count");
 
     storage.removeEmail(email);
     equal(storage.loggedInCount(), 0, "after email removed, not logged in anywhere");
-    testHelpers.testUndefined(storage.getLoggedIn(TEST_ORIGIN), "sites with email no longer logged in");
+    testHelpers.testUndefined(storage.site.get(TEST_ORIGIN, "logged_in"), "sites with email no longer logged in");
   });
 
 }());

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -1058,7 +1058,7 @@
     xhr.setContextInfo("auth_level", "password");
 
     lib.syncEmailKeypair(LOGGED_IN_EMAIL, function() {
-      storage.setLoggedIn(lib.getOrigin(), LOGGED_IN_EMAIL);
+      storage.site.set(lib.getOrigin(), "logged_in", LOGGED_IN_EMAIL);
       lib.getSilentAssertion(LOGGED_IN_EMAIL, function(email, assertion) {
         equal(email, LOGGED_IN_EMAIL, "correct email");
         strictEqual(assertion, null, "correct assertion");
@@ -1073,7 +1073,7 @@
     var REQUESTED_EMAIL = "requested@testuser.com";
 
     lib.syncEmailKeypair(LOGGED_IN_EMAIL, function() {
-      storage.setLoggedIn(lib.getOrigin(), LOGGED_IN_EMAIL);
+      storage.site.set(lib.getOrigin(), "logged_in", LOGGED_IN_EMAIL);
       lib.getSilentAssertion(REQUESTED_EMAIL, function(email, assertion) {
         equal(email, LOGGED_IN_EMAIL, "correct email");
         testAssertion(assertion, start);

--- a/resources/static/test/cases/dialog/js/misc/internal_api.js
+++ b/resources/static/test/cases/dialog/js/misc/internal_api.js
@@ -95,7 +95,7 @@
   asyncTest("get with silent: true, authenticated user, no requiredEmail, email address associated with site, XHR failure - return null assertion.", function() {
     user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
       user.syncEmails(function() {
-        storage.setLoggedIn(ORIGIN, "email", TEST_EMAIL);
+        storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
 
         xhr.useResult("invalid");
 
@@ -194,16 +194,16 @@
   asyncTest("logout of authenticated user logs the user out of origin", function() {
     user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
       // simulate multiple origin->email associations.
-      storage.setLoggedIn(ORIGIN, "email", TEST_EMAIL);
-      storage.setLoggedIn(ORIGIN + "2", "email", TEST_EMAIL);
+      storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
+      storage.site.set(ORIGIN + "2", "logged_in", TEST_EMAIL);
 
       internal.logout(ORIGIN, function(success) {
         equal(success, true, "user has been successfully logged out");
 
         // with logout, only the association specified for the origin is
         // cleared.
-        testUndefined(storage.getLoggedIn(ORIGIN, "email"));
-        testNotUndefined(storage.getLoggedIn(ORIGIN + "2", "email"));
+        testUndefined(storage.site.get(ORIGIN, "logged_in"));
+        testNotUndefined(storage.site.get(ORIGIN + "2", "logged_in"));
 
         start();
       });
@@ -220,14 +220,14 @@
   asyncTest("logoutEverywhere of authenticated user logs the user out everywhere", function() {
     user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
       // simulate multiple origin->email associations.
-      storage.setLoggedIn(ORIGIN, "email", TEST_EMAIL);
-      storage.setLoggedIn(ORIGIN + "2", "email", TEST_EMAIL);
+      storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
+      storage.site.set(ORIGIN + "2", "logged_in", TEST_EMAIL);
 
       internal.logoutEverywhere(function(success) {
         equal(success, true, "user has been successfully logged out everywhere");
         // with logoutEverywhere, both associations should be cleared.
-        testUndefined(storage.getLoggedIn(ORIGIN, "email"));
-        testUndefined(storage.getLoggedIn(ORIGIN + "2", "email"));
+        testUndefined(storage.site.get(ORIGIN, "logged_in"));
+        testUndefined(storage.site.get(ORIGIN + "2", "logged_in"));
 
         start();
       });

--- a/resources/static/test/cases/pages/js/reset_password.js
+++ b/resources/static/test/cases/pages/js/reset_password.js
@@ -107,7 +107,7 @@
       testHasClass("body", "complete");
       testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
       testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
-      equal(storage.getLoggedIn("https://test.domain"), "testuser@testuser.com", "logged in status set");
+      equal(storage.site.get("https://test.domain", "logged_in"), "testuser@testuser.com", "logged in status set");
       start();
     });
   });

--- a/resources/static/test/cases/pages/js/verify_secondary_address.js
+++ b/resources/static/test/cases/pages/js/verify_secondary_address.js
@@ -89,7 +89,7 @@
       testHasClass("body", "complete");
       testElementTextEquals(".website", returnTo, "origin is set to redirect to login.persona.org");
       testDocumentRedirected(doc, returnTo, "redirection occurred to correct URL");
-      equal(storage.getLoggedIn("https://test.domain"), "testuser@testuser.com", "logged in status set");
+      equal(storage.site.get("https://test.domain", "logged_in"), "testuser@testuser.com", "logged in status set");
       start();
     });
   });


### PR DESCRIPTION
- Remove setLoggedIn and getLoggedIn
- Remove signInEmail namespace

Data is now handled by the storage.site.set/get functions with approprite namespace keys. This is to make where this info is stored consistent with other site specific info.
