### PR TITLE
Underscore props are filtered out of b2g identity messages, alas

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -203,9 +203,9 @@ $(document).ready(function() {
       siteName: $('#siteName').attr('checked') ? "Persona Test Relying Party" : undefined,
       siteLogo: $('#siteLogo').attr('checked') ? "/i/logo.png" : undefined,
       returnTo: $('#returnTo').attr('checked') ? "/postVerificationReturn.html" : undefined,
-      _experimental_forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
-      _experimental_forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
-      _experimental_allowUnverified: $('#allowUnverified').attr('checked') ? true : false,
+      experimental_forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
+      experimental_forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
+      experimental_allowUnverified: $('#allowUnverified').attr('checked') ? true : false,
       oncancel: function() {
         loggit("oncancel");
         $(".specify button.assertion").removeAttr('disabled');

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -280,26 +280,26 @@ BrowserID.Modules.Dialog = (function() {
 
         // forceAuthentication is used by the Marketplace to ensure that the
         // user knows the password to this account. We ignore any active session.
-        if (paramsFromRP._experimental_forceAuthentication) {
+        if (paramsFromRP.experimental_forceAuthentication) {
           params.forceAuthentication = validateBoolean(
-              paramsFromRP._experimental_forceAuthentication,
-              "_experimental_forceAuthentication");
+              paramsFromRP.experimental_forceAuthentication,
+              "experimental_forceAuthentication");
         }
 
         // forceIsuser is used by the Marketplace to disable primary support
         // and replace fxos.login.persona.org as the issuer of certs
-        if (paramsFromRP._experimental_forceIssuer) {
+        if (paramsFromRP.experimental_forceIssuer) {
           params.forceIssuer =
-              fixupIssuer(paramsFromRP._experimental_forceIssuer);
+              fixupIssuer(paramsFromRP.experimental_forceIssuer);
         }
 
         // allowUnverified means that the user doesn't need to have
         // verified their email address in order to send an assertion.
         // if the user *has* verified, it will be a verified assertion.
-        if (paramsFromRP._experimental_allowUnverified) {
+        if (paramsFromRP.experimental_allowUnverified) {
           params.allowUnverified = validateBoolean(
-              paramsFromRP._experimental_allowUnverified,
-              "_experimental_allowUnverified");
+              paramsFromRP.experimental_allowUnverified,
+              "experimental_allowUnverified");
         }
 
         if (hash.indexOf("#AUTH_RETURN") === 0) {

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -535,41 +535,41 @@
     });
   });
 
-  asyncTest("_experimental_forceAuthentication", function() {
+  asyncTest("experimental_forceAuthentication", function() {
     testExpectGetSuccess(
-      {_experimental_forceAuthentication: true},
+      {experimental_forceAuthentication: true},
       {forceAuthentication: true}
     );
   });
 
-  asyncTest("_experimental_forceAuthentication invalid", function() {
+  asyncTest("experimental_forceAuthentication invalid", function() {
     testExpectGetFailure(
-      {_experimental_forceAuthentication: "true"});
+      {experimental_forceAuthentication: "true"});
   });
 
   asyncTest("get with valid issuer - allowed", function() {
     var issuer = "fxos.persona.org";
     testExpectGetSuccess(
-      { _experimental_forceIssuer: issuer },
+      { experimental_forceIssuer: issuer },
       { forceIssuer: issuer }
     );
   });
 
   asyncTest("get with non hostname issuer - bzzzt", function() {
     var issuer = "https://issuer.must.be.a.hostname";
-    testExpectGetFailure({ _experimental_forceIssuer: issuer });
+    testExpectGetFailure({ experimental_forceIssuer: issuer });
   });
 
-  asyncTest("_experimental_allowUnverified", function() {
+  asyncTest("experimental_allowUnverified", function() {
     testExpectGetSuccess(
-      {_experimental_allowUnverified: true},
+      {experimental_allowUnverified: true},
       {allowUnverified: true}
     );
   });
 
-  asyncTest("_experimental_allowUnverified invalid", function() {
+  asyncTest("experimental_allowUnverified invalid", function() {
     testExpectGetFailure(
-      {_experimental_allowUnverified: "true"});
+      {experimental_allowUnverified: "true"});
   });
 
   asyncTest("get with valid rp_api - allowed", function() {


### PR DESCRIPTION
Fixes issue #3369 
