### PR TITLE
Better sync dialog service state

### DIFF
--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -24,19 +24,16 @@ BrowserID.Modules.Actions = (function() {
       try {
         serviceManager.stop(runningService);
       } catch (e) {
-        // stop() throws if module wasn't running, no action needed,
-        // but IE8 can't do try/finally without a dummy catch. see eg
-        // http://webbugtrack.blogspot.com/2007/11/bug-184-catch-to-try-catch-finally-in.html
-      } finally {
-        runningService = null;
+        // stop() throws if runningService wasn't running, no action needed.
       }
+      runningService = null;
     }
 
     var module;
     try {
       module = serviceManager.start(name, options);
     } catch (e) {
-      // module failed to start or was already running.
+      // service failed to start or was already running.
       // we must parse the error message to determine which.
       if (e.message.indexOf('already running') > -1) {
         runningService = name;


### PR DESCRIPTION
Needs comments. @shane-tomlinson mind taking a look?

When investigating #3466, I found out that there are some edge cases in which BrowserID.Modules.Actions doesn't cleanly sync the currently-running service state held by BrowserID.module.

In this diff, I've added some try/catches to ensure that the `runningService` state in Actions is properly unset and reset.

However, in making this change, the dialog/js/modules/actions unit tests fail--because they expect uncaught Errors to be thrown, and assert on the contents of the error message. This doesn't seem to match up with the actual use of the `start` and `stop` methods in the codebase, though: `start` and `stop` are called by [`startService`](https://github.com/mozilla/browserid/blob/dev/resources/static/dialog/js/modules/actions.js#L19-L33), which in turn is called by methods like [`doRPInfo`](https://github.com/mozilla/browserid/blob/dev/resources/static/dialog/js/modules/actions.js#L191-L193). No try/catches anywhere.

I can see two ways to go: either we modify the unit tests, or maybe we merge bid.Modules.Actions and bid.module, so that there's no need to juggle state across the two. Making the latter change is currently is a bit outside what I can pull off, I'd like to get input before delving in.

I guess a third option would be to let the Errors be uncaught and just be a little more careful about when we unset and reset `runningService` without adding all the try/catch/finally stuff.
