### PR TITLE
Prevent .onmatch from being called if an assertion is generated in the dialog.

### DIFF
--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -117,11 +117,13 @@
     pause = true;
   });
 
-  chan.bind("dialog_complete", function(trans, params) {
+  chan.bind("dialog_complete", function(trans, checkAuthStatus) {
     pause = false;
-    // the dialog running can change authentication status,
-    // lets manually purge our network cache
-    network.clearContext();
-    checkAndEmit();
+    if (checkAuthStatus) {
+      // the dialog running can change authentication status,
+      // lets manually purge our network cache
+      user.clearContext();
+      checkAndEmit();
+    }
   });
 }());

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -396,7 +396,10 @@
           if (!err && r && r.email) {
             commChan.notify({ method: 'loggedInUser', params: r.email });
           }
-          commChan.notify({ method: 'dialog_complete' });
+          // do not check the authentication status in the dialog if an
+          // assertion has been generated. onmatch is incorrectly called
+          // if an assertion has already been generated. See #3170
+          commChan.notify({ method: 'dialog_complete', params: !r.assertion });
         }
 
         // clear the window handle


### PR DESCRIPTION
@lloyd - I would love to pow-wow on this. My "fix" is any time an assertion is generated by the dialog, do not then attempt to generate an assertion in the communication_iframe.

I am not convinced this is correct, but the behavior has survived IE8 with every combination of primary/secondary, single or multiple browsers that I could think of.

issue #3170
