### PR TITLE
Submit KPI data when the dialog closes either in the interaction_iframe OR in the internal_api.

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -164,7 +164,12 @@ exports.resources = {
     '/common/js/crypto-loader.js',
     '/common/js/provisioning.js',
     '/common/js/user.js',
+
+    '/common/js/models/models.js',
+    '/common/js/models/interaction_data.js',
+
     '/dialog/js/misc/internal_api.js',
+
     '/communication_iframe/start.js'
   ],
   '/production/include.js': [

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -29,7 +29,7 @@ BrowserID.Network = (function() {
   }
 
   function withContext(cb, onFailure) {
-    if(typeof context !== "undefined") cb(context);
+    if(typeof context !== "undefined") complete(cb, context);
     else {
       // session_context always checks for a javascript readable cookie,
       // this allows our javascript code in the dialog and communication iframe

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -6,7 +6,10 @@
   var bid = BrowserID,
       network = bid.Network,
       user = bid.User,
-      storage = bid.Storage;
+      storage = bid.Storage,
+      interactionData = bid.Models.InteractionData;
+
+
 
   // Initialize all localstorage values to default values.  Neccesary for
   // proper sync of IE8 localStorage across multiple simultaneous
@@ -15,7 +18,6 @@
 
   network.init();
   user.init();
-
 
   var chan = Channel.build({
     window: window.parent,
@@ -119,6 +121,15 @@
 
   chan.bind("dialog_complete", function(trans, params) {
     pause = false;
+    // The dialog has closed, so that we get results from users who only open
+    // the dialog a single time, send the KPIs immediately. Note, this does not
+    // take care of native contexts. Native contexts are taken care of in in
+    // dialog/js/misc/internal_api.js. Errors sending the KPI data should not
+    // affect anything else.
+    try {
+      interactionData.publishCurrent();
+    } catch(e) {}
+
     // the dialog running can change authentication status,
     // lets manually purge our network cache
     network.clearContext();

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -431,6 +431,15 @@ BrowserID.TestHelpers = (function() {
         testInvalidPassword("password", "different_password");
       });
 
+    },
+
+    /**
+     * Test to see if a number is within the specified range. min and max are
+     * inclusive.
+     */
+    testNumberInRange: function(numToTest, min, max, msg) {
+      ok(numToTest >= min, msg || (numToTest + "is >= " + min));
+      ok(numToTest <= max, msg || (numToTest + " is <= " + max));
     }
   };
 


### PR DESCRIPTION
@kparlante - this one is for you!

Only generate GUIDs for a KPI blob whenever needed:
- When the dialog is orphaned AND
- A staging event occurs without a confirmation event.
