### PR TITLE
default ephemeral aws should use kpiggybank-dev

### DIFF
--- a/config/aws.json
+++ b/config/aws.json
@@ -21,7 +21,7 @@
   },
   "proxy": { "bind_to": { "port": 10006 } },
   "router": { "bind_to": { "port": 8080 } },
-  "kpi_backend_db_url" : "https://kpiggybank-stage.personatest.org/wsapi/interaction_data",
+  "kpi_backend_db_url" : "https://kpiggybank-dev.personatest.org/wsapi/interaction_data",
   // whether to show the development menu.
   "enable_development_menu": true,
   // explicitly undefine public_static_url, as the configuration will then fallback to


### PR DESCRIPTION
@lloyd: Fixes https://github.com/mozilla/browserid/issues/3471
