### PR TITLE
Make shim popup minimzable. Fixes #3211

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -131,7 +131,7 @@
 
     var windowOpenOpts =
       (isFennec ? undefined :
-       "menubar=0,location=1,resizable=1,scrollbars=1,status=0,dialog=1,minimizable=1,width=700,height=375");
+       "menubar=0,location=1,resizable=1,scrollbars=1,status=0,width=700,height=375");
 
     var w;
 


### PR DESCRIPTION
AFAICT, the `dialog` and `minimizable` options are weird, Firefox-specific things that clearly are not working as intended.
