### PR TITLE
Add tabindex attributes to the TOS/PP links.

### DIFF
--- a/resources/static/dialog/views/rp_info.ejs
+++ b/resources/static/dialog/views/rp_info.ejs
@@ -21,8 +21,8 @@
   <p id="rptospp" class="tospp">
     <%- format(gettext("By proceeding, you agree to %(site)s's <a %(terms)s>Terms</a> and <a %(privacy)s>Privacy Policy</a>."),
                {
-                 terms: 'href="' + termsOfService + '" id="rp_tos" target="_blank"',
-                 privacy: 'href="' + privacyPolicy + '" id="rp_pp" target="_blank"',
+                 terms: 'href="' + termsOfService + '" id="rp_tos" target="_blank" tabindex="10"',
+                 privacy: 'href="' + privacyPolicy + '" id="rp_pp" target="_blank" tabindex="10"',
                  site: siteName || hostname
                })
     %>

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -72,8 +72,10 @@
                     <p class="submit tospp">
                        <%- format(gettext("By proceeding, you agree to %(site)s's <a %(terms)s>Terms</a> and <a %(privacy)s>Privacy Policy</a>."),
                                   { site: "Persona",
-                                    terms: 'href="https://login.persona.org/tos" target="_new"',
-                                    privacy: 'href="https://login.persona.org/privacy" target="_new"' }) %>
+                                    terms:
+                                        'href="https://login.persona.org/tos" target="_new" tabindex="1"',
+                                    privacy:
+                                        'href="https://login.persona.org/privacy" target="_new" tabindex="1"' }) %>
                     </p>
 
 


### PR DESCRIPTION
Allows users to tab directly from the email/password field to the submit button.

fixes #3082
