### PR TITLE
Constrain tooltips to be displayed on the screen.

### DIFF
--- a/resources/static/common/js/tooltip.js
+++ b/resources/static/common/js/tooltip.js
@@ -8,7 +8,8 @@ BrowserID.Tooltip = (function() {
   var ANIMATION_TIME = 250,
       TOOLTIP_MIN_DISPLAY = 2000,
       TOOLTIP_OFFSET_TOP_PX = 5,
-      TOOLTIP_OFFSET_LEFT_PX = 10,
+      TOOLTIP_OFFSET_LEFT_PX = 0,
+      TOOLTIP_MARGIN_TO_SCREEN_EDGE_PX = 20,
       READ_WPM = 200,
       bid = BrowserID,
       dom = bid.DOM,
@@ -71,8 +72,21 @@ BrowserID.Tooltip = (function() {
   function anchorTooltip(tooltip, target) {
     target = $(target);
     var targetOffset = target.offset();
+
     targetOffset.top -= (tooltip.outerHeight() + TOOLTIP_OFFSET_TOP_PX);
+
+    // make sure the tooltip does not run off the top
+    if (targetOffset.top < TOOLTIP_MARGIN_TO_SCREEN_EDGE_PX)
+      targetOffset.top = TOOLTIP_MARGIN_TO_SCREEN_EDGE_PX;
+
     targetOffset.left += TOOLTIP_OFFSET_LEFT_PX;
+
+    // make sure the tooltip does not run off the right
+    var right = targetOffset.left + tooltip.outerWidth();
+    var rightLimit = $(window).innerWidth() - TOOLTIP_MARGIN_TO_SCREEN_EDGE_PX;
+    if (right > rightLimit) {
+      targetOffset.right = TOOLTIP_MARGIN_TO_SCREEN_EDGE_PX;
+    }
 
     tooltip.css(targetOffset);
   }

--- a/resources/static/test/cases/common/js/tooltip.js
+++ b/resources/static/test/cases/common/js/tooltip.js
@@ -75,8 +75,10 @@
     tooltip.showTooltip("#longTooltip");
     var visibleTooltip = $(".tooltip:visible");
 
-    ok(parseInt(visibleTooltip.css('top')) > 0);
-    ok(parseInt(visibleTooltip.css('right')) < visibleTooltip.outerWidth());
+    var offset = visibleTooltip.offset();
+    ok(offset.top > 0);
+    ok((offset.left + visibleTooltip.outerWidth())
+        < $(window).innerWidth());
   });
 
 }());

--- a/resources/static/test/cases/common/js/tooltip.js
+++ b/resources/static/test/cases/common/js/tooltip.js
@@ -71,4 +71,12 @@
     testUndefined(err, "exception not thrown if tooltip element does not exist");
   });
 
+  test("constrain tooltip to screen", function() {
+    tooltip.showTooltip("#longTooltip");
+    var visibleTooltip = $(".tooltip:visible");
+
+    ok(parseInt(visibleTooltip.css('top')) > 0);
+    ok(parseInt(visibleTooltip.css('right')) < visibleTooltip.outerWidth());
+  });
+
 }());

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -25,6 +25,16 @@
       display: none;
     }
 
+    /**
+     * Give the tooltip anchor an absolute location that guarantees the
+     * tooltip will have to be shifted back onto the screen.
+     */
+    #needsTooltip {
+      position: absolute;
+      top: 5px;
+      left: 99%;
+    }
+
   </style>
 	</head>
 	<body>


### PR DESCRIPTION
@jedp and @jrgm - this is a hotfix to the current stage for #3496. An ephemeral instance exists to test, tooltips-off-screen-stage.personatest.org
