### PR TITLE
Ensure caches always check ETags on dynamic pages. Fixes #3547

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -39,7 +39,7 @@ function cacheAllTheThings(res) {
   if (config.get('env') !== 'local') {
     // allow caching, but require revalidation via ETag
     res.etagify();
-    res.setHeader('Cache-Control', 'public, max-age=0');
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
   } else {
     // disable all caching for local dev
     res.setHeader('Cache-Control', 'no-store');

--- a/tests/cache-header-tests.js
+++ b/tests/cache-header-tests.js
@@ -74,8 +74,8 @@ function hasProperCacheHeaders(path) {
       assert.strictEqual(r.statusCode, 200);
       // check X-Frame-Option headers
       hasProperFramingHeaders(r, path);
-      // ensure public, max-age=0
-      assert.strictEqual(r.headers['cache-control'], 'public, max-age=0');
+      // ensure public, max-age=0, must-revalidate
+      assert.strictEqual(r.headers['cache-control'], 'public, max-age=0, must-revalidate');
       // the behavior of combining a last-modified date and an etag is undefined by
       // rfc2616, so let's always use ETags, and ignore last modified date.
       assert.ok(r.headers['etag'])


### PR DESCRIPTION
@shane-tomlinson or @jrgm, mind having a look? I feel like this bug took me down a rabbit hole into an upside down world of eight-year-old blog posts/bugzilla bugs covering HTTP caching quirks in IE6 etc. Yuck!

Not sure the best way to test this. I considered actually changing the static endpoints and reloading the dialog, but it seems like there should be a way to do this via front-end unit test.
