### PR TITLE
Fix for users who are unable to sign out.

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -44,6 +44,7 @@ BrowserID.Storage = (function() {
     for (var site in allInfo) {
       siteSet(site, "logged_in", allInfo[site]);
     }
+    storage.removeItem("loggedIn");
   }
   upgradeLoggedInInfo();
   // END TRANSITION CODE
@@ -595,5 +596,13 @@ BrowserID.Storage = (function() {
      * @method setDefaultValues
      */
     setDefaultValues: setDefaultValues
+    // BEGIN TRANSITION CODE
+    /**
+     * Upgrade the site->user logged in info from the loggedIn namespace to be
+     * under the site namespace.
+     */
+    ,
+    upgradeLoggedInInfo: upgradeLoggedInInfo
+    // END TRANSITION CODE
   };
 }());

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -185,6 +185,13 @@
           'testuser@testuser.com');
 
       equal(localStorage.getItem('loggedIn'), null);
+
+      try {
+        // make sure re-invoking upgrade path does not cause an error.
+        storage.upgradeLoggedInInfo();
+      } catch(e) {
+        ok(false, "unexpected error");
+      }
   });
   // END TRANSITION CODE
 

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -173,5 +173,20 @@
     testHelpers.testUndefined(storage.site.get(TEST_ORIGIN, "logged_in"), "sites with email no longer logged in");
   });
 
+  // BEGIN TRANSITION CODE
+  test("upgradeLoggedInInfo upgrades old loggedInInfo and removes namespace",
+      function() {
+      localStorage.loggedIn = JSON.stringify({
+        'testrp.com': 'testuser@testuser.com'
+      });
+
+      storage.upgradeLoggedInInfo();
+      equal(storage.site.get("testrp.com", "logged_in"),
+          'testuser@testuser.com');
+
+      equal(localStorage.getItem('loggedIn'), null);
+  });
+  // END TRANSITION CODE
+
 }());
 


### PR DESCRIPTION
@seanmonstar, @callahad, @jrgm - This is for a hotfix of prod. Review would be fantastic.

When upgrading localStorage from loggedIn to use the site namespace, I failed to remove the old loggedIn namespace, making it so users would sign out, refresh the page, and be signed in again.

fixes #3386
