### PR TITLE
Don't attempt to append to doc.head. Fixes #3287

### DIFF
--- a/resources/static/common/js/crypto-loader.js
+++ b/resources/static/common/js/crypto-loader.js
@@ -18,7 +18,8 @@ BrowserID.CryptoLoader = (function() {
   function addScript(src) {
     var script = document.createElement("script");
     script.setAttribute("src", src);
-    document.head.appendChild(script);
+    var entryPoint = document.getElementsByTagName("script")[0];
+    entryPoint.parentNode.insertBefore(script, entry);
   }
 
   function waitUntilExists(checkFor, context, done) {

--- a/resources/static/common/js/crypto-loader.js
+++ b/resources/static/common/js/crypto-loader.js
@@ -19,7 +19,7 @@ BrowserID.CryptoLoader = (function() {
     var script = document.createElement("script");
     script.setAttribute("src", src);
     var entryPoint = document.getElementsByTagName("script")[0];
-    entryPoint.parentNode.insertBefore(script, entry);
+    entryPoint.parentNode.insertBefore(script, entryPoint);
   }
 
   function waitUntilExists(checkFor, context, done) {


### PR DESCRIPTION
Attempting to append the dynamically-created script tag to document.head
    doesn't always work. In our case, it isn't working in IE8. Instead, we
    use an entry point that's guaranteed to exist, by finding the 0th script
    tag on the page. There must be at least one script tag, since the script
    itself is somehow running :-)
