### PR TITLE
Update coarse user agent parser for FirefoxOS

### DIFF
--- a/lib/coarse_user_agent_parser.js
+++ b/lib/coarse_user_agent_parser.js
@@ -19,13 +19,28 @@ exports.parse = function (ua_string) {
         browser: 'Unknown',
         version: 'Unknown'
       },
-      os_matchers = [
-        'iPod', 'iPad', 'iPhone',
-        'Android', 'BlackBerry', 'Linux', 'Macintosh',
+      os_matchers = {
+        'iPod': 'iPod',
+        'iPad': 'iPad',
+        'iPhone': 'iPhone',
+        'Android': 'Android',
+        'BlackBerry': 'BlackBerry',
+        'Linux': 'Linux',
+        'Macintosh': 'Macintosh',
+        // http://lawrencemandel.com/2012/07/27/decision-made-firefox-os-user-agent-string/
+        'FirefoxOS': 'Mozilla/5.0 (Mobile; rv:',
         // http://en.wikipedia.org/wiki/Microsoft_Windows#Timeline_of_releases
-        // Windows 8       Windows 7        Windows Vista     Windows XP        Windows 2000
-        'Windows NT 6.2', 'Windows NT 6.1', 'Windows NT 6.0', 'Windows NT 5.1', 'Windows NT 5.0'
-      ],
+        // Windows 8
+        'Windows NT 6.2': 'Windows NT 6.2',
+        // Windows 7
+        'Windows NT 6.1': 'Windows NT 6.1',
+        // Windows Vista
+        'Windows NT 6.0': 'Windows NT 6.0',
+        // Windows XP
+        'Windows NT 5.1': 'Windows NT 5.1',
+        // Windows 2000
+        'Windows NT 5.0': 'Windows NT 5.0'
+      },
       basic = function (ua_string) {
         // Looks for SomeString/5.1 at the end of a UA and parses 5.1 as an integer returning 5
         // Expected outputs... Firefox 14, Safari 533, Opera 12
@@ -77,15 +92,13 @@ exports.parse = function (ua_string) {
 
   // In os_matchers and browser_matchers order matters, many browsers pretend to be other
   // browsers http://webaim.org/blog/user-agent-string-history/
-  var os_known = false;
-  os_matchers.forEach(function (el) {
-    if (os_known) return;
-    if (ua_string.indexOf(el) !== -1) {
-      os_known = true;
-      user_agent.os = el;
+  for (var os in os_matchers) {
+    var os_match = os_matchers[os];
+    if (ua_string.indexOf(os_match) !== -1) {
+      user_agent.os = os;
+      break;
     }
-    return;
-  });
+  }
 
   var browser_known = false;
   browser_matchers.forEach(function (el) {

--- a/tests/data/user_agents.json
+++ b/tests/data/user_agents.json
@@ -29060,6 +29060,12 @@
       "os": "Unknown",
       "browser": "MSIE",
       "version": 2
+    },
+    {
+      "ua": "Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0",
+      "os": "FirefoxOS",
+      "browser": "Firefox",
+      "version": 18
     }
   ]
 }


### PR DESCRIPTION
us_matchers is now a table, the key is the OS, the value is the string to search for.

Add the current FirefoxOS string

fixes #3373
