### PR TITLE
Async snippet 2

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -85,7 +85,7 @@ function onScriptLoaded(s) {
         // if navigator.id's reference has been replaced by the shim,
         // _qd will no longer be available.
         if (nav.id._qd) {
-          // bail till ready, back off slowly with no timeout because EDGE/2G
+          // bail till ready, back off slowly with no timeout
           return setTimeout(onParsed, parseWait+=50);
         }
         while (next = idq.shift()) {

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -47,6 +47,43 @@ pre {
 }
 
 </style>
+<script>
+navigator.id = navigator.id || {}; // important: does include.js bail if navigator.id, navigator.id.watch, or navigator.id.get is defined?
+navigator.id.q = [];
+
+function makeQueueable(funcName) {
+  var f = function() { navigator.id.q.push({func: funcName, args: arguments}) }
+  f.isQueueable = true; // so we can check it was overwritten
+  return f;
+}
+navigator.id.watch = makeQueueable('watch');
+navigator.id.get = makeQueueable('get');
+
+var scr = document.createElement('script');
+scr.async = true;
+scr.src = 'https://login.persona.org/include.js';
+scr.onload = scr.onreadystatechange = function() {
+  var rdyState = scr.readyState;
+  if (!rdyState || /loaded|complete/.test(rdyState)) {
+    var pollCount = 0;
+    function onParsed() {
+      if (navigator.id.watch.isQueueable || navigator.id.get.isQueueable) {
+        pollCount++;
+        if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
+        return setTimeout(onParsed, 50); // bail till ready, todo verify it's acutally needed to wait for parse time.
+      }
+      while (navigator.id.q.length) {
+        var next = navigator.id.q.shift();
+        navigator.id[next.func].apply(null, next.args);
+      }
+      scr.onload = null;
+      scr.onreadystatechange = null;
+    }
+  }
+};
+var entry = document.getElementsByTagName('script')[0];
+entry.parentNode.insertBefore(scr, entry);
+</script>
 </head>
 <body>
 <div class="title">
@@ -125,7 +162,6 @@ pre {
 </body>
 
 <script src="jquery-min.js"></script>
-<script src="https://login.persona.org/include.js"></script>
 <script>
 
 try {

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -49,41 +49,17 @@ pre {
 </style>
 <script>
 navigator.id = navigator.id || {}; // important: does include.js bail if navigator.id, navigator.id.watch, or navigator.id.get is defined?
-navigator.id.q = [];
+navigator.idq = [];
 
 function makeQueueable(funcName) {
-  var f = function() { navigator.id.q.push({func: funcName, args: arguments}) }
+  var f = function() { navigator.idq.push({func: funcName, args: arguments}) }
   f.isQueueable = true; // so we can check it was overwritten
   return f;
 }
 navigator.id.watch = makeQueueable('watch');
 navigator.id.get = makeQueueable('get');
-
-var scr = document.createElement('script');
-scr.async = true;
-scr.src = 'https://login.persona.org/include.js';
-scr.onload = scr.onreadystatechange = function() {
-  var rdyState = scr.readyState;
-  if (!rdyState || /loaded|complete/.test(rdyState)) {
-    var pollCount = 0;
-    function onParsed() {
-      if (navigator.id.watch.isQueueable || navigator.id.get.isQueueable) {
-        pollCount++;
-        if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
-        return setTimeout(onParsed, 50); // bail till ready, todo verify it's acutally needed to wait for parse time.
-      }
-      while (navigator.id.q.length) {
-        var next = navigator.id.q.shift();
-        navigator.id[next.func].apply(null, next.args);
-      }
-      scr.onload = null;
-      scr.onreadystatechange = null;
-    }
-  }
-};
-var entry = document.getElementsByTagName('script')[0];
-entry.parentNode.insertBefore(scr, entry);
 </script>
+
 </head>
 <body>
 <div class="title">
@@ -263,4 +239,33 @@ $(document).ready(function() {
 
 </script>
 
+<script>
+var scr = document.createElement('script');
+scr.async = true;
+scr.src = 'https://login.persona.org/include.js';
+scr.onload = scr.onreadystatechange = function() {
+  var rdyState = scr.readyState;
+  // if (!rdyState || /loaded|complete/.test(rdyState)) {
+  if (!rdyState || /loaded|complete/.test(rdyState)) {
+    var pollCount = 0;
+    function onParsed() {
+      if (navigator.id.watch.isQueueable || navigator.id.get.isQueueable) {
+        pollCount++;
+        if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
+        return setTimeout(onParsed, 50); // bail till ready, todo verify it's acutally needed to wait for parse time.
+      }
+      while (navigator.idq.length) {
+        var next = navigator.idq.shift();
+        navigator.id[next.func].apply(navigator.id, next.args);
+      }
+      delete navigator.idq;
+      scr.onload = null;
+      scr.onreadystatechange = null;
+    }
+    onParsed()
+  }
+};
+var entry = document.getElementsByTagName('script')[0];
+entry.parentNode.insertBefore(scr, entry);
+</script>
 </html>

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -60,8 +60,12 @@ var api = ['get','getVerifiedEmail','logout','request','watch'],
     parseWait = 50,
     next,
     doc = document,
-    isIE = !!doc.attachEvent,
-    scr = doc.createElement('script');
+    readyState = 'readyState',
+    attachEvent = 'attachEvent',
+    DOMContentLoaded = 'DOMContentLoaded',
+    isIE = !!doc[attachEvent],
+    scr = doc.createElement('script'),
+    onreadystatechange = 'onreadystatechange';
 
 // stub out the API
 while(funcName = api.pop()) {
@@ -75,7 +79,7 @@ id._qd = id._shimmed = true;
 
 function onScriptLoaded(s) {
   return function() {
-    rdyState = s.readyState;
+    rdyState = s[readyState];
     if (!rdyState || /loaded|complete/.test(rdyState)) {
       (function onParsed() {
         // if navigator.id's reference has been replaced by the shim,
@@ -87,7 +91,7 @@ function onScriptLoaded(s) {
         while (next = idq.shift()) {
           nav.id[next.f].apply(nav.id, next.a);
         }
-        s.onload = s.onreadystatechange = null;
+        s.onload = s[onreadystatechange] = null;
       }());
     }
   };
@@ -95,21 +99,21 @@ function onScriptLoaded(s) {
 
 // insert script on DOMContentReady with IE8 fallback
 function addScript() {
-  isIE ? doc.detachEvent('onreadystatechange', addScript) :
-    doc.removeEventListener('DOMContentLoaded', addScript, false);
+  isIE ? doc.detachEvent(onreadystatechange, addScript) :
+    doc.removeEventListener(DOMContentLoaded, addScript, false);
   scr.async = true; scr.type = 'text/javascript';
-  scr.src = 'https://login.persona.org/include.js'; scr.onload = scr.onreadystatechange = onScriptLoaded(scr);
+  scr.src = 'https://login.persona.org/include.js'; scr.onload = scr[onreadystatechange] = onScriptLoaded(scr);
   doc.getElementsByTagName('script')[0].parentNode.appendChild(scr);
 }
 
-isIE ? doc.attachEvent('onreadystatechange', function() { if (doc.readyState === 'complete') addScript() }) :
-  doc.addEventListener('DOMContentLoaded', addScript, false);
+isIE ? doc[attachEvent](onreadystatechange, function() { if (doc[readyState] === 'complete') addScript() }) :
+  doc.addEventListener(DOMContentLoaded, addScript, false);
 }
 }());
 
-/* uglified version: 916 bytes, and I'm sure we could shrink it further.
+/* uglified version: 853 bytes, and I bet we could shrink it further.
 
-(function(){function l(b){return function(){f=b.readyState,(!f||/loaded|complete/.test(f))&&function c(){if(a.id._qd)return setTimeout(c,g+=50);for(;h=d.shift();)a.id[h.f].apply(a.id,h.a);b.onload=b.onreadystatechange=null}()}}function m(){j?i.detachEvent("onreadystatechange",m):i.removeEventListener("DOMContentLoaded",m,!1),k.async=!0,k.type="text/javascript",k.src="https://login.persona.org/include.js",k.onload=k.onreadystatechange=l(k),i.getElementsByTagName("script")[0].parentNode.appendChild(k)}var a=navigator;if(!a.id&&!a.mozId){for(var c,f,h,b=["get","getVerifiedEmail","logout","request","watch"],d=[],e=a.id={},g=50,i=document,j=!!i.attachEvent,k=i.createElement("script");c=b.pop();)e[c]=function(a){return function(){d.push({f:a,a:arguments})}}(c);e._qd=e._shimmed=!0,j?i.attachEvent("onreadystatechange",function(){"complete"===i.readyState&&m()}):i.addEventListener("DOMContentLoaded",m,!1)}})();
+(function(){function p(b){return function(){f=b[j],(!f||/loaded|complete/.test(f))&&function c(){if(a.id._qd)return setTimeout(c,g+=50);for(;h=d.shift();)a.id[h.f].apply(a.id,h.a);b.onload=b[o]=null}()}}function q(){m?i.detachEvent(o,q):i.removeEventListener(l,q,!1),n.async=!0,n.type="text/javascript",n.src="https://login.persona.org/include.js",n.onload=n[o]=p(n),i.getElementsByTagName("script")[0].parentNode.appendChild(n)}var a=navigator;if(!a.id&&!a.mozId){for(var c,f,h,b=["get","getVerifiedEmail","logout","request","watch"],d=[],e=a.id={},g=50,i=document,j="readyState",k="attachEvent",l="DOMContentLoaded",m=!!i[k],n=i.createElement("script"),o="onreadystatechange";c=b.pop();)e[c]=function(a){return function(){d.push({f:a,a:arguments})}}(c);e._qd=e._shimmed=!0,m?i[k](o,function(){"complete"===i[j]&&q()}):i.addEventListener(l,q,!1)}})();
 
 */
 </script>

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -48,22 +48,70 @@ pre {
 
 </style>
 <script>
-// first part of the async snippet. has to be loaded before other scripts relying on persona.
-// if include.js is loaded async, does it need to be separate?
-// yes I think, because the RP might require in a content script and get a 'navigator.id.foo is undefined' error.
-if (navigator.id || navigator.mozId) { return; }
-navigator.id = {}; navigator.idq = [];
-function makeQueueable(funcName) {
-  var f = function() { navigator.idq.push({func: funcName, args: arguments}) }
-  f.isQueueable = true; // so we can check it was overwritten
-  return f;
-}
+// unminified async snippet
+(function() {
+var nav=navigator;
+if (!nav.id && !nav.mozId) {
+var api = ['get','getVerifiedEmail','logout','request','watch'],
+    funcName,
+    idq = [],
+    id = nav.id = {},
+    rdyState,
+    parseWait = 50,
+    next,
+    doc = document,
+    isIE = !!doc.attachEvent,
+    scr = doc.createElement('script');
+
 // stub out the API
-navigator.id.get = makeQueueable('get');
-navigator.id.getVerifiedEmail = makeQueueable('getVerifiedEmail');
-navigator.id.logout = makeQueueable('logout');
-navigator.id.request = makeQueueable('request');
-navigator.id.watch = makeQueueable('watch');
+while(funcName = api.pop()) {
+  id[funcName] = (function(funcName) {
+    return function() { idq.push({f: funcName, a: arguments}); };
+  }(funcName));
+}
+// _qd is a marker for us to keep track of whether the shim has overridden
+// id. _shimmed forces the shim to overwrite id when it loads
+id._qd = id._shimmed = true;
+
+function onScriptLoaded(s) {
+  return function() {
+    rdyState = s.readyState;
+    if (!rdyState || /loaded|complete/.test(rdyState)) {
+      (function onParsed() {
+        // if navigator.id's reference has been replaced by the shim,
+        // _qd will no longer be available.
+        if (nav.id._qd) {
+          // bail till ready, back off slowly with no timeout because EDGE/2G
+          return setTimeout(onParsed, parseWait+=50);
+        }
+        while (next = idq.shift()) {
+          nav.id[next.f].apply(nav.id, next.a);
+        }
+        s.onload = s.onreadystatechange = null;
+      }());
+    }
+  };
+}
+
+// insert script on DOMContentReady with IE8 fallback
+function addScript() {
+  isIE ? doc.detachEvent('onreadystatechange', addScript) :
+    doc.removeEventListener('DOMContentLoaded', addScript, false);
+  scr.async = true; scr.type = 'text/javascript';
+  scr.src = 'https://login.persona.org/include.js'; scr.onload = scr.onreadystatechange = onScriptLoaded(scr);
+  doc.getElementsByTagName('script')[0].parentNode.appendChild(scr);
+}
+
+isIE ? doc.attachEvent('onreadystatechange', function() { if (doc.readyState === 'complete') addScript() }) :
+  doc.addEventListener('DOMContentLoaded', addScript, false);
+}
+}());
+
+/* uglified version: 916 bytes, and I'm sure we could shrink it further.
+
+(function(){function l(b){return function(){f=b.readyState,(!f||/loaded|complete/.test(f))&&function c(){if(a.id._qd)return setTimeout(c,g+=50);for(;h=d.shift();)a.id[h.f].apply(a.id,h.a);b.onload=b.onreadystatechange=null}()}}function m(){j?i.detachEvent("onreadystatechange",m):i.removeEventListener("DOMContentLoaded",m,!1),k.async=!0,k.type="text/javascript",k.src="https://login.persona.org/include.js",k.onload=k.onreadystatechange=l(k),i.getElementsByTagName("script")[0].parentNode.appendChild(k)}var a=navigator;if(!a.id&&!a.mozId){for(var c,f,h,b=["get","getVerifiedEmail","logout","request","watch"],d=[],e=a.id={},g=50,i=document,j=!!i.attachEvent,k=i.createElement("script");c=b.pop();)e[c]=function(a){return function(){d.push({f:a,a:arguments})}}(c);e._qd=e._shimmed=!0,j?i.attachEvent("onreadystatechange",function(){"complete"===i.readyState&&m()}):i.addEventListener("DOMContentLoaded",m,!1)}})();
+
+*/
 </script>
 
 </head>
@@ -243,60 +291,5 @@ $(document).ready(function() {
   $('#loggedInUser').val(storage.loggedInUser ? storage.loggedInUser : "");
 });
 
-</script>
-
-<script>
-// TODO: maybe a blog post on this stuff, eh?
-// TODO: instead of just loading in regular flow, wait until 'onload' or other
-//       event fires. this is possible, but tricky in IE8.
-// WIP refs: 
-//  disqus embed: http://help.disqus.com/customer/portal/articles/472097-universal-embed-code
-//  ga embed: https://developers.google.com/analytics/devguides/collection/gajs/
-//  meebo embed: https://github.com/meebo/embed-code/blob/master/embed-code.js
-//  lightningjs embed (so crufty): https://github.com/olark/lightningjs/blob/master/lightningjs-embed.js
-//  great SO answer on custom IE8 events, need to confirm accurate with wrox book: http://stackoverflow.com/questions/13435008/how-to-trigger-a-custom-javascript-event-in-ie8
-
-/* to make onScriptLoaded smaller + look like something not to be tampered with,
-   we can set some vars (nid = navigator.id, nidw = nid.watch, nidq = navigator.idq),
-   then minify it:
-
-   function onScriptLoaded(e){var t=navigator.id,n=t.watch,r=navigator.idq;return function(){
-   var i=e.readyState;if(!i||/loaded|complete/.test(i)){var o=0;function u(){if(n.isQueueable){
-   o++;if(o>200){throw new Error("include.js failed to load after 10 sec")}return setTimeout(u,50)
-   }while(r.length){var i=r.shift();t[i.func].apply(navigator.id,i.args)}delete navigator.idq;
-   e.onload=null;e.onreadystatechange=null}u()}}}
-
-*/
-function onScriptLoaded(s) {
-  return function() {
-    var rdyState = s.readyState;
-    if (!rdyState || /loaded|complete/.test(rdyState)) {
-      var pollCount = 0;
-      function onParsed() {
-        if (navigator.id.watch.isQueueable) {
-          pollCount++;
-          if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
-          return setTimeout(onParsed, 50); // bail till ready, todo verify it's actually needed to wait for parse time.
-        }
-        while (navigator.idq.length) {
-          var next = navigator.idq.shift();
-          navigator.id[next.func].apply(navigator.id, next.args);
-        }
-        delete navigator.idq;
-        s.onload = null;
-        s.onreadystatechange = null;
-      }
-      onParsed()
-    }
-  };
-}
-
-var scr = document.createElement('script'); scr.async = true; scr.type = 'text/javascript';
-scr.src = 'https://login.persona.org/include.js'; scr.onload = scr.onreadystatechange = onScriptLoaded(scr);
-// GA snippet and 3pJS book
-var entry = document.getElementsByTagName('script')[0]; entry.parentNode.insertBefore(scr, entry);
-// cleaner, how disqus currently does it:
-// (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(scr);
-}
 </script>
 </html>

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -48,16 +48,22 @@ pre {
 
 </style>
 <script>
-navigator.id = navigator.id || {}; // important: does include.js bail if navigator.id, navigator.id.watch, or navigator.id.get is defined?
-navigator.idq = [];
-
+// first part of the async snippet. has to be loaded before other scripts relying on persona.
+// if include.js is loaded async, does it need to be separate?
+// yes I think, because the RP might require in a content script and get a 'navigator.id.foo is undefined' error.
+if (navigator.id || navigator.mozId) { return; }
+navigator.id = {}; navigator.idq = [];
 function makeQueueable(funcName) {
   var f = function() { navigator.idq.push({func: funcName, args: arguments}) }
   f.isQueueable = true; // so we can check it was overwritten
   return f;
 }
-navigator.id.watch = makeQueueable('watch');
+// stub out the API
 navigator.id.get = makeQueueable('get');
+navigator.id.getVerifiedEmail = makeQueueable('getVerifiedEmail');
+navigator.id.logout = makeQueueable('logout');
+navigator.id.request = makeQueueable('request');
+navigator.id.watch = makeQueueable('watch');
 </script>
 
 </head>
@@ -240,32 +246,57 @@ $(document).ready(function() {
 </script>
 
 <script>
-var scr = document.createElement('script');
-scr.async = true;
-scr.src = 'https://login.persona.org/include.js';
-scr.onload = scr.onreadystatechange = function() {
-  var rdyState = scr.readyState;
-  // if (!rdyState || /loaded|complete/.test(rdyState)) {
-  if (!rdyState || /loaded|complete/.test(rdyState)) {
-    var pollCount = 0;
-    function onParsed() {
-      if (navigator.id.watch.isQueueable || navigator.id.get.isQueueable) {
-        pollCount++;
-        if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
-        return setTimeout(onParsed, 50); // bail till ready, todo verify it's acutally needed to wait for parse time.
+// TODO: maybe a blog post on this stuff, eh?
+// TODO: instead of just loading in regular flow, wait until 'onload' or other
+//       event fires. this is possible, but tricky in IE8.
+// WIP refs: 
+//  disqus embed: http://help.disqus.com/customer/portal/articles/472097-universal-embed-code
+//  ga embed: https://developers.google.com/analytics/devguides/collection/gajs/
+//  meebo embed: https://github.com/meebo/embed-code/blob/master/embed-code.js
+//  lightningjs embed (so crufty): https://github.com/olark/lightningjs/blob/master/lightningjs-embed.js
+//  great SO answer on custom IE8 events, need to confirm accurate with wrox book: http://stackoverflow.com/questions/13435008/how-to-trigger-a-custom-javascript-event-in-ie8
+
+/* to make onScriptLoaded smaller + look like something not to be tampered with,
+   we can set some vars (nid = navigator.id, nidw = nid.watch, nidq = navigator.idq),
+   then minify it:
+
+   function onScriptLoaded(e){var t=navigator.id,n=t.watch,r=navigator.idq;return function(){
+   var i=e.readyState;if(!i||/loaded|complete/.test(i)){var o=0;function u(){if(n.isQueueable){
+   o++;if(o>200){throw new Error("include.js failed to load after 10 sec")}return setTimeout(u,50)
+   }while(r.length){var i=r.shift();t[i.func].apply(navigator.id,i.args)}delete navigator.idq;
+   e.onload=null;e.onreadystatechange=null}u()}}}
+
+*/
+function onScriptLoaded(s) {
+  return function() {
+    var rdyState = s.readyState;
+    if (!rdyState || /loaded|complete/.test(rdyState)) {
+      var pollCount = 0;
+      function onParsed() {
+        if (navigator.id.watch.isQueueable) {
+          pollCount++;
+          if (pollCount > 200) { throw new Error('include.js failed to load after 10 sec') }
+          return setTimeout(onParsed, 50); // bail till ready, todo verify it's actually needed to wait for parse time.
+        }
+        while (navigator.idq.length) {
+          var next = navigator.idq.shift();
+          navigator.id[next.func].apply(navigator.id, next.args);
+        }
+        delete navigator.idq;
+        s.onload = null;
+        s.onreadystatechange = null;
       }
-      while (navigator.idq.length) {
-        var next = navigator.idq.shift();
-        navigator.id[next.func].apply(navigator.id, next.args);
-      }
-      delete navigator.idq;
-      scr.onload = null;
-      scr.onreadystatechange = null;
+      onParsed()
     }
-    onParsed()
-  }
-};
-var entry = document.getElementsByTagName('script')[0];
-entry.parentNode.insertBefore(scr, entry);
+  };
+}
+
+var scr = document.createElement('script'); scr.async = true; scr.type = 'text/javascript';
+scr.src = 'https://login.persona.org/include.js'; scr.onload = scr.onreadystatechange = onScriptLoaded(scr);
+// GA snippet and 3pJS book
+var entry = document.getElementsByTagName('script')[0]; entry.parentNode.insertBefore(scr, entry);
+// cleaner, how disqus currently does it:
+// (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(scr);
+}
 </script>
 </html>


### PR DESCRIPTION
@shane-tomlinson mind taking a look? I could use some feedback.
#### Summary

This is a more well-rounded successor to the async snippet prototype I started last week (#3571). Seeking feedback.
#### Next Steps

If this looks good, I think the next step would be to create some RP integration docs (blog post and/or MDN page), and _maybe_ create a separate local testing example RP. Does this seem reasonable? Thoughts?
#### Background

We're in a bit of an awkward position relative to your typical third-party provider because we are shimming browser APIs, so our async snippet really does want to set global state. So, an async Persona snippet needs two parts: (1) something in the head that stubs out nav.id.\* before the script has loaded and sets up queues to collect function calls, and (2) the usual async snippet which builds a script tag, appends to the page, then unqueues waiting function calls when the script is ready.

This two-part thing seems complicated for a typical RP to have to integrate. I'm not sure.

The alternative I can think of is to put both parts of the snippet in the head, and wrap part (2) in a window.onload handler. This would also give additional flexibility, since the listener could be configured to listen for custom events--if the RP wanted to load some of their content scripts, and then fire nav.id.watch, for instance.
