### PR TITLE
Issue 3410 disable continue

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -402,6 +402,10 @@ a.secondary[disabled], .submit_disabled a.secondary, .submit_disabled a.secondar
   float: right;
 }
 
+.left {
+  float: left;
+}
+
 .center {
   text-align: center;
 }

--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -303,7 +303,11 @@ button::-moz-focus-inner, .button::-moz-focus-inner {
 /* Override all previously applied styles so that the button does not change
  * styles even if the user hovers, focuses or clicks on the button.
 */
-button[disabled], .submit_disabled button, .submit_disabled .button,
+button[disabled],
+button[disabled]:hover, .button[disabled]:hover,
+button[disabled]:focus, .button[disabled]:focus,
+button[disabled]:active, .button[disabled]:active,
+.submit_disabled button, .submit_disabled .button,
 .submit_disabled button:hover, .submit_disabled .button:hover,
 .submit_disabled button:focus, .submit_disabled .button:focus,
 .submit_disabled button:active, .submit_disabled .button:active {
@@ -320,7 +324,7 @@ button[disabled], .submit_disabled button, .submit_disabled .button,
   text-shadow: 0 1px #444, 0 0 2px #555;
   -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
   opacity: .5;
-  border-bottom: 1px solid #777;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.3), 0 1px 0 rgba(0, 0, 0, 0.2);
 }
 
 .submit_disabled .submit button, .submit_disabled .submit .button,
@@ -335,7 +339,6 @@ button[disabled], .submit_disabled button, .submit_disabled .button,
     background-image: url("/common/i/button-loader.gif#iefix"),       -o-linear-gradient(top, #4eb5e5, #3196cf);
     background-image: url("/common/i/button-loader.gif#iefix"),          linear-gradient(top, #4eb5e5, #3196cf);
     background-position: 95% center;
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.3), 0 1px 0 rgba(0, 0, 0, 0.2);
 }
 
 button.negative {

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -82,7 +82,11 @@
    * Override all the disabled styles on the buttons. The mobile button
    * has no spinner.
    */
-  button[disabled], .submit_disabled button, .submit_disabled .button,
+  button[disabled],
+  button[disabled]:hover, .button[disabled]:hover,
+  button[disabled]:focus, .button[disabled]:focus,
+  button[disabled]:active, .button[disabled]:active,
+  .submit_disabled button, .submit_disabled .button,
   .submit_disabled button:hover, .submit_disabled .button:hover,
   .submit_disabled button:focus, .submit_disabled .button:focus,
   .submit_disabled button:active, .submit_disabled .button:active,
@@ -95,6 +99,7 @@
     background: #e8e8e8;
     border: 1px solid #a1c3cc;
     box-shadow: none;
+    text-shadow: none;
   }
 
 

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -48,7 +48,7 @@
     height: 40px;
     min-width: 105px;
     font-size: 14px;
-    padding: 6px 25px 8px;
+    padding: 6px 0 8px;
     float: right;
     font-weight: 400;
     color: #414343;
@@ -134,7 +134,20 @@
   }
 
   .buttonrow > .right {
-    margin-right: 0;
+    margin: 0;
+  }
+
+  /**
+   * Oh, what hideousnous this is. All because flex box doesn't want to play
+   * nicely on B2G. The buttons are each 50% wide, but with a left margin
+   * to keep buttons separated. The margin causes buttons to overflow onto
+   * two lines. Pull the right button to the right by 10px to keep the
+   * buttons on one line. The buttonrow has its right hand padding adjusted by
+   * 10px to handle this.
+   */
+  .buttonrow > button,
+  .buttonrow > button.right {
+    margin: 0 -10px 0 10px;
   }
 
   input[type=email],
@@ -142,6 +155,14 @@
     font-size: 17px;
     padding: 11px 5px;
     border-radius: 5px;
+  }
+
+  /**
+   * Any buttons in the button row should be at minimum 50% wide. If the
+   * language causes the button to expand greater than that, great.
+   */
+  .buttonrow > button, .buttonrow > a {
+    min-width: 50%;
   }
 
   /**
@@ -176,12 +197,19 @@
   }
 
 
-  .isMobile {
+  .isMobile,
+  .returning .isReturning,
+  .start .isStart,
+  .addressInfo .isAddressInfo {
     display: block;
   }
 
-  .isDesktop, a.emphasize.isDesktop, .returning .isDesktopStart {
-    display: none;
+  /**
+   * If this is a desktop element, no way, no how should it be showing. This
+   * situation is what !important is for.
+   */
+  .isDesktop, .returning .isDesktopOrStart {
+    display: none !important;
   }
 
   /**
@@ -356,12 +384,16 @@
   /*
    * The button row should always be against the bottom border of the
    * dialog. Get rid of its margin.
+   *
+   * The 20px right hand padding is so we can place two buttons side by side at
+   * 50% and use a negative margin to keep them from scrolling over two lines.
+   * Hideous, but flex box is giving us difficulties.
    */
   #signIn .buttonrow {
     position: absolute;
     left: 0;
     right: 0;
-    padding: 20px;
+    padding: 20px 20px 20px 10px;
     background-color: #dcdcdc;
     border-top: 1px solid #bcbcbc;
     box-shadow: 0px 1px #fff inset;

--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -512,16 +512,26 @@ a.emphasize:active {
     margin: 0 0 0 5px;
 }
 
+/**
+ * Start off hiding all of the state specific elements
+ */
 .isReturning, .isStart, .isAddressInfo, .isMobile {
   display: none;
 }
 
 
+/**
+* These handle the authentication page states, but do not take into account
+* any elements that have the .isMobile class.
+*/
 .returning .isReturning, .start .isStart, .addressInfo .isAddressInfo {
   display: block;
 }
 
-.newuser {
+/**
+ * Re-disable any elements that have the .isMobile class.
+ */
+.newuser, .isReturning.isMobile, .isStart.isMobile, .isAddressInfo.isMobile {
     display: none;
 }
 

--- a/resources/static/dialog/js/modules/add_email.js
+++ b/resources/static/dialog/js/modules/add_email.js
@@ -16,7 +16,8 @@ BrowserID.Modules.AddEmail = (function() {
       ANIMATION_TIME = 250,
       BODY_SELECTOR = "body",
       EMAIL_SELECTOR = "#newEmail",
-      SUBMIT_DISABLED_CLASS = "submit_disabled";
+      SUBMIT_DISABLED_CLASS = "submit_disabled",
+      CANCEL_SELECTOR = "#cancel";
 
   function hideHint(selector) {
     $("." + selector).hide();
@@ -72,7 +73,7 @@ BrowserID.Modules.AddEmail = (function() {
       self.renderForm("add_email", options);
       hideHint("addressInfo");
 
-      self.click("#cancel", cancelAddEmail);
+      self.click(CANCEL_SELECTOR, cancelAddEmail);
       Module.sc.start.call(self, options);
     },
     submit: addEmail

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -212,6 +212,16 @@ BrowserID.Modules.Authenticate = (function() {
     var self=this;
     addressInfo = null;
 
+    // If we are signing in to the Persona main site, do not show
+    // the Persona intro that says "<site> uses Persona to sign you in!"
+    if (user.getOrigin() === PERSONA_URL) {
+      dom.hide(PERSONA_INTRO_SELECTOR);
+    }
+
+    // If we are already in the enterEmailState, skip out or else we mess with
+    // auto-completion.
+    if (self.submit === checkEmail) return;
+
     if (!dom.is(EMAIL_SELECTOR, ":disabled")) {
       self.publish("enter_email");
       dom.setInner(AUTHENTICATION_LABEL, dom.getInner(EMAIL_LABEL));
@@ -220,11 +230,6 @@ BrowserID.Modules.Authenticate = (function() {
       dom.focus(EMAIL_SELECTOR);
     }
 
-    // If we are signing in to the Persona main site, do not show
-    // the Persona intro that says "<site> uses Persona to sign you in!"
-    if (user.getOrigin() === PERSONA_URL) {
-      dom.hide(PERSONA_INTRO_SELECTOR);
-    }
   }
 
   function enterPasswordState(callback) {

--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -17,6 +17,7 @@ BrowserID.Modules.Authenticate = (function() {
       lastEmail = "",
       addressInfo,
       hints = ["returning","start","addressInfo"],
+      DISABLED_ATTRIBUTE = "disabled",
       CONTENTS_SELECTOR = "#formWrap .contents",
       AUTH_FORM_SELECTOR = "#authentication_form",
       EMAIL_SELECTOR = "#authentication_email",
@@ -25,6 +26,7 @@ BrowserID.Modules.Authenticate = (function() {
       RP_NAME_SELECTOR = "#start_rp_name",
       BODY_SELECTOR = "body",
       AUTHENTICATION_CLASS = "authentication",
+      CONTINUE_BUTTON_SELECTOR = ".continue",
       FORM_CLASS = "form",
       AUTHENTICATION_LABEL = "#authentication_form label[for=authentication_email]",
       ENTER_EMAIL_LABEL = "#authentication_form .label.enter_email",
@@ -76,9 +78,8 @@ BrowserID.Modules.Authenticate = (function() {
         self = this;
     if (!email) return;
 
-    dom.setAttr(EMAIL_SELECTOR, 'disabled', 'disabled');
+    dom.setAttr(EMAIL_SELECTOR, DISABLED_ATTRIBUTE, DISABLED_ATTRIBUTE);
     dom.addClass(BODY_SELECTOR, "submit_disabled");
-
     if (info && info.type) {
       onAddressInfo(info);
     }
@@ -94,7 +95,7 @@ BrowserID.Modules.Authenticate = (function() {
 
     function onAddressInfo(info) {
       addressInfo = info;
-      dom.removeAttr(EMAIL_SELECTOR, 'disabled');
+      dom.removeAttr(EMAIL_SELECTOR, DISABLED_ATTRIBUTE);
 
       self.hideLoad();
 
@@ -271,6 +272,18 @@ BrowserID.Modules.Authenticate = (function() {
       lastEmail = newEmail;
       enterEmailState.call(this);
     }
+
+    /**
+     * The continue button is only available on mobile after the user has
+     * started to type an email address.
+     */
+    if (newEmail) {
+      dom.removeAttr(CONTINUE_BUTTON_SELECTOR, DISABLED_ATTRIBUTE);
+    }
+    else {
+      dom.setAttr(CONTINUE_BUTTON_SELECTOR, DISABLED_ATTRIBUTE,
+        DISABLED_ATTRIBUTE);
+    }
   }
 
   var Module = bid.Modules.PageModule.extend({
@@ -331,7 +344,8 @@ BrowserID.Modules.Authenticate = (function() {
     createFxAccount: createFxAccount,
     transitionNoPassword: transitionNoPassword,
     authenticate: authenticate,
-    forgotPassword: forgotPassword
+    forgotPassword: forgotPassword,
+    emailChange: emailChange
     // END TESTING API
   });
 

--- a/resources/static/dialog/js/modules/required_email.js
+++ b/resources/static/dialog/js/modules/required_email.js
@@ -15,6 +15,7 @@ BrowserID.Modules.RequiredEmail = (function() {
       auth_level,
       primaryInfo,
       secondaryAuth,
+      CANCEL_SELECTOR = "#cancel",
       FORGOT_PASSWORD_SELECTOR = ".forgotPassword";
 
   function closePrimaryUser(callback) {
@@ -231,7 +232,7 @@ BrowserID.Modules.RequiredEmail = (function() {
         self.click("#sign_in", signIn);
         self.click("#verify_address", verifyAddress);
         self.click(FORGOT_PASSWORD_SELECTOR, forgotPassword);
-        self.click("#cancel", cancel);
+        self.click(CANCEL_SELECTOR, cancel);
       }
 
       RequiredEmail.sc.start.call(self, options);

--- a/resources/static/dialog/js/modules/set_password.js
+++ b/resources/static/dialog/js/modules/set_password.js
@@ -8,6 +8,7 @@ BrowserID.Modules.SetPassword = (function() {
       helpers = bid.Helpers,
       complete = helpers.complete,
       dialogHelpers = helpers.Dialog,
+      CANCEL_SELECTOR = "#cancel",
       PASSWORD_SELECTOR = "#password",
       VPASSWORD_SELECTOR = "#vpassword",
       sc;
@@ -60,7 +61,7 @@ BrowserID.Modules.SetPassword = (function() {
         dialogHelpers.showRPTosPP.call(self);
       }
 
-      self.click("#cancel", cancel);
+      self.click(CANCEL_SELECTOR, cancel);
 
       sc.start.call(self, options);
     },

--- a/resources/static/dialog/views/pick_email.ejs
+++ b/resources/static/dialog/views/pick_email.ejs
@@ -42,6 +42,6 @@
 
       <p class="submit add cf buttonrow">
         <button id="signInButton"><%= gettext('sign in') %></button>
-        <a href="#" class="right cancelDialog isMobile"><%= gettext('cancel') %></a>
+        <a href="#" class="cancelDialog isMobile"><%= gettext('cancel') %></a>
       </p>
   </div>

--- a/resources/static/dialog/views/verify_primary_user.ejs
+++ b/resources/static/dialog/views/verify_primary_user.ejs
@@ -27,7 +27,7 @@
       <button class="isDesktop" id="verifyWithPrimary"><%- format(gettext("sign in with %s"), [idpName]) %></button>
       <a href="#" class="cancel emphasize right isDesktop"><%= gettext("Use a different email address") %></a>
       <button class="isMobile" id="verifyWithPrimary"><%- gettext("sign in") %></button>
-      <a href="#" class="cancel right isMobile"><%= gettext("cancel") %></a>
+      <a href="#" class="cancel isMobile"><%= gettext("cancel") %></a>
   </p>
 
 

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -33,7 +33,8 @@
       TRANSITION_TO_SECONDARY_LABEL = "#authentication_form .label.transition_to_secondary",
       PASSWORD_LABEL = "#authentication_form .label.password_state",
       IDP_SELECTOR = "#authentication_form .authentication_idp_name",
-      AUTHENTICATION_CLASS = "authentication";
+      AUTHENTICATION_CLASS = "authentication",
+      CONTINUE_BUTTON_SELECTOR = ".continue";
 
 
   function reset() {
@@ -462,6 +463,24 @@
     });
 
     controller.transitionNoPassword(start);
+  });
+
+  test("emailChange - submit button disabled if there is no input",
+      function() {
+    // start off with nothing
+    $(EMAIL_SELECTOR).val("");
+    controller.emailChange();
+    ok($(CONTINUE_BUTTON_SELECTOR).attr("disabled"));
+
+    // type a char
+    $(EMAIL_SELECTOR).val("t");
+    controller.emailChange();
+    ok( ! $(CONTINUE_BUTTON_SELECTOR).attr("disabled"));
+
+    // delete the char.
+    $(EMAIL_SELECTOR).val("");
+    controller.emailChange();
+    ok($(CONTINUE_BUTTON_SELECTOR).attr("disabled"));
   });
 
 }());

--- a/resources/static/test/cases/dialog/js/modules/set_password.js
+++ b/resources/static/test/cases/dialog/js/modules/set_password.js
@@ -12,6 +12,7 @@
       testElementNotExists = testHelpers.testElementDoesNotExist,
       testElementTextContains = testHelpers.testElementTextContains,
       testTooltipVisible = testHelpers.testTooltipVisible,
+      CANCEL_SELECTOR = "#cancel",
       register = testHelpers.register;
 
   function createController(options) {
@@ -35,13 +36,13 @@
   test("create with no options - show template, user must verify email, can cancel", function() {
     ok($("#set_password").length, "set_password template added");
     testElementExists("#verify_user");
-    testElementExists("#cancel");
+    testElementExists(CANCEL_SELECTOR);
   });
 
   test("create with cancelable=false option - cancel button not shown", function() {
     controller.destroy();
     createController({ cancelable: false });
-    testElementNotExists("#cancel");
+    testElementNotExists(CANCEL_SELECTOR);
   });
 
   test("create with transition_no_password", function() {
@@ -105,6 +106,6 @@
       start();
     });
 
-    $("#cancel").click();
+    $(CANCEL_SELECTOR).click();
   });
 }());

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -34,11 +34,11 @@
                     <ul class="inputs">
 
                         <li>
-                            <label for="authentication_email" class="isDesktopStart"></label>
+                            <label for="authentication_email" class="isDesktopOrStart"></label>
                             <span class="label email_state"><%= gettext('Enter your email address') %></span>
                             <span class="label transition_to_secondary"><%- format(gettext('%(idp)s no longer allows you to log into Persona with your %(idp)s password. You must now use your existing Persona password to log in with this email address.'), { idp: '<strong class="authentication_idp_name"></strong>'}) %></span>
                             <span class="label password_state"><%= gettext('Now enter your Persona password.') %></span>
-                            <input id="authentication_email" class="isDesktopStart" type="email" autocapitalize="off" autocorrect="off" spellcheck="false" value="" maxlength="254" placeholder="<%= gettext('enter email address') %>"/>
+                            <input id="authentication_email" class="isDesktopOrStart" type="email" autocapitalize="off" autocorrect="off" spellcheck="false" value="" maxlength="254" placeholder="<%= gettext('enter email address') %>"/>
 
                             <div id="email_format" class="tooltip" for="authentication_email">
                               <%= gettext('This field must be an email address.') %>
@@ -85,7 +85,7 @@
                     </p>
 
 
-                    <p class="submit tospp cf isDesktopStart">
+                    <p class="submit tospp cf isDesktopOrStart">
                        <%- format(gettext("By proceeding, you agree to %(site)s's <a %(terms)s>Terms</a> and <a %(privacy)s>Privacy Policy</a>."),
                                   { site: "Persona",
                                     terms:
@@ -95,29 +95,25 @@
                     </p>
 
                     <p class="submit cf buttonrow">
-                      <button class="isStart isAddressInfo "><%= gettext('next') %></button>
 
-                      <span class="isStart isAddressInfo right">
-                        <a href="#" class="isMobile cancelDialog">
-                          <%= gettext('cancel') %>
-                        </a>
-                      </span>
+                      <button class="isStart isAddressInfo"><%= gettext('next') %></button>
+
+                      <a href="#" class="isMobile isStart isAddressInfo cancelDialog">
+                        <%= gettext('cancel') %>
+                      </a>
 
                       <button class="isReturning">
                         <%= gettext('sign in') %>
                       </button>
 
-                      <span class="isReturning right">
-                        <a href="#" class="isMobile cancelPassword">
-                          <%= gettext('cancel') %>
-                        </a>
-                      </span>
+                      <a href="#" class="isMobile isReturning cancelPassword">
+                        <%= gettext('cancel') %>
+                      </a>
 
-                      <span class="submit cf isReturning">
-                        <a class="isDesktop forgotPassword" href="#">
-                          <%= gettext('Forgot your password?') %>
-                        </a>
-                      </span>
+                      <a class="isDesktop isReturning forgotPassword left" href="#">
+                        <%= gettext('Forgot your password?') %>
+                      </a>
+
                     </p>
 
 

--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -96,7 +96,13 @@
 
                     <p class="submit cf buttonrow">
 
-                      <button class="isStart isAddressInfo"><%= gettext('next') %></button>
+                      <button class="isDesktop isStart isAddressInfo right">
+                        <%= gettext('next') %>
+                      </button>
+
+                      <button class="isMobile isStart isAddressInfo continue right" disabled>
+                        <%= gettext('continue') %>
+                      </button>
 
                       <a href="#" class="isMobile isStart isAddressInfo cancelDialog">
                         <%= gettext('cancel') %>

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -53,6 +53,7 @@
           <span class="label email_state">enter email</span>
           <span class="label transition_to_secondary"><strong class="authentication_idp_name"></strong> transition</span>
           <span class="label password_state">enter password</span>
+          <button class="continue" disabled>Next!</button>
         </div>
 
         <div id="controller_head">


### PR DESCRIPTION
@jedp - they are coming in fast and furious!

Disable "continue" button on mobile until the user has typed in a character.

```
* On mobile, rename the next button to continue
* Disable the "continue" button until the user types a char in the email field.
* Clean up the button hover states on desktop and mobile when the button is diabled.
```

This builds upon #3408, so that should be reviewed first.

The ephemeral instance to test on is disable-continue.personatest.org
