### PR TITLE
Prefetch dialog resources in the communication_iframe

### DIFF
--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -4,6 +4,15 @@
 <head><title>non-interactive iframe</title>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
+  <%- cachify(util.format('/production/%s/dialog.js', locale), {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/production/dialog.css', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/grain.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/dialog/i/persona-logo-transparent.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/dialog/i/arrow_grey.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-loader.gif', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow-hover.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify('/common/i/button-arrow-active.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
   <%- cachify_js('/production/communication_iframe.js') %>
 </head>
 <body></body>

--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -4,6 +4,7 @@
 <head><title>non-interactive iframe</title>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
+  <% if (production) { %>
   <%- cachify_prefetch(util.format('/production/%s/dialog.js', locale)) %>
   <%- cachify_prefetch(util.format('/production/%s/dialog.css', locale)) %>
   <%- cachify_prefetch('/common/i/grain.png') %>
@@ -13,6 +14,7 @@
   <%- cachify_prefetch('/common/i/button-arrow.png') %>
   <%- cachify_prefetch('/common/i/button-arrow-hover.png') %>
   <%- cachify_prefetch('/common/i/button-arrow-active.png') %>
+  <% } %>
   <%- cachify_js('/production/communication_iframe.js') %>
 </head>
 <body></body>

--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -4,15 +4,15 @@
 <head><title>non-interactive iframe</title>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
-  <%- cachify(util.format('/production/%s/dialog.js', locale), {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/production/dialog.css', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/common/i/grain.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/dialog/i/persona-logo-transparent.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/dialog/i/arrow_grey.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/common/i/button-loader.gif', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/common/i/button-arrow.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/common/i/button-arrow-hover.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
-  <%- cachify('/common/i/button-arrow-active.png', {tag_format: '<link rel="prefetch" href="%s">'}) %>
+  <%- cachify_prefetch(util.format('/production/%s/dialog.js', locale)) %>
+  <%- cachify_prefetch('/production/dialog.css') %>
+  <%- cachify_prefetch('/common/i/grain.png') %>
+  <%- cachify_prefetch('/dialog/i/persona-logo-transparent.png') %>
+  <%- cachify_prefetch('/dialog/i/arrow_grey.png') %>
+  <%- cachify_prefetch('/common/i/button-loader.gif') %>
+  <%- cachify_prefetch('/common/i/button-arrow.png') %>
+  <%- cachify_prefetch('/common/i/button-arrow-hover.png') %>
+  <%- cachify_prefetch('/common/i/button-arrow-active.png') %>
   <%- cachify_js('/production/communication_iframe.js') %>
 </head>
 <body></body>

--- a/resources/views/communication_iframe.ejs
+++ b/resources/views/communication_iframe.ejs
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <meta charset="utf-8">
   <%- cachify_prefetch(util.format('/production/%s/dialog.js', locale)) %>
-  <%- cachify_prefetch('/production/dialog.css') %>
+  <%- cachify_prefetch(util.format('/production/%s/dialog.css', locale)) %>
   <%- cachify_prefetch('/common/i/grain.png') %>
   <%- cachify_prefetch('/dialog/i/persona-logo-transparent.png') %>
   <%- cachify_prefetch('/dialog/i/arrow_grey.png') %>


### PR DESCRIPTION
Take advantage of the fact that we open a communication iframe to specify a list of dialog resources that could be prefetched by the browser.

Note that these prefetch lines are only suggestions only and the browser is free to ignore them (Chrome on Android has an "only prefetch on wifi" preference for example). However when prefetch happens, the dialog opens up instantly because all of its resources are already in the cache.

See http://feeding.cloud.geek.nz/posts/prefetching-resources-to-prime-browser/ for the background behind this patch.
