### PR TITLE
Enable the spinner on mobile webkit, it works now.

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -533,26 +533,26 @@ footer .help {
 
 @-webkit-keyframes spin {
     from {
-        -webkit-transform: rotate(0turn);
+        -webkit-transform: rotate(0deg);
     }
     to {
-        -webkit-transform: rotate(1turn);
+        -webkit-transform: rotate(365deg);
     }
 }
 @-moz-keyframes spin {
     from {
-        -moz-transform: rotate(0turn);
+        -moz-transform: rotate(0deg);
     }
     to {
-        -moz-transform: rotate(1turn);
+        -moz-transform: rotate(365deg);
     }
 }
 @keyframes spin {
     from {
-        transform: rotate(0turn);
+        transform: rotate(0deg);
     }
     to {
-        transform: rotate(1turn);
+        transform: rotate(365deg);
     }
 }
 
@@ -563,9 +563,9 @@ footer .help {
     margin: 0 auto 25px;
     width: 50px;
     height: 50px;
-    -webkit-animation: 0.9s spin infinite steps(30);
-    -moz-animation: 0.9s spin infinite steps(30);
-    animation: 0.9s spin infinite steps(30);
+    -webkit-animation: 0.9s spin infinite linear;
+    -moz-animation: 0.9s spin infinite linear;
+    animation: 0.9s spin infinite linear;
 }
 
 

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -533,14 +533,6 @@
   }
 
   /**
-   * Chrome for Android 4.2.2 shows a completely white screen because of the
-   * keyframe animations on the loading spinner. Sorry mobile webkit.
-   */
-  .loadingSpinner {
-    -webkit-animation-name: none;
-  }
-
-  /**
    * The margins are too large on the desktop lightbox.
    */
   .lightbox {


### PR DESCRIPTION
Since we changed the way the spinner is animated, it no longer gives Chrome on Android a problem.

issue #3342
