### PR TITLE
increment release number; document hotfix for issues #3362, #3393

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ train-2013.05.08:
   * Don't reset sessions to ephemeral duration after email verification: #3336
   * (hotfix 2013.05.14) verifier parameters for forceIssuer and allowUnverified now have an experimental_ prefix
   * (hotfix 2013.05.15) Fix for users who are unable to sign out: issue #3386, #3398
+  * (hotfix 2013.05.16) confirm email link page is all white with no error on screen: issue #3362, #3397
+  * (hotfix 2013.05.16) [main site] error/wait/delay screen has transparent background: issue #3393, #3396
 
 train-2013.04.26:
   * up to 25% performance improvement on mobile (delayed loading of crypto code): #3060, #3287

--- a/resources/static/pages/js/verify_secondary_address.js
+++ b/resources/static/pages/js/verify_secondary_address.js
@@ -98,6 +98,7 @@ BrowserID.verifySecondaryAddress = (function() {
       else {
         // renderError is used directly instead of pageHelpers.showFailure
         // because showFailure hides the title in the extended info.
+        dom.show("body");
         self.renderError("error", errors.cannotConfirm);
         complete(oncomplete, false);
       }

--- a/resources/static/test/cases/pages/js/verify_secondary_address.js
+++ b/resources/static/test/cases/pages/js/verify_secondary_address.js
@@ -66,6 +66,7 @@
   }
 
   function testCannotConfirm() {
+    ok($("body").is(":visible"));
     testHelpers.testErrorVisible();
   }
 
@@ -108,8 +109,10 @@
   asyncTest("invalid token - show cannot confirm error", function() {
     xhr.useResult("invalid");
 
+    $("body").hide();
     createController(config, function() {
       testCannotConfirm();
+      $("body").show();
       start();
     });
   });

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -41,9 +41,9 @@
     </header>
 <% } %>
 
-    <div id="wait"><div class="contents"></div></div>
-    <div id="error"><div class="contents"></div></div>
-    <div id="delay"><div class="contents"></div></div>
+    <div id="wait" class="message_screen"><div class="contents"></div></div>
+    <div id="error" class="message_screen"><div class="contents"></div></div>
+    <div id="delay" class="message_screen"><div class="contents"></div></div>
 
     <%- body %>
 

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2013.05.08
-Release:       3%{?dist}_%{svnrev}
+Release:       4%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
This adds two small but useful changes that are already merged to dev:
-  confirm email link page is all white with no error on screen: issue #3362, #3397
-  [main site] error/wait/delay screen has transparent background: issue #3393, #3396
