### PR TITLE
Fix primaries on FirefoxOS!

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -620,3 +620,7 @@ footer .help {
 #development li a {
   color: #fff;
 }
+
+#development input[type=text] {
+  padding: 3px 5px;
+}

--- a/resources/static/common/js/modules/development.js
+++ b/resources/static/common/js/modules/development.js
@@ -29,6 +29,7 @@ BrowserID.Modules.Development = (function() {
         this.click("#clearLocalStorage", clearLocalStorage);
         this.click("#clearEmailsForSites", clearEmailsForSites);
         this.click("#forceIsThisYourComputer", forceIsThisYourComputer);
+        this.click("#redirectTo", redirectTo);
         this.click("#closeDevelopment", close);
       }
 
@@ -94,6 +95,15 @@ BrowserID.Modules.Development = (function() {
 
   function forceIsThisYourComputer() {
     storage.usersComputer.forceAsk(user.userid());
+  }
+
+  function redirectTo() {
+    var href = dom.getInner("#siteToRedirectTo");
+
+    if (href) {
+      bid.module.stopAll();
+      document.location = href;
+    }
   }
 
   function close() {

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -44,6 +44,24 @@ BrowserID.Modules.Dialog = (function() {
       return;
     }
 
+    // returning from the primary verification flow, we were native before, we
+    // are native now. This prevents the UI from trying to establish a channel
+    // back to the RP.
+    if (win.sessionStorage.primaryVerificationFlow) {
+      try {
+        var info = JSON.parse(win.sessionStorage.primaryVerificationFlow);
+        if (info.native) return;
+      } catch(e) {
+        self.renderError("error", {
+          action: {
+            title: "error in sessionStorage",
+            message: "could not decode sessionStorage.primaryVerificationFlow: "
+                          + String(e)
+          }
+        });
+      }
+    }
+
     // next, we see if the caller intends to call native APIs
     if (hash === "#NATIVE" || hash === "#INTERNAL") {
       // don't do winchan, let it be.
@@ -303,7 +321,9 @@ BrowserID.Modules.Dialog = (function() {
         }
 
         if (hash.indexOf("#AUTH_RETURN") === 0) {
-          var primaryParams = JSON.parse(win.sessionStorage.primaryVerificationFlow);
+          var primaryParams =
+              JSON.parse(win.sessionStorage.primaryVerificationFlow);
+
           params.email = primaryParams.email;
           params.add = primaryParams.add;
           params.type = "primary";

--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -30,7 +30,10 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
     // set up some information about what we're doing
     win.sessionStorage.primaryVerificationFlow = JSON.stringify({
       add: add,
-      email: email
+      email: email,
+      // native is used when the user returns from the primary to prevent
+      // WinChan from establishing the postMessage channel.
+      native: win.document.location.hash === "#NATIVE"
     });
 
     var url = helpers.toURL(auth_url, { email: email });

--- a/resources/static/dialog/views/development.ejs
+++ b/resources/static/dialog/views/development.ejs
@@ -7,6 +7,8 @@
     <li><a id="clearLocalStorage" href="/">Clear localStorage</a></li>
     <li><a id="clearEmailsForSites" href="/">Clear Site&lt;-&gt;Emails</a></li>
     <li><a id="forceIsThisYourComputer" href="/">Force "Is This Your Computer"</a></li>
+    <li><input type="text" id="siteToRedirectTo" placeholder="URL to redirect to"/></li>
+    <li><a id="redirectTo" href="/">Redirect To Above Site</a></li>
     <li><a id="closeDevelopment" href="/">Close</a></li>
 </ul>
 

--- a/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
@@ -112,6 +112,14 @@
           equal(win.document.location,
               "https://auth_url?email=unregistered%40testuser.com");
           equal(messageTriggered, true);
+          // make sure the data used when returning from the primary is as
+          // expected.
+          var dataUsedOnReturnFromPrimary =
+              JSON.parse(win.sessionStorage.primaryVerificationFlow);
+          equal(dataUsedOnReturnFromPrimary.native, true);
+          equal(dataUsedOnReturnFromPrimary.add, false);
+          equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");
+
           start();
         });
       }
@@ -132,6 +140,14 @@
         controller.submit(function() {
           equal(win.document.location,
               "https://auth_url?email=unregistered%40testuser.com");
+
+          // make sure the data used when returning from the primary is as
+          // expected.
+          var dataUsedOnReturnFromPrimary =
+              JSON.parse(win.sessionStorage.primaryVerificationFlow);
+          equal(dataUsedOnReturnFromPrimary.native, true);
+          equal(dataUsedOnReturnFromPrimary.add, true);
+          equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");
           start();
         });
       }


### PR DESCRIPTION
@jedp - this is a PR to fix the "relay frame cannot be found" error on FirefoxOS
- Save a marker in sessionStorage that indicates the return from a primary is in a native context. If so, do not attempt to set up the channel.
- Add the ability to redirect to a site from the dev menu. This is useful on FirefoxOS where the trusted UI has no URL bar.
