### PR TITLE
Remove no op code from email

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -31,32 +31,29 @@ if (smtp_params && smtp_params.host) {
 
 const TEMPLATE_PATH = path.join(__dirname, "..", "resources", "email_templates");
 
-// the underbar decorator to allow getext to extract strings
-function _(str) { return str; }
-
 // a map of all the different emails we send
 const templates = {
   "new": {
     landing: 'verify_email_address',
-    subject: _("Confirm email address for Persona"),
+    subject: "Confirm email address for Persona",
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'new.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'new.html.ejs'))
   },
   "reset": {
     landing: 'reset_password',
-    subject: _("Reset Persona password"),
+    subject: "Reset Persona password",
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'reset.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'reset.html.ejs'))
   },
   "confirm": {
     landing: 'confirm',
-    subject: _("Confirm email address for Persona"),
+    subject: "Confirm email address for Persona",
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.html.ejs'))
   },
   "transition": {
     landing: 'complete_transition',
-    subject: _("Confirm email address for Persona"),
+    subject: "Confirm email address for Persona",
     template: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.ejs')),
     templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.html.ejs'))
   },


### PR DESCRIPTION
I don't believe the `_` function does anything here.

This removes this no op codepath.
