### PR TITLE
Fix the ugly npm install errors.

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -25,11 +25,15 @@ function node(script) {
 
 node('./generate_ephemeral_keys.js');
 
-console.log(">>> Installing automation-tests dependencies");
-// install automation-test dependencies
-var npm_process = child_process.spawn('npm', ['install'], {
-  cwd: path.join(__dirname, '..', 'automation-tests'),
-  env: process.env
-});
-npm_process.stdout.pipe(process.stdout);
-npm_process.stderr.pipe(process.stderr);
+// To install the automation-tests dependencies, specify AUTOMATION_TESTS=true
+// on the command line when running npm install. See issue  #3160
+if (process.env.AUTOMATION_TESTS) {
+  console.log(">>> Installing automation-tests dependencies");
+  // install automation-test dependencies
+  var npm_process = child_process.spawn('npm', ['install'], {
+    cwd: path.join(__dirname, '..', 'automation-tests'),
+    env: process.env
+  });
+  npm_process.stdout.pipe(process.stdout);
+  npm_process.stderr.pipe(process.stderr);
+}


### PR DESCRIPTION
Here you go @jrgm and @jbonacci 

Only install the automation-tests deps if AUTOMATION_TESTS=true is defined on the command line.

fixes #3160
