### PR TITLE
undo PR 3085 in train-2013.03.29

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -24,12 +24,3 @@ function node(script) {
 }
 
 node('./generate_ephemeral_keys.js');
-
-console.log(">>> Installing automation-tests dependencies");
-// install automation-test dependencies
-var npm_process = child_process.spawn('npm', ['install'], {
-  cwd: path.join(__dirname, '..', 'automation-tests'),
-  env: process.env
-});
-npm_process.stdout.pipe(process.stdout);
-npm_process.stderr.pipe(process.stderr);


### PR DESCRIPTION
i.e., shipping a build that claims to fail is bad karma. So don't automatically try to `npm install browserid/automation-tests`
