### PR TITLE
renderError will publish an error_screen event

### DIFF
--- a/resources/static/common/js/lib/tinyscore.js
+++ b/resources/static/common/js/lib/tinyscore.js
@@ -58,6 +58,14 @@
       return -1;
     },
 
+    keyOf: function(obj, value) {
+      for (var key in obj) {
+        if (obj[key] === value) {
+          return key;
+        }
+      }
+    },
+
     size: function(obj) {
       return _.isArray(obj) ? obj.length : _.keys(obj).length;
     },

--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -29,6 +29,7 @@ BrowserID.Modules.InteractionData = (function() {
       model = bid.Models.InteractionData,
       user = bid.User,
       storage = bid.Storage,
+      errors = bid.Errors,
       complete = bid.Helpers.complete,
       dom = bid.DOM,
       REPEAT_COUNT_INDEX = 3,
@@ -40,6 +41,20 @@ BrowserID.Modules.InteractionData = (function() {
     } else {
       return 'xhr.malformed_report';
     }
+  }
+
+  function parseErrorScreen(msg, data) {
+    var parts = [];
+
+    if (data.action) {
+      parts.push(_.keyOf(errors, data.action));
+    }
+
+    if (data.network && data.network.status > 399) {
+      parts.push(data.network.status);
+    }
+
+    return 'screen.error.' + parts.join('.');
   }
 
   /**
@@ -102,7 +117,8 @@ BrowserID.Modules.InteractionData = (function() {
     password_submit: "authenticate.password_submitted",
     authentication_success: "authenticate.password_success",
     authentication_fail: "authenticate.password_fail",
-    xhr_complete: removeGetData
+    xhr_complete: removeGetData,
+    error_screen: parseErrorScreen
   };
 
   function getKPIName(msg, data) {

--- a/resources/static/common/js/modules/page_module.js
+++ b/resources/static/common/js/modules/page_module.js
@@ -70,7 +70,10 @@ BrowserID.Modules.PageModule = (function() {
     renderWait: showScreen.curry(screens.wait),
     hideWait: hideScreen.curry(screens.wait),
 
-    renderError: showScreen.curry(screens.error),
+    renderError: function(template, info, oncomplete) {
+      this.publish('error_screen', info);
+      return showScreen.call(this, screens.error, template, info, oncomplete);
+    },
     hideError: hideScreen.curry(screens.error),
 
     renderDelay: showScreen.curry(screens.delay),

--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -8,6 +8,7 @@
       testHelpers = bid.TestHelpers,
       network = bid.Network,
       storage = bid.Storage,
+      errors = bid.Errors,
       model = bid.Models.InteractionData,
       xhr = bid.Mocks.xhr,
       mediator = bid.Mediator,
@@ -486,6 +487,21 @@
     equal(xhrEvent[0], "xhr_complete.GET/wsapi/user_creation_status");
 
     start();
+  });
+
+  test("error_screen formats an error object", function() {
+    createController();
+    controller.addEvent("error_screen", {
+      action: errors.addressInfo,
+      network: {
+        status: 503
+      }
+    });
+
+    var eventStream = controller.getCurrentEventStream();
+    var errorEvent = eventStream.pop();
+
+    equal(errorEvent[0], "screen.error.addressInfo.503");
   });
 
   asyncTest("Consecutive xhr_complete messages for the same URL only have one entry", function() {

--- a/resources/static/test/cases/common/js/modules/page_module.js
+++ b/resources/static/test/cases/common/js/modules/page_module.js
@@ -80,6 +80,16 @@
     testRenderMessagingScreen("renderError", ERROR_CONTENTS_SELECTOR);
   });
 
+  test("renderError publishes an error_screen event", function() {
+    createController();
+    mediator.subscribe("error_screen", function(msg, data) {
+      equal(msg, 'error_screen', 'error_screen event triggered');
+      equal(data.foo, 'bar', 'passed error object');
+    });
+
+    controller.renderError("error", { foo: 'bar' });
+  });
+
   test("renderDelay renders a delay screen", function() {
     testRenderMessagingScreen("renderDelay", DELAY_CONTENTS_SELECTOR);
   });


### PR DESCRIPTION
These events are stored in the event stream. This will allow us to see when a user drops out of the dialog because they ran into an error screen.

example: screen.error.relaySetup

fixes #3302
