### PR TITLE
Fixes #3573 : make sure the '.buttonrow > .right' buttons line up on the right hand side

### DIFF
--- a/resources/views/dialog.ejs
+++ b/resources/views/dialog.ejs
@@ -95,7 +95,7 @@
 
                     <p class="submit cf buttonrow">
 
-                      <button class="isDesktop isStart isAddressInfo right">
+                      <button class="isDesktop isStart isAddressInfo">
                         <%= gettext('next') %>
                       </button>
 


### PR DESCRIPTION
Patch for #3573.

Hoping that this doesn't affect anything else. 
