### PR TITLE
Last minute firefoxos fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ train-2013.05.08:
   * Fix an issue where slow database replication could block primary logins: #3309
   * Require a password reset when too many failed password attempts are made: #2656
   * Don't reset sessions to ephemeral duration after email verification: #3336
+  * (hotfix 2013.05.14) verifier parameters for forceIssuer and allowUnverified now have an experimental_ prefix
 
 train-2013.04.26:
   * up to 25% performance improvement on mobile (delayed loading of crypto code): #3060, #3287

--- a/bin/verifier
+++ b/bin/verifier
@@ -91,8 +91,8 @@ function doVerification(req, resp, next) {
 
   var assertion = req.query.assertion ? req.query.assertion : req.body.assertion;
   var audience = req.query.audience ? req.query.audience : req.body.audience;
-  var forceIssuer = req.query.forceIssuer ? req.query.forceIssuer : req.body.forceIssuer;
-  var allowUnverified = req.query.allowUnverified ? req.query.allowUnverified : req.body.allowUnverified;
+  var forceIssuer = req.query.experimental_forceIssuer ? req.query.experimental_forceIssuer : req.body.experimental_forceIssuer;
+  var allowUnverified = req.query.experimental_allowUnverified ? req.query.experimental_allowUnverified : req.body.experimental_allowUnverified;
 
   if (!(assertion && audience)) {
     // why couldn't we extract these guys?  Is it because the request parameters weren't encoded as we expect? GH-643
@@ -170,3 +170,4 @@ var bindTo = config.get('bind_to');
 app.listen(bindTo.port, bindTo.host, function(conn) {
   logger.info("running on http://" + app.address().address + ":" + app.address().port);
 });
+ 

--- a/scripts/awsbox_remote/post_deploy.sh
+++ b/scripts/awsbox_remote/post_deploy.sh
@@ -16,5 +16,4 @@ git log --pretty=%h -1 > ../code/resources/static/ver.txt
 cd ../code
 
 echo ">> generating production resources"
-env CONFIG_FILES=config/aws.json scripts/compress
-
+scripts/compress

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2013.05.08
-Release:       1%{?dist}_%{svnrev}
+Release:       2%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries

--- a/tests/unverified-email-test.js
+++ b/tests/unverified-email-test.js
@@ -189,7 +189,7 @@ suite.addBatch({
         wsapi.post('/verify', {
           audience: UNVERIFIED_ORIGIN,
           assertion: assertion,
-          allowUnverified: true
+          experimental_allowUnverified: true
         }).call(this);
       },
       "to succeed": function (err, r) {


### PR DESCRIPTION
1. (doesn't affect production code) aws / ephemeral specific change to let us support localization in aws instances
2. update verifier to add an `experimental_` prefix to `allowUnverified` and `forceIssuer`
