### PR TITLE
update selenium_driver to 2.32.0, firefox to 21, and safari from 5/10.6 to 6/10.8

### DIFF
--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -4,20 +4,20 @@
 //
 const platforms = {
   // Firefox
-  "win7_firefox_16": {
+  "win7_firefox_21": {
     platform:'Windows 2008',
     browserName:'firefox',
-    version:'16'
+    version:'21'
   },
-  "linux_firefox_16": {
+  "linux_firefox_21": {
     platform: 'Linux',
     browserName: 'firefox',
-    version: '16'
+    version: '21'
   },
-  "osx_firefox_14": {
+  "osx_firefox_21": {
     platform: 'Mac 10.6',
     browserName:'firefox',
-    version:'14'
+    version:'21'
   },
 
   // Chrome
@@ -51,10 +51,10 @@ const platforms = {
   },
 
   // Safari
-  "osx_safari_5": {
-    platform:'Mac 10.6',
+  "osx_safari_6": {
+    platform:'Mac 10.8',
     browserName: 'safari',
-    version:'5'
+    version:'6'
   }
 };
 
@@ -72,9 +72,9 @@ const defaultCapabilities = {
   'max-session': 180,
   // use newest available selenium-server version
   // necessary for IE9 to work, but a good idea generally
-  'selenium-version': '2.26.0'
+  'selenium-version': '2.32.0'
 };
 
 exports.platforms = platforms;
 exports.defaultCapabilities = defaultCapabilities;
-exports.defaultPlatform = "win7_firefox_16";
+exports.defaultPlatform = "win7_firefox_21";


### PR DESCRIPTION
I'm getting ~stable results for {win7_chrome,win7_firefox_21,linux_firefox_21} as I did before this change. 

I've actually been using this as a local hack for a while too, and time to modernize/formalize this. 

Note: osx_firefox_21 has some test failures about handling alerts in the safari driver that we had previously. 

Also with this change, sign-in-test is stable on all browsers (as was frontend-qunit-test which doesn't stress out selenium window handling).
