### PR TITLE
Add two margins.

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -121,6 +121,7 @@ input[type=password] {
     width: 100%;
     color: #383838;
     font-size: 13px;
+    margin-top: 6px;
     padding: 5px;
     border-width: 1px;
     border-style: solid;

--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -417,6 +417,7 @@ a.emphasize {
   border-radius: 2px;
   color: #484848;
   font-size: 11px;
+  margin-bottom: 6px;
   padding: 0 5px;
   display: inline-block;
   line-height: 22px;


### PR DESCRIPTION
@skinny97214 had me add these margins yesterday. Submitting a PR today.
- Add a top margin to "Add another address" and "this is not me" for non-english speakers when the buttons spread across two lines.
- Add a top margin to all email, text, and password fields.

fixes #3250

The fix looks like:

![Screen Shot 2013-04-16 at 21 30 05](https://f.cloud.github.com/assets/848085/388226/967c39b8-a6d4-11e2-8b75-09dc6a7109e7.png)
