### PR TITLE
Improve readability of nav links in the header nav

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -527,13 +527,16 @@ header .nav a {
   font-size: 16px;
   padding: 4px 8px;
   color: #fff;
-  text-shadow: 0 1px 0 #999;
+  text-shadow: 0 1px 0 #333;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .5);
 }
 
 header .nav a:hover {
   color: #383838;
   background-color: #f4f3f0;
   border-radius: 3px;
+  text-shadow: 0 1px 0 #fff;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, .5);
 }
 
 header ul {


### PR DESCRIPTION
Might be just me, but I'm thinking this increases readability of top navigation links by quite a bit.
### Regular before

![Screen Shot 2013-04-10 at 19 28 29](https://f.cloud.github.com/assets/380/363464/6ff62ab2-a204-11e2-8e01-e324c3135351.png)
### Regular after

![Screen Shot 2013-04-10 at 19 28 53](https://f.cloud.github.com/assets/380/363465/700fa50a-a204-11e2-98a9-cb98469e9340.png)
### Hover before

![Screen Shot 2013-04-10 at 19 29 47](https://f.cloud.github.com/assets/380/363466/7029640e-a204-11e2-809d-31ab94d2c645.png)
### Hover after

![Screen Shot 2013-04-10 at 19 30 05](https://f.cloud.github.com/assets/380/363467/70354f80-a204-11e2-926a-892db425ea22.png)
