### PR TITLE
Fix button width in "Is this your computer" not keeping up with screen resize.

### DIFF
--- a/resources/static/common/js/dom-helpers.js
+++ b/resources/static/common/js/dom-helpers.js
@@ -13,7 +13,7 @@ BrowserID.DOMHelpers = (function() {
     // widest, and then go from there.
     els.css({
       "min-width": "0px",
-      "width": null
+      "width": ""
     });
 
     els.each(function(index, element) {

--- a/resources/static/test/cases/common/js/dom-helpers.js
+++ b/resources/static/test/cases/common/js/dom-helpers.js
@@ -16,11 +16,20 @@
   test("makeEqualWidth", function() {
     bid.Renderer.render("#page_head", "is_this_your_computer", {});
 
+    // Ensure old width is removed before calculating the natural width of the
+    // element. Check by setting the width of one of the elements manually and
+    // then see if it is removed later. See issue #2066
+    $("#your_computer_content button").eq(0).css({"width": "4000px"});
+
     domHelpers.makeEqualWidth("#your_computer_content button");
 
     var lastWidth;
     $("#your_computer_content button").each(function(index, element) {
       var currWidth = $(element).outerWidth();
+
+      // make sure the impossibly large width was removed.
+      ok(parseInt(currWidth, 10) !== 4000);
+
       if (lastWidth) {
         equal(currWidth, lastWidth, "button widths are the same");
       }


### PR DESCRIPTION
jQuery changed the way to remove a manually set CSS style. We did not keep up when we updated jQuery. Now we do.

fixes #2066
