### PR TITLE
Fixes #2482 : Add 90 day expires header to /favicon.ico

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -183,6 +183,9 @@ exports.resources = {
   ],
   '/production/relay.js': [
     '/relay/relay.js'
+  ],
+  '/favicon.ico': [
+    '/favicon.ico'
   ]
 };
 exports.resources[dialog_min_js] = dialog_js;

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -30,6 +30,7 @@
   <!--[if lt IE 9]>
     <%- cachify_css('/production/ie8_dialog.css') %>
   <![endif]-->
+  <link rel="shortcut icon" href=<%- cachify('/favicon.ico') -%>>
   <% /* the title comes from the server when the page is loaded.
          It still needs translated, so wrap it in its own gettext
      */ %>

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -14,6 +14,7 @@
     <%- cachify_css('/production/ie8_main.css') %>
   <![endif]-->
   <%- cachify_js(util.format('/production/%s/browserid.js', locale)) %>
+  <link rel="shortcut icon" href=<%- cachify('/favicon.ico') -%>>
   <% /* the title comes from the server when the page is loaded.
          It still needs translated, so wrap it in its own gettext
      */ %>


### PR DESCRIPTION
For issue #2482.

@shane-tomlinson This is my first attempt at doing anything in browserid (so please forgive me my inadequacies).

Ok, so my plan was to add a 90 days expires to the /favicon.ico. From one level it looks fine. I've added the magic number to lib/configuration.js, and also added it to config/production.json but added it as a one-day expire to config/local.json. Not sure if these are the best numbers, but certainly it was testing my mental state as to what was going on.

But the real question is whether this is ok. The headers on favicon locally prior to the patch were:

```
tiger:~/src/mozilla-browserid<dev>$ curl -I http://localhost:10010/favicon.ico
HTTP/1.1 200 OK
X-Powered-By: Express
x-frame-options: DENY
Date: Tue, 25 Jun 2013 06:10:05 GMT
Cache-Control: public, max-age=0
Last-Modified: Tue, 25 Jun 2013 05:39:30 GMT
ETag: "1150-1372138770000"
Content-Type: image/x-icon
Accept-Ranges: bytes
Content-Length: 1150
Access-Control-Allow-Origin: http://127.0.0.1:10002
Vary: Accept-Encoding,Accept-Language
Connection: keep-alive
```

And now they are:

```
tiger:~/src/mozilla-browserid<dev>$ curl -I http://localhost:10010/favicon.ico
HTTP/1.1 200 OK
X-Powered-By: Express
x-frame-options: DENY
Access-Control-Allow-Origin: http://127.0.0.1:10002
Vary: Accept-Encoding,Accept-Language
Content-Type: image/x-icon
Content-Length: 1150
ETag: "b10db83c6c2dcf7afb278ec81bb2fbc0"
Cache-Control: public, max-age=7776000
Date: Tue, 25 Jun 2013 06:35:28 GMT
Connection: keep-alive
```

Since I used `connect.favicon()` to serve the content, it looks like it has changed the format of the ETag header. Also the Last-Modified has gone (does this matter with the new Cache-Control?). Accept-Ranges has also gone.

Again, not sure that using `connect.favicon()` is ok - whilst it can do the job, I mainly used it so I could set a separate `maxAge` in the options, separate from the `connect.static()` middleware just below it.

Would love to know your thoughts. :)

Cheers,
Andy
