### PR TITLE
Use Feura Sans font for the mobile layout.

### DIFF
--- a/bin/static
+++ b/bin/static
@@ -14,7 +14,8 @@ http = require('http'),
 urlparse = require('urlparse'),
 express = require('express'),
 connect_fonts = require('connect-fonts'),
-connect_fonts_opensans = require('connect-fonts-opensans');
+connect_fonts_opensans = require('connect-fonts-opensans'),
+connect_fonts_feurasans = require('connect-fonts-feurasans');
 
 const
 assets = require('../lib/static_resources').all,
@@ -94,7 +95,7 @@ var static_root = path.join(__dirname, "..", "resources", "static");
 config.performSubstitution(app);
 
 var font_middleware = connect_fonts.setup({
-  fonts: [ connect_fonts_opensans ],
+  fonts: [ connect_fonts_opensans, connect_fonts_feurasans ],
   allow_origin: config.get('public_url'),
   ua: 'all'
 });

--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -121,6 +121,9 @@ exports.resources = {
     '/:locale/opensans-regular/fonts.css',
     '/:locale/opensans-bold/fonts.css',
     '/:locale/opensans-light/fonts.css',
+    '/:locale/feurasans-regular/fonts.css',
+    '/:locale/feurasans-bold/fonts.css',
+    '/:locale/feurasans-light/fonts.css',
     '/common/css/style.css',
     '/dialog/css/style.css',
     '/dialog/css/m.css'

--- a/lockdown.json
+++ b/lockdown.json
@@ -82,6 +82,9 @@
   "connect-fonts": {
     "0.0.9-alpha8": "3d4c983e5b93a8a0e7793e9ef606c4f8413d113f"
   },
+  "connect-fonts-feurasans": {
+    "0.0.2": "7ae4b9e9062177959e29b9bafb70fee21f295a5d"
+  },
   "connect-fonts-opensans": {
     "0.0.3-beta1": "3a48105408514e7ef9fc2f4d1c784be0e102e744"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "validator": "0.4.9",
         "winston": "0.6.2",
         "connect-fonts": "0.0.9-alpha8",
-        "connect-fonts-opensans": "0.0.3-beta1"
+        "connect-fonts-opensans": "0.0.3-beta1",
+        "connect-fonts-feurasans": "0.0.2"
     },
     "optionalDependencies": {
         "node-statsd": "https://github.com/downloads/lloyd/node-statsd/0509f85.tgz"

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -21,12 +21,20 @@
 
   /* Remove background image gradients set in style.css which cause
    * horizontal lines to appear while the dialog is loading.
+   * Set the default font to Feura Sans
    */
   body {
     height: 100%;
     background: #eff0f2 none;
+    font-family: 'Feura Sans', 'Open Sans', 'Lucida Sans', 'Lucida Grande', 'Lucida Sans Unicode', Verdana, sans-serif;
   }
 
+  /**
+   * Get rid of the OpenSans letter-spacing.
+   */
+  h1, h2, h3, h4, h5, h6 {
+    letter-spacing: normal;
+  }
 
   header, footer, .persona_intro {
     display: none;

--- a/scripts/compress-worker.js
+++ b/scripts/compress-worker.js
@@ -9,10 +9,11 @@ uglifycss = require('uglifycss'),
 mkdirp = require('mkdirp'),
 connect_fonts = require('connect-fonts'),
 connect_fonts_opensans = require('connect-fonts-opensans'),
+connect_fonts_feurasans = require('connect-fonts-feurasans'),
 path = require('path');
 
 var font_middleware = connect_fonts.setup({
-  fonts: [ connect_fonts_opensans ],
+  fonts: [ connect_fonts_opensans, connect_fonts_feurasans ],
   "allow-origin": config.get('public_url')
 });
 

--- a/scripts/create_font_css.js
+++ b/scripts/create_font_css.js
@@ -12,6 +12,7 @@ templates = require('../lib/templates'),
 cachify = require('connect-cachify'),
 connect_fonts = require('connect-fonts'),
 connect_fonts_opensans = require('connect-fonts-opensans'),
+connect_fonts_feurasans = require('connect-fonts-feurasans'),
 config = require('../lib/configuration'),
 mkdirp = require('mkdirp');
 
@@ -19,7 +20,7 @@ var dir = process.cwd();
 var output_dir = process.env.BUILD_DIR || dir;
 
 connect_fonts.setup({
-  fonts: [ connect_fonts_opensans ],
+  fonts: [ connect_fonts_opensans, connect_fonts_feurasans ],
   "allow-origin": config.get('public_url')
 });
 


### PR DESCRIPTION
@skinny97214, @mhanratty, I have updated the dialog available from http://all-together-now.123done.org to use the Feura Sans font set available from the https://github.com/mozilla-b2g/gaia/ repo. Can you see what you think?

fixes #3430
