### PR TITLE
Issue 3148 xhr polling

### DIFF
--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -317,8 +317,11 @@
 
       // new page
       createController(false);
+
       // make user authenticated
       xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
+
       network.withContext(function() {
         var request = xhr.getLastRequest('/wsapi/interaction_data');
         var data = JSON.parse(request.data).data[0];
@@ -377,8 +380,11 @@
 
       // new page
       createController(false);
+
       // make user authenticated
       xhr.setContextInfo("auth_level", "password");
+      xhr.setContextInfo("userid", 1);
+
       network.withContext(function() {
         var request = xhr.getLastRequest('/wsapi/interaction_data');
         var data = JSON.parse(request.data).data[0];
@@ -459,6 +465,25 @@
     var event = eventStream[index];
     var newOffset = event[1];
     ok(newOffset >= 1000, "event's offset has been updated (orig-new): " + origOffset + "-" + newOffset);
+
+    start();
+  });
+
+  asyncTest("GET data stripped from xhr_complete messages", function() {
+    createController();
+
+    controller.addEvent("xhr_complete", {
+      network: {
+        type: "GET",
+        url: "/wsapi/user_creation_status?email=testuser@testuser.com"
+      }
+    });
+
+    var eventStream = controller.getCurrentEventStream();
+    var xhrEvent = eventStream[eventStream.length - 1];
+
+    // Is GET data stripped?
+    equal(xhrEvent[0], "xhr_complete.GET/wsapi/user_creation_status");
 
     start();
   });

--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -488,4 +488,41 @@
     start();
   });
 
+  asyncTest("Consecutive xhr_complete messages for the same URL only have one entry", function() {
+    createController();
+
+    var REPEAT_COUNT = 5;
+
+    controller.addEvent("xhr_complete", {
+      network: {
+        type: "GET",
+        url: "/wsapi/session_context",
+        duration: 13
+      }
+    });
+
+    for(var i = 0; i < REPEAT_COUNT; i++) {
+      controller.addEvent("xhr_complete", {
+        network: {
+          type: "GET",
+          url: "/wsapi/user_creation_status?email=testuser@testuser.com",
+          duration: 6
+        }
+      });
+    }
+
+    var eventStream = controller.getCurrentEventStream();
+    // Were consecutive XHR events of the same URL prevented?
+    equal(eventStream.length, 2);
+
+    var firstEvent = eventStream[0];
+    var secondEvent = eventStream[1];
+
+    equal(firstEvent[0], "xhr_complete.GET/wsapi/session_context");
+    equal(secondEvent[0], "xhr_complete.GET/wsapi/user_creation_status");
+    equal(secondEvent[controller.REPEAT_COUNT_INDEX], REPEAT_COUNT);
+
+    start();
+  });
+
 }());


### PR DESCRIPTION
@jrgm and @kparlante - could you review this?

There are two commits, the first is a test for the change that @ozten did a little while ago to strip GET data from the submitted URL.

The second is to consolidate consecutive XHR requests to the same URL into one entry.

@kparlante - when the event starts with xhr_complete, there may be a 4th item in the event's array - the number of consecutive times the xhr event was called. If the URL was only called once, the count is omitted.

fixes #3148 
