### PR TITLE
Fix getSilentAssertion for B2G.

### DIFF
--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -226,6 +226,13 @@
 
     function checkAndEmit() {
       // this will re-certify the user if neccesary
+      // Firefox OS 1.0.1 keeps one copy of the communication iframe in memory
+      // all the time. The communication iframe gets a copy of session context
+      // when it first loads and caches it, it is never updated even if the user
+      // uses the dialog to sign in. To avoid manually updating the cache when the user
+      // signs in using the dialog, clear the cache every time a new tab
+      // requires internalWatch.
+      user.clearContext();
       user.getSilentAssertion(loggedInUser, function(email, assertion) {
         if (email) {
           // only send login events when the assertion is defined - when

--- a/resources/static/test/cases/dialog/js/misc/internal_api.js
+++ b/resources/static/test/cases/dialog/js/misc/internal_api.js
@@ -210,26 +210,28 @@
   });
 
   asyncTest(".watch - authenticated user requests an assertion with saved issuer - assertion generated with cert for that issuer", function() {
-    user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
-      storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
-      storage.site.set(ORIGIN, "email", TEST_EMAIL);
-      storage.site.set(ORIGIN, "issuer", "fxos_issuer");
+    xhr.setContextInfo("auth_level", "password");
+    xhr.setContextInfo("userid", 1);
+    storage.addEmail(TEST_EMAIL);
 
-      internal.watch(function(resp) {
-        if (resp.method === "login") {
-          ok(resp.assertion);
-        }
-        else if (resp.method === "ready") {
-          start();
-        }
-        else {
-          ok(false, "unexpected method call: " + resp.method);
-        }
-      }, {
-        origin: ORIGIN,
-        loggedInUser: "testuser2@testuser.com"
-      }, console.log);
-    });
+    storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
+    storage.site.set(ORIGIN, "email", TEST_EMAIL);
+    storage.site.set(ORIGIN, "issuer", "fxos_issuer");
+
+    internal.watch(function(resp) {
+      if (resp.method === "login") {
+        ok(resp.assertion);
+      }
+      else if (resp.method === "ready") {
+        start();
+      }
+      else {
+        ok(false, "unexpected method call: " + resp.method);
+      }
+    }, {
+      origin: ORIGIN,
+      loggedInUser: "testuser2@testuser.com"
+    }, console.log);
   });
 
 
@@ -244,53 +246,57 @@
   });
 
   asyncTest(".watch with authenticated user, no loggedInUser passed - assertion generated", function() {
-    user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
-      storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
-      storage.site.set(ORIGIN, "email", TEST_EMAIL);
-      var und;
+    xhr.setContextInfo("auth_level", "password");
+    xhr.setContextInfo("userid", 1);
+    storage.addEmail(TEST_EMAIL);
 
-      var count = 0;
-      internal.watch(function(resp) {
-        count++;
-        // login should happen before ready
-        if (resp.method === "login") {
-          equal(count, 1);
-          ok(resp.assertion);
-        }
-        else if (resp.method === "ready") {
-          equal(count, 2);
-          start();
-        }
-        else {
-          ok(false, "unexpected method call: " + resp.method);
-        }
-      }, {
-        origin: ORIGIN,
-        loggedInUser: und
-      });
+    storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
+    storage.site.set(ORIGIN, "email", TEST_EMAIL);
+    var und;
+
+    var count = 0;
+    internal.watch(function(resp) {
+      count++;
+      // login should happen before ready
+      if (resp.method === "login") {
+        equal(count, 1);
+        ok(resp.assertion);
+      }
+      else if (resp.method === "ready") {
+        equal(count, 2);
+        start();
+      }
+      else {
+        ok(false, "unexpected method call: " + resp.method);
+      }
+    }, {
+      origin: ORIGIN,
+      loggedInUser: und
     });
   });
 
   asyncTest(".watch with authenticated user, loggedInUser passed - only call with ready method", function() {
-    user.authenticate(TEST_EMAIL, TEST_PASSWORD, function() {
-      storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
-      storage.site.set(ORIGIN, "email", TEST_EMAIL);
-      var und;
+    xhr.setContextInfo("auth_level", "password");
+    xhr.setContextInfo("userid", 1);
+    storage.addEmail(TEST_EMAIL);
 
-      var count = 0;
-      internal.watch(function(resp) {
-        count++;
-        if (resp.method === "ready") {
-          equal(count, 1);
-          start();
-        }
-        else {
-          ok(false, "unexpected method call: " + resp.method);
-        }
-      }, {
-        origin: ORIGIN,
-        loggedInUser: TEST_EMAIL
-      });
+    storage.site.set(ORIGIN, "logged_in", TEST_EMAIL);
+    storage.site.set(ORIGIN, "email", TEST_EMAIL);
+    var und;
+
+    var count = 0;
+    internal.watch(function(resp) {
+      count++;
+      if (resp.method === "ready") {
+        equal(count, 1);
+        start();
+      }
+      else {
+        ok(false, "unexpected method call: " + resp.method);
+      }
+    }, {
+      origin: ORIGIN,
+      loggedInUser: TEST_EMAIL
     });
   });
 


### PR DESCRIPTION
Firefox OS 1.0.1 keeps one copy of the communication iframe around. When it loads, it fetches a copy of session context and then caches it. Whenever the user signs in to a tab, the communication iframe's session context cache is not updated. To avoid updates to B2G code, force a refresh of session context whenever calling user.getSilentAssertion.

This fixes #3380 
