### PR TITLE
Fix submit buttons staying disabled after cancel from set-password and re-submit with same email address.

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -18,6 +18,7 @@ BrowserID.Modules.Authenticate = (function() {
       addressInfo,
       hints = ["returning","start","addressInfo"],
       DISABLED_ATTRIBUTE = "disabled",
+      SUBMIT_DISABLED_CLASS = "submit_disabled",
       CONTENTS_SELECTOR = "#formWrap .contents",
       AUTH_FORM_SELECTOR = "#authentication_form",
       EMAIL_SELECTOR = "#authentication_email",
@@ -77,7 +78,7 @@ BrowserID.Modules.Authenticate = (function() {
     if (!email) return;
 
     dom.setAttr(EMAIL_SELECTOR, DISABLED_ATTRIBUTE, DISABLED_ATTRIBUTE);
-    dom.addClass(BODY_SELECTOR, "submit_disabled");
+    dom.addClass(BODY_SELECTOR, SUBMIT_DISABLED_CLASS);
     if (info && info.type) {
       onAddressInfo(info);
     }
@@ -94,6 +95,7 @@ BrowserID.Modules.Authenticate = (function() {
     function onAddressInfo(info) {
       addressInfo = info;
       dom.removeAttr(EMAIL_SELECTOR, DISABLED_ATTRIBUTE);
+      dom.removeClass(BODY_SELECTOR, SUBMIT_DISABLED_CLASS);
 
       self.hideLoad();
 

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -290,6 +290,18 @@
   });
 
 
+  asyncTest("checkEmail leaves no traces - all inputs re-enabled when complete",
+      function() {
+    $(EMAIL_SELECTOR).val("registered@testuser.com");
+
+    controller.checkEmail(null, function() {
+      equal($("body").hasClass("submit_disabled"), false);
+      equal(typeof $("#authentication_email").attr("disabled"), "undefined");
+
+      start();
+    });
+  });
+
 
   asyncTest("clear password if user changes email address", function() {
     xhr.useResult("known_secondary");


### PR DESCRIPTION
@seanmonstar - can you review this one too? This should probably be reviewed after #3432 because the same front end unit test fails here without the merge from there.
- Remove the "submit_disabled" class on the body when address info retreival is complete.
- fixes #3431
