### PR TITLE
When the user cancels from the "primary_offline" state, reset the caches so the user can try the address again.

### DIFF
--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -421,8 +421,8 @@ BrowserID.State = (function() {
         // the record info.
         record = user.getStoredEmailKeypair(email);
 
-        // XXX If the user has a cert, do we really care of the primary is
-        // offline? Shouldn't we just sign them in?
+        // If a primary is offline, do not generate a cert for it because there
+        // is a good chance that the RP cannot fetch the IdP's public key.
         if ('offline' === addressInfo.state) {
           redirectToState("primary_offline", addressInfo);
         }

--- a/resources/static/dialog/js/modules/primary_offline.js
+++ b/resources/static/dialog/js/modules/primary_offline.js
@@ -5,10 +5,14 @@ BrowserID.Modules.PrimaryOffline = (function() {
   "use strict";
 
   var bid = BrowserID,
-      helpers = bid.Helpers;
+      helpers = bid.Helpers,
+      user = bid.User;
 
   function startDialogOver() {
     /*jshint validthis:true*/
+    // Reset the caches so that a user who cancels from this screen can go back
+    // and try the same address again in a few minutes.
+    user.resetCaches();
     this.close("cancel_state");
   }
 
@@ -23,7 +27,11 @@ BrowserID.Modules.PrimaryOffline = (function() {
       self.renderError("primary_offline", options);
       self.click("#primary_offline_confirm", startDialogOver);
       Module.sc.start.call(self, options);
-    }
+    },
+
+    // BEGIN TESTING API
+    cancel: startDialogOver
+    // END TESTING API
   });
 
   return Module;


### PR DESCRIPTION
@ozten, you were the original module author, mind giving this a review?

An ephemeral instance is set up at https://address-lookup-faill.personatest.org

Fixes #3155
