### PR TITLE
Catch, log, and throw client errors

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -398,8 +398,11 @@
         if (!err && r && r.assertion) {
           try {
             if (observers.login) observers.login(r.assertion);
-          } catch(e) {
+          } catch(clientError) {
             // client's observer threw an exception
+            // help developers debug by logging the error
+            console.log(clientError);
+            throw clientError;
           }
         }
 


### PR DESCRIPTION
As requested in issue #3374

When there's an error in client login code, log and then throw the error as a help for developers trying to integrate persona.
