### PR TITLE
Fix new_user KPI for two scenarios:

### DIFF
--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -210,6 +210,10 @@ BrowserID.State = (function() {
     handleState("new_user", function(msg, info) {
       self.newUserEmail = info.email;
 
+      // Add new_account to the KPIs *before* the staging occurs allows us to
+      // know when we are losing users due to the email verification.
+      mediator.publish("kpi_data", { new_account: true });
+
       startAction(false, "doSetPassword", info);
       complete(info.complete);
     });
@@ -224,6 +228,10 @@ BrowserID.State = (function() {
     // B2G forceIssuer on primary
     handleState("new_fxaccount", function(msg, info) {
       self.newFxAccountEmail = info.email;
+
+      // Add new_account to the KPIs *before* the staging occurs allows us to
+      // know when we are losing users due to the email verification.
+      mediator.publish("kpi_data", { new_account: true });
 
       info.fxaccount = true;
       startAction(false, "doSetPassword", info);
@@ -243,17 +251,6 @@ BrowserID.State = (function() {
        * #1 is taken care of by newUserEmail, #2 by addEmailEmail, #3 by resetPasswordEmail,
        * #4 by transitionNoPassword and #5 by fxAccountEmail
        */
-
-      if (self.newUserEmail || self.newFxAccountEmail) {
-        // Add new_account to the KPIs *before* the staging occurs allows us to
-        // know when we are losing users due to the email verification.
-        //
-        // Only set the new_account KPI post password-set so that we users who
-        // type the wrong email address and press "cancel" on the set password
-        // screen are not counted as new users.
-        mediator.publish("kpi_data", { new_account: true });
-      }
-
       info = _.extend({ email: self.newUserEmail || self.addEmailEmail ||
                                self.resetPasswordEmail || self.transitionNoPassword ||
                                self.newFxAccountEmail}, info);
@@ -604,6 +601,12 @@ BrowserID.State = (function() {
     handleState("email_confirmed", handleEmailConfirmed);
 
     handleState("cancel_state", function(msg, info) {
+      if (self.newUserEmail || self.newFxAccountEmail) {
+        // If the user cancels from the set_password screen, they should not be
+        // counted as new users.
+        mediator.publish("kpi_data", { new_account: false });
+      }
+
       cancelState(info);
     });
 

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -210,10 +210,6 @@ BrowserID.State = (function() {
     handleState("new_user", function(msg, info) {
       self.newUserEmail = info.email;
 
-      // Add new_account to the KPIs *before* the staging occurs allows us to
-      // know when we are losing users due to the email verification.
-      mediator.publish("kpi_data", { new_account: true });
-
       startAction(false, "doSetPassword", info);
       complete(info.complete);
     });
@@ -247,6 +243,17 @@ BrowserID.State = (function() {
        * #1 is taken care of by newUserEmail, #2 by addEmailEmail, #3 by resetPasswordEmail,
        * #4 by transitionNoPassword and #5 by fxAccountEmail
        */
+
+      if (self.newUserEmail || self.newFxAccountEmail) {
+        // Add new_account to the KPIs *before* the staging occurs allows us to
+        // know when we are losing users due to the email verification.
+        //
+        // Only set the new_account KPI post password-set so that we users who
+        // type the wrong email address and press "cancel" on the set password
+        // screen are not counted as new users.
+        mediator.publish("kpi_data", { new_account: true });
+      }
+
       info = _.extend({ email: self.newUserEmail || self.addEmailEmail ||
                                self.resetPasswordEmail || self.transitionNoPassword ||
                                self.newFxAccountEmail}, info);

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -690,52 +690,53 @@
     });
   });
 
-  test("new_user KPI not sent when user hits 'cancel' from set_password screen",
-      function() {
+
+  asyncTest("new_user KPI for new users", function() {
     mediator.subscribe("kpi_data", function(msg, info) {
-      ok(false, "unexpected kpi_data message");
+      equal(info.new_account, true);
+      start();
     });
 
+    // Sequence:
+    // 1. user types in unrecognized email address, is shown set password screen
+    // 2. user enters password
+    //
+    // Expect:
+    // kpi_data message with new_account: true
+    mediator.publish("new_user", { email: TEST_EMAIL });
+  });
+
+  asyncTest("new_user KPI for new FirefoxOS users", function() {
+    mediator.subscribe("kpi_data", function(msg, info) {
+      equal(info.new_account, true);
+      start();
+    });
+
+    // Sequence:
+    // 1. user types in unrecognized email address, is shown set password screen
+    // 2. user enters password
+    //
+    // Expect:
+    // kpi_data message with new_account: true
+    mediator.publish("new_fxaccount", { email: TEST_EMAIL });
+  });
+
+  asyncTest("new_user KPI set to `false` when user hits 'cancel' " +
+      "from set_password screen", function() {
     // Sequence:
     // 1. user types in unrecognized email address, is shown set password screen
     // 2. user clicks "cancel" button
     //
     // Expect:
-    // No kpi_data message
+    // kpi_data message with new_account: false
     mediator.publish("new_user", { email: TEST_EMAIL });
-    mediator.publish("cancel");
-  });
 
-  asyncTest("new_user KPI sent on password_set for new users", function() {
     mediator.subscribe("kpi_data", function(msg, info) {
-      equal(info.new_account, true);
+      equal(info.new_account, false);
       start();
     });
 
-    // Sequence:
-    // 1. user types in unrecognized email address, is shown set password screen
-    // 2. user enters password
-    //
-    // Expect:
-    // kpi_data message with new_user: true
-    mediator.publish("new_user", { email: TEST_EMAIL });
-    mediator.publish("password_set");
-  });
-
-  asyncTest("new_user KPI sent on password_set for new FirefoxOS users", function() {
-    mediator.subscribe("kpi_data", function(msg, info) {
-      equal(info.new_account, true);
-      start();
-    });
-
-    // Sequence:
-    // 1. user types in unrecognized email address, is shown set password screen
-    // 2. user enters password
-    //
-    // Expect:
-    // kpi_data message with new_user: true
-    mediator.publish("new_fxaccount", { email: TEST_EMAIL });
-    mediator.publish("password_set");
+    mediator.publish("cancel_state");
   });
 
 }());

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -690,4 +690,52 @@
     });
   });
 
+  test("new_user KPI not sent when user hits 'cancel' from set_password screen",
+      function() {
+    mediator.subscribe("kpi_data", function(msg, info) {
+      ok(false, "unexpected kpi_data message");
+    });
+
+    // Sequence:
+    // 1. user types in unrecognized email address, is shown set password screen
+    // 2. user clicks "cancel" button
+    //
+    // Expect:
+    // No kpi_data message
+    mediator.publish("new_user", { email: TEST_EMAIL });
+    mediator.publish("cancel");
+  });
+
+  asyncTest("new_user KPI sent on password_set for new users", function() {
+    mediator.subscribe("kpi_data", function(msg, info) {
+      equal(info.new_account, true);
+      start();
+    });
+
+    // Sequence:
+    // 1. user types in unrecognized email address, is shown set password screen
+    // 2. user enters password
+    //
+    // Expect:
+    // kpi_data message with new_user: true
+    mediator.publish("new_user", { email: TEST_EMAIL });
+    mediator.publish("password_set");
+  });
+
+  asyncTest("new_user KPI sent on password_set for new FirefoxOS users", function() {
+    mediator.subscribe("kpi_data", function(msg, info) {
+      equal(info.new_account, true);
+      start();
+    });
+
+    // Sequence:
+    // 1. user types in unrecognized email address, is shown set password screen
+    // 2. user enters password
+    //
+    // Expect:
+    // kpi_data message with new_user: true
+    mediator.publish("new_fxaccount", { email: TEST_EMAIL });
+    mediator.publish("password_set");
+  });
+
 }());


### PR DESCRIPTION
@kparlante - mind reviewing?
- FirefoxOS was not reporting new users
- If a user hits cancel from the "set password" screen.

fixes #3359
fixes #3459
