### PR TITLE
Fix the set password input fields being too wide if the user enters an e...mail address > 31 characters on a mobile device.

### DIFF
--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -192,6 +192,12 @@
     visibility: hidden;
     display: block;
     height: 0;
+    /* hidden items still take up their natural width in the DOM, which can
+     * cause some funkiness if there is a really long email address. Long
+     * addresses cause the set password input boxes to be wider than the
+     * screen. See issue #3409
+     */
+    width: 0;
   }
 
   /**

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -198,6 +198,7 @@
      * screen. See issue #3409
      */
     width: 0;
+    overflow: hidden;
   }
 
   /**


### PR DESCRIPTION
@seanmonstar - could I get a quick review?

fixes #3409 

This can be tested on input-too-wide.personatest.org/input-too-wide.123done.org
