### PR TITLE
WinChan detects if window gets closed

### DIFF
--- a/resources/static/include_js/_winchan.js
+++ b/resources/static/include_js/_winchan.js
@@ -37,7 +37,7 @@
         var userAgent = navigator.userAgent;
         return (userAgent.indexOf('Fennec/') != -1) ||  // XUL
                (userAgent.indexOf('Firefox/') != -1 && userAgent.indexOf('Android') != -1);   // Java
-      } catch(e) {};
+      } catch(e) {}
       return false;
     }
 
@@ -132,12 +132,26 @@
 
           if (!messageTarget) messageTarget = w;
 
+          // lets listen in case the window blows up before telling us
+          var closeInterval = setInterval(function() {
+            if (w && w.closed) {
+              cleanup();
+              if (cb) {
+                cb('unknown closed window');
+                cb = null;
+              }
+            }
+          }, 500);
+
           var req = JSON.stringify({a: 'request', d: opts.params});
 
           // cleanup on unload
           function cleanup() {
             if (iframe) document.body.removeChild(iframe);
             iframe = undefined;
+            if (closeInterval) closeInterval = clearInterval(closeInterval);
+            removeListener(window, 'message', onMessage);
+            removeListener(window, 'unload', cleanup);
             if (w) {
               try {
                 w.close();
@@ -157,13 +171,12 @@
               var d = JSON.parse(e.data);
               if (d.a === 'ready') messageTarget.postMessage(req, origin);
               else if (d.a === 'error') {
+                cleanup();
                 if (cb) {
                   cb(d.d);
                   cb = null;
                 }
               } else if (d.a === 'response') {
-                removeListener(window, 'message', onMessage);
-                removeListener(window, 'unload', cleanup);
                 cleanup();
                 if (cb) {
                   cb(null, d.d);
@@ -197,8 +210,6 @@
       };
     }
   })();
-
-
 
   // END WINCHAN
 


### PR DESCRIPTION
if the dialog is redirected to an IdP to do auth, and the user dismisses
the dialog then, this will let winchan detect that the dialog has been
closed. it will trigger oncancel.

fixes #1773

**Related**: This should probably be reviewed on WinChan first. If changes need to be made there, I can modify here as well. See lloyd/winchan#28 and lloyd/winchan#29
