### PR TITLE
Give useful information to the KPIs when reporting a custom error.

### DIFF
--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -47,12 +47,16 @@ BrowserID.Modules.InteractionData = (function() {
     var parts = [];
 
     if (data.action) {
-      parts.push(_.keyOf(errors, data.action));
+      var errorType = _.keyOf(errors, data.action)
+                          || data.action.title || "unknown";
+      parts.push(errorType);
     }
 
     if (data.network && data.network.status > 399) {
       parts.push(data.network.status);
     }
+
+    if (!parts.length) parts[0] = "unknown";
 
     return 'screen.error.' + parts.join('.');
   }

--- a/resources/static/test/cases/common/js/modules/interaction_data.js
+++ b/resources/static/test/cases/common/js/modules/interaction_data.js
@@ -382,19 +382,37 @@
     start();
   });
 
-  test("error_screen formats an error object", function() {
+  function testErrorScreen(config, expectedErrorType) {
     createController();
-    controller.addEvent("error_screen", {
-      action: errors.addressInfo,
-      network: {
-        status: 503
-      }
-    });
+    controller.addEvent("error_screen", config);
 
     var eventStream = controller.getCurrentEventStream();
     var errorEvent = eventStream.pop();
 
-    equal(errorEvent[0], "screen.error.addressInfo.503");
+    equal(errorEvent[0], expectedErrorType);
+  }
+
+  test("error_screen formats an error object", function() {
+    testErrorScreen({
+      action: errors.addressInfo,
+      network: {
+        status: 503
+      }
+    }, "screen.error.addressInfo.503");
+  });
+
+  test("error_screen takes care of custom error types", function() {
+    testErrorScreen({
+      action: {
+        title: "custom error type"
+      }
+    }, "screen.error.custom error type");
+  });
+
+  test("error_screen takes care of error type without title", function() {
+    testErrorScreen({
+      action: { }
+    }, "screen.error.unknown");
   });
 
   asyncTest("Consecutive xhr_complete messages for the same URL only have one entry", function() {


### PR DESCRIPTION
- If reporting a custom error type, use the action.title field as the reported error.

fixes #3584
