### PR TITLE
compensate for focus issues on ie8 by clicking text fields before sending keystrokes to it

### DIFF
--- a/automation-tests/tests/add-primary-to-primary.js
+++ b/automation-tests/tests/add-primary-to-primary.js
@@ -65,6 +65,7 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signInButton)
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, secondPrimaryEmail)
       .wclick(CSS['dialog'].addNewEmailButton)
       .wclick(CSS['dialog'].verifyWithPrimaryButton)

--- a/automation-tests/tests/add-primary-to-secondary.js
+++ b/automation-tests/tests/add-primary-to-secondary.js
@@ -72,6 +72,7 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signInButton)
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, primaryEmail)
       .wclick(CSS['dialog'].addNewEmailButton)
       .wclick(CSS['dialog'].verifyWithPrimaryButton)

--- a/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
@@ -73,6 +73,7 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signinButton)
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].signInButton)
+      .wclick(CSS['dialog'].choosePassword) // Click this text field to help IE8.
       .wtype(CSS['dialog'].choosePassword, 'password')
       .wtype(CSS['dialog'].verifyPassword, 'password')
       .wclick(CSS['dialog'].createUserButton, done);

--- a/automation-tests/tests/idp-transition/transition-to-secondary-forgot-password.js
+++ b/automation-tests/tests/idp-transition/transition-to-secondary-forgot-password.js
@@ -83,6 +83,7 @@ runner.run(module, {
   "add primary email to account": function(done) {
     browser.chain({onError: done})
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, primaryToSecondaryUser)
       .wclick(CSS['dialog'].addNewEmailButton)
       .wwin(done);

--- a/automation-tests/tests/idp-transition/transition-to-secondary.js
+++ b/automation-tests/tests/idp-transition/transition-to-secondary.js
@@ -83,6 +83,7 @@ runner.run(module, {
   "add primary email to account": function(done) {
     browser.chain({onError: done})
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, primaryToSecondaryUser)
       .wclick(CSS['dialog'].addNewEmailButton)
       .wwin(done);

--- a/automation-tests/tests/remove-email.js
+++ b/automation-tests/tests/remove-email.js
@@ -109,6 +109,7 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signInButton)
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, secondPrimaryEmail)
       .wclick(CSS['dialog'].addNewEmailButton)
       .wclick(CSS['dialog'].verifyWithPrimaryButton)
@@ -125,8 +126,10 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signInButton)
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, secondaryEmail)
       .wclick(CSS['dialog'].addNewEmailButton)
+      .wclick(CSS['dialog'].choosePassword) // Click this text field to help IE8.
       .wtype(CSS['dialog'].choosePassword, secondaryPassword)
       .wtype(CSS['dialog'].verifyPassword, secondaryPassword)
       .wclick(CSS['dialog'].createUserButton, done);

--- a/automation-tests/tests/reset-password-test.js
+++ b/automation-tests/tests/reset-password-test.js
@@ -68,6 +68,7 @@ runner.run(module, {
 
   "after password reset, original browser asks for new password 'cause this is a different browser": function(done) {
     browser.chain({onError: done})
+      .wclick(CSS['dialog'].postVerificationPassword) // Click this text field to help IE8.
       .wtype(CSS['dialog'].postVerificationPassword, NEW_PASSWORD)
       .wclick(CSS['dialog'].postVerificationPasswordButton, done);
   },

--- a/automation-tests/tests/returning-user.js
+++ b/automation-tests/tests/returning-user.js
@@ -63,9 +63,12 @@ runner.run(module, {
       .wclick(CSS['123done.org'].signinButton)
       .wwin(CSS['persona.org'].windowName)
       .wclick(CSS['dialog'].useNewEmail)
+      .wclick(CSS['dialog'].newEmail) // Click this text field to help IE8.
       .wtype(CSS['dialog'].newEmail, secondary)
       .wclick(CSS['dialog'].addNewEmailButton)
+      .wclick(CSS['dialog'].choosePassword) // Click this text field to help IE8.
       .wtype(CSS['dialog'].choosePassword, secondary.split('@')[0])
+      .wclick(CSS['dialog'].choosePassword) // Click this text field to help IE8.
       .wtype(CSS['dialog'].verifyPassword, secondary.split('@')[0])
       .wclick(CSS['dialog'].createUserButton, done)
   },


### PR DESCRIPTION
This is the wrong way to fix this, as it points out some focus issues on IE8 in the UI. So don't actually merge this PR if we can clean up where focus is wrong.

So, when https://github.com/lloyd/testidp.org/issues/10 is fixed, and the IE8 focus issues get resolved, the IE{8.9} situation goes from this:

![pre](https://f.cloud.github.com/assets/758162/673110/486402e0-d8a9-11e2-9709-9163c9cfa051.png)

To this;
![post](https://f.cloud.github.com/assets/758162/673111/52e31224-d8a9-11e2-8d37-d1ae60d4b807.png)

(Side note: Opera is confused about clicking on the button with an very long testidp.org email address that extends outside the view to the left; this seems to me a bug in OperaDriver targetting the top-left rather than the middle of the element. Some of the OSX failures for Safari are due to the lack of support for dealing with `alert`'s (already an issue on file)).
