### PR TITLE
Append FirefoxOS navigator.mozId properties on to the client created navigator.id object.

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -115,9 +115,15 @@
     // Is there a native implementation on this platform?
     // If so, hook navigator.id onto it.
     if (navigator.mozId) {
-      navigator.id = navigator.mozId;
-    } else {
-      navigator.id = {};
+      for (var key in navigator.mozId) {
+        // Setting navigator.id = navigator.mozId makes navigator.id immutable,
+        // making it impossible to dynamically add properties or functions to
+        // the navigator.id object. The initial revision of FirefoxOS does not
+        // have the primary API built in, so the shimmed primary API must be
+        // used. To allow for this, use a client-side created navigator.id.
+        // This is FirefoxOS, we know Function.prototype.bind exists there.
+        navigator.id[key] = navigator.mozId[key].bind(navigator.mozId);
+      }
     }
   }
 


### PR DESCRIPTION
@jedp - one more for you! This can be tested on "kpi-this-session.personatest.org" and with eyedee.me, which now includes both include.js and authentication_api.js

This allows the shimmed primary APIs to work on FirefoxOS.
