### PR TITLE
Fix TOS/PP iframe scrolling.

### DIFF
--- a/resources/static/dialog/js/modules/inline_tospp.js
+++ b/resources/static/dialog/js/modules/inline_tospp.js
@@ -17,11 +17,13 @@ BrowserID.Modules.InlineTosPp = (function() {
       TOSPP_CLOSE_SELECTOR = "#tosppmodal",
       TOSPP_IFRAME = "#tosppframe",
       IFRAME_PARENT_SELECTOR = "body",
+      win,
       sc;
 
   var Module = bid.Modules.PageModule.extend({
     start: function(options) {
       options = options || {};
+      win = options.window || window;
 
       var self=this;
 
@@ -56,6 +58,21 @@ BrowserID.Modules.InlineTosPp = (function() {
   function showTOSPP(url) {
     /*jshint validthis:true*/
     var self=this;
+
+    /*
+     * Because of the hell that is cross-browser iframe support and scrolling,
+     * we are going to avoid all of those rendering issues by only opening the
+     * TOS/PP in an iframe IFF the device *DOES NOT SUPPORT* window.open. At
+     * the time of writing this code, this is only FirefoxOS. FirefoxOS does
+     * the right thing with respect to scrolling.
+     */
+    if (win.open) {
+      // A reference to the new window will be returned if the environment can
+      // open one. If there is no reference, window.opened failed and the
+      // TOS/PP should be shown in an iframe.
+      var winRef = win.open(url);
+      if (winRef) return;
+    }
 
     if (!self._tospp) {
       self._tospp = renderer.append(IFRAME_PARENT_SELECTOR, "inline_tospp", {

--- a/resources/static/test/cases/dialog/js/modules/inline_tospp.js
+++ b/resources/static/test/cases/dialog/js/modules/inline_tospp.js
@@ -7,7 +7,9 @@
   var controller,
       bid = BrowserID,
       InlineTosPp = bid.Modules.InlineTosPp,
-      testHelpers = bid.TestHelpers;
+      WindowMock = bid.Mocks.WindowMock,
+      testHelpers = bid.TestHelpers,
+      TOSPP_URL = "https://login.persona.org/privacy";
 
   function createController(options) {
     options = options || {};
@@ -38,14 +40,41 @@
     }
   });
 
-  asyncTest("can create and show", function() {
+  // Simulate opening new windows in a normal browser.
+  asyncTest("window.open opens new window - show tos/pp in new window",
+      function() {
+
+    var winMock = new WindowMock({
+      suppressOpen: false
+    });
+
     createController({
+      window: winMock,
       ready: function() {
-        var url = "https://login.persona.org/privacy";
-        controller.show(url);
+        controller.show(TOSPP_URL);
+        equal($("#tosppmodal:visible").length, 0);
+
+        equal(winMock.open_url, TOSPP_URL);
+
+        start();
+      }
+    });
+  });
+
+  // Simulate FirefoxOS where new windows cannot be opened.
+  asyncTest("window.open does not open new window - show tos/pp in iframe",
+      function() {
+    var winMock = new WindowMock({
+      suppressOpen: true
+    });
+
+    createController({
+      window: winMock,
+      ready: function() {
+        controller.show(TOSPP_URL);
         equal($("#tosppmodal:visible").length, 1);
 
-        equal($("#tosppframe").attr('src'), url);
+        equal($("#tosppframe").attr('src'), TOSPP_URL);
 
         controller.close();
         equal($("#tosppmodal:visible").length, 0);

--- a/resources/static/test/mocks/window.js
+++ b/resources/static/test/mocks/window.js
@@ -11,13 +11,33 @@ BrowserID.Mocks.WindowMock = (function() {
     };
   }
 
-  function WindowMock() {
+  function WindowMock(options) {
+    options = options || {};
+
     this.document = new DocumentMock();
+    if (options.href) {
+      this.document.location.href = options.href;
+    }
+
+    if (options.hash) {
+      this.document.location.hash = options.hash;
+    }
+
     this.sessionStorage = {};
+
+    this.suppressOpen = options.suppressOpen || false;
   }
+
   WindowMock.prototype = {
     open: function(url, name, options) {
+      if (this.suppressOpen) return;
+
       this.open_url = url;
+
+      return new WindowMock({
+        suppressOpen: this.suppressOpen,
+        href: url
+      });
     }
   };
 


### PR DESCRIPTION
Sidestep the scrolling issue entirely. Only show the TOS/PP agreement in an embedded iframe IFF the browsing enviornment does not support window.open

fixes #3442
