### PR TITLE
Force focus of either a button or an input if available when any screen is shown.

### DIFF
--- a/resources/static/common/js/lib/dom-jquery.js
+++ b/resources/static/common/js/lib/dom-jquery.js
@@ -322,7 +322,22 @@ BrowserID.DOM = ( function() {
          * @param {selelector || element} elementToFocus
          */
         focus: function( elementToFocus ) {
-          jQuery( elementToFocus ).focus();
+          try {
+            jQuery( elementToFocus ).focus();
+          } catch(e) {
+            // IE8 is awesome and can except if an element it doesn't believe
+            // can be focused is attempted to be focused.
+            if (window.console) window.console.log(String(e));
+          }
+        },
+
+        /**
+         * Blur an element
+         * @method blur
+         * @param {selelector || element} elementToBlur
+         */
+        blur: function( elementToBlur ) {
+          jQuery( elementToBlur ).blur();
         },
 
         /**

--- a/resources/static/common/js/modules/page_module.js
+++ b/resources/static/common/js/modules/page_module.js
@@ -59,11 +59,6 @@ BrowserID.Modules.PageModule = (function() {
 
       screens.form.show(template, data);
       self.hideWarningScreens();
-      dom.focus("input:visible:not(:disabled):eq(0)");
-      // XXX jQuery.  bleck.
-      if($("*:focus").length === 0) {
-        dom.focus("button:visible:eq(0)");
-      }
     },
 
     // the wait, error and delay screens make up the warning screens.

--- a/resources/static/common/js/screens.js
+++ b/resources/static/common/js/screens.js
@@ -11,13 +11,34 @@ BrowserID.Screens = (function() {
       BODY = "body";
 
   function Screen(target, className) {
+    target = target + " .contents";
     return {
       show: function(template, vars) {
         var self=this;
 
-        renderer.render(target + " .contents", template, vars);
+        renderer.render(target, template, vars);
         dom.addClass(BODY, className);
         dom.fireEvent(window, "resize");
+
+        /* First, try focusing the first visible button.
+         * Then, try to focus an input. If there is no input,
+         * then no action will be taken and the button will
+         * remain focused.
+         */
+
+        var buttons = dom.getDescendentElements(
+                          "button:visible:not(:disabled)", target);
+        var inputs = dom.getDescendentElements(
+                          "input:visible:not(:disabled)", target);
+
+        if (inputs.length) {
+          dom.blur("*:focus");
+          dom.focus(inputs.get(0));
+        }
+        else if (buttons.length) {
+          dom.blur("*:focus");
+          dom.focus(buttons.get(0));
+        }
 
         // extendedInfo takes care of info that is on a screen but hidden by
         // default.  When the user clicks the "open extended info" button, it

--- a/resources/static/dialog/js/modules/is_this_your_computer.js
+++ b/resources/static/dialog/js/modules/is_this_your_computer.js
@@ -20,10 +20,6 @@ BrowserID.Modules.IsThisYourComputer = (function() {
 
       self.renderWait("is_this_your_computer", options);
 
-      // renderWait does not automatically focus the first input element or
-      // button, so it must be done manually.
-      dom.focus("#this_is_my_computer");
-
       self.click("#this_is_my_computer", self.yes);
       self.click("#this_is_not_my_computer", self.no);
 

--- a/resources/static/test/cases/common/js/modules/page_module.js
+++ b/resources/static/test/cases/common/js/modules/page_module.js
@@ -21,7 +21,8 @@
       WAIT_CONTENTS_SELECTOR = "#wait .contents",
       WAIT_SHOWN_SELECTOR = "body.waiting",
       BODY_SELECTOR = "body",
-      FIRST_INPUT_SELECTOR = "input:visible:eq(0)",
+      FIRST_INPUT_SELECTOR = FORM_CONTENTS_SELECTOR + " input:visible",
+      FIRST_BUTTON_SELECTOR = FORM_CONTENTS_SELECTOR + " button:visible",
       mediator = bid.Mediator;
 
   function testRenderMessagingScreen(renderer, contentEl) {
@@ -63,17 +64,23 @@
     equal(html, "", "with no template specified, no text is loaded");
   });
 
-  test("renderForm with template with input element - render the correct dialog, focus first input element", function() {
+  test("renderForm with template with input element and button - render the correct dialog, focus first input element", function() {
     createController();
 
-    controller.renderForm("test_template_with_input", {
-      title: "Test title",
-      message: "Test message"
-    });
+    controller.renderForm("test_template_with_input", {});
 
     var html = el.find(FORM_CONTENTS_SELECTOR).html();
     ok(html.length, "with template specified, form text is loaded");
     testElementFocused(FIRST_INPUT_SELECTOR);
+  });
+
+  test("renderForm with template with button only - focus the button", function() {
+    createController();
+
+    controller.renderForm("test_template_no_input", {});
+
+    var html = el.find(FORM_CONTENTS_SELECTOR).html();
+    testElementFocused(FIRST_BUTTON_SELECTOR);
   });
 
   test("renderError renders an error screen", function() {

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -320,12 +320,15 @@ BrowserID.TestHelpers = (function() {
         ok(true, msg || selector + " is focused");
       }
       else {
+        $(focusedEl).blur();
         // In some environments such as PhantomJS, input elements cannot be
         // checked for focus.  Make a temporary input element which we can
         // check to see if it is possible to focus. If it is possible, this is
         // a failure.  If it is not possible, print a message and continue.
         // Remove the element when complete.
-        var input = $("<input type='radio' />").appendTo("body").focus();
+        var input = $("<input type='radio' />");
+        input.appendTo("body")
+        input.focus();
         if (input.is(":focus")) {
           ok(false, msg || selector + " is focused");
           // refocus the original input element.


### PR DESCRIPTION
If a button or input box is not available on a screen, no change from the current behavior.

fixes #2981
