### PR TITLE
'native' is reserved on Android 2.2, so access it array-style.

### DIFF
--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -50,7 +50,8 @@ BrowserID.Modules.Dialog = (function() {
     if (win.sessionStorage.primaryVerificationFlow) {
       try {
         var info = JSON.parse(win.sessionStorage.primaryVerificationFlow);
-        if (info.native) return;
+        /*jshint sub: true */
+        if (info['native']) return;
       } catch(e) {
         self.renderError("error", {
           action: {

--- a/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
@@ -116,7 +116,7 @@
           // expected.
           var dataUsedOnReturnFromPrimary =
               JSON.parse(win.sessionStorage.primaryVerificationFlow);
-          equal(dataUsedOnReturnFromPrimary.native, true);
+          equal(dataUsedOnReturnFromPrimary['native'], true);
           equal(dataUsedOnReturnFromPrimary.add, false);
           equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");
 
@@ -145,7 +145,7 @@
           // expected.
           var dataUsedOnReturnFromPrimary =
               JSON.parse(win.sessionStorage.primaryVerificationFlow);
-          equal(dataUsedOnReturnFromPrimary.native, true);
+          equal(dataUsedOnReturnFromPrimary['native'], true);
           equal(dataUsedOnReturnFromPrimary.add, true);
           equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");
           start();


### PR DESCRIPTION
Fixes #3522. FML.
