### PR TITLE
make verifier work with app:// urls on FirefoxOS

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -48,7 +48,7 @@ var types = {
   origin: function(x) {
     /* origin regex
     /^                          // beginning
-    https?:\/\/                 // starts with http:// or https://
+    (?:https?|app):\/\/         // starts with http://, https://, or app:// (b2g desktop)
     (?=.{1,254}(?::|$))         // hostname must be within 1-254 characters
     (?:                         // match hostname part (<part>.<part>...)
       (?!-)                     // cannot start with a dash (allow it to start with a digit re issue #2042)
@@ -61,7 +61,7 @@ var types = {
     (:\d+)?                     // optional port
     $/i;                        // end; case-insensitive
     */
-    var regex = /^https?:\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
+    var regex = /^(?:https?|app):\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
     if (typeof x !== 'string' || !x.match(regex)) {
       throw new Error("not a valid origin");
     }

--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -53,7 +53,8 @@ function compareAudiences(want, got) {
     // 3. domain only 'rp.tld'
 
     // case 1 & 1a
-    if (/^https?:\/\//.test(got)) {
+    // (app:// urls are seen on FirefoxOS desktop and possibly mobile)
+    if (/^(?:https?|app):\/\//.test(got)) {
       var gu = normalizeParsedURL(url.parse(got));
       got_scheme = gu.protocol;
       got_domain = gu.hostname;

--- a/tests/verifier-test.js
+++ b/tests/verifier-test.js
@@ -61,7 +61,9 @@ suite.addBatch({
     'http://fakesite.com:8100 and http://fakesite.com:80': matchesAudience(false),
     'https://fakesite.com:9100 and https://fakesite.com:443': matchesAudience(false),
     'http://fakesite.com:80 and http://fakesite.com:8000': matchesAudience(false),
-    'https://fakesite.com:443 and https://fakesite.com:9000': matchesAudience(false)
+    'https://fakesite.com:443 and https://fakesite.com:9000': matchesAudience(false),
+
+    'app://browser.gaiamobile.org and app://browser.gaiamobile.org:80': matchesAudience(true)
   }
 });
 


### PR DESCRIPTION
The apps on FirefosOS desktop builds, and at least some of the apps on mobile, have an `app://` schema.  

This PR updates the verifier's url matcher so those apps can use persona.
