### PR TITLE
Fix typo which breaks ActiveX-based XHRs (fixes #3383)

### DIFF
--- a/resources/static/common/js/lib/micrajax.js
+++ b/resources/static/common/js/lib/micrajax.js
@@ -24,7 +24,7 @@ window.Micrajax = (function() {
     }
     else if (window.ActiveXObject) {
       // ...if not, try the ActiveX control
-      xhrObject = new ActiveXObject('Microsoft.XM/LHTTP');
+      xhrObject = new ActiveXObject('Microsoft.XMLHTTP');
     }
 
     return xhrObject;


### PR DESCRIPTION
This can be tested on IE by disabling the "Enable native XMLHTTP support" setting in "Tools | Internet options | Advanced".

(I have not been able to verify it myself since I don't have an IE8 VM handy.)
