### PR TITLE
Remove the wait message when generating an assertion that caused IE8/9 ugliness.

### DIFF
--- a/resources/static/common/js/wait-messages.js
+++ b/resources/static/common/js/wait-messages.js
@@ -10,11 +10,6 @@ BrowserID.Wait = (function(){
       message:  gettext("In just a moment you'll be signed into Persona.")
     },
 
-    generateKey: {
-      title:  gettext("Finishing Sign In..."),
-      message:  gettext("Please wait a few seconds while we sign you into the site.")
-    },
-
     slowXHR: {
       title:  gettext("We are sorry, this is taking longer than it should."),
       message:  gettext("If this doesn't resolve itself within a few seconds, please close the window and try again."),

--- a/resources/static/dialog/js/misc/helpers.js
+++ b/resources/static/dialog/js/misc/helpers.js
@@ -46,8 +46,6 @@
     var self=this,
         wait = bid.Screens.wait;
 
-    wait.show("wait", bid.Wait.generateKey);
-
     user.getAssertion(email, user.getOrigin(), function(assert) {
       assert = assert || null;
       wait.hide();


### PR DESCRIPTION
@seanmonstar, could you review this?

We originally put the wait message in because the keys used to generate the assertion were very long. We have since shortened the key length to a point where assertion generation is fast on even mobile devices.

Removing the screen.

fixes #2618
