### PR TITLE
Fix returning from IdP verification on FirefoxOS

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -28,7 +28,9 @@ BrowserID.Storage = (function() {
   "use strict";
 
   var ONE_DAY_IN_MS = (1000 * 60 * 60 * 24),
-      storage = BrowserID.getStorage();
+      IDP_INFO_LIFESPAN_MS = 1000 * 60 * 60,
+      storage = BrowserID.getStorage(),
+      win = window;
 
   // Set default values immediately so that IE8 localStorage synchronization
   // issues do not become a factor. See issue #2206
@@ -442,6 +444,118 @@ BrowserID.Storage = (function() {
     storage.emailToUserID = JSON.stringify(allInfo);
   }
 
+  // generate a random string for use as a per-window nonce.
+  function generateRandomString(length) {
+    var chars =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    var str = "";
+    for (var i = 0; i < length; ++i) {
+      str += chars.charAt(Math.ceil(Math.random() * chars.length));
+    }
+
+    return str;
+  }
+
+  function getIdpVerificationNonce() {
+    var nonce = sessionStorage.idpNonce || win.name;
+    var und;
+    // the dialog window name, when opened by the shim, is __persona_dialog.
+    // Ignore it, it's not a nonce.
+    if (nonce === "__persona_dialog") nonce = und;
+
+    return nonce;
+  }
+
+
+  function getIdpVerificationInfo(nonce) {
+    // set in dialog/modules/verify_with_primary.js if the user must
+    // verify with their primary.
+    nonce = nonce || getIdpVerificationNonce();
+
+    if (!nonce) return;
+
+    var storageKey = 'idpVerification' + nonce;
+    var data = storage[storageKey];
+
+    var primaryParams;
+    if (data)
+      try {
+        primaryParams = JSON.parse(data);
+      } catch(e) {
+        // invalid JSON, delete it
+        storage.removeItem(storageKey);
+        throw e;
+      }
+
+    return primaryParams;
+  }
+
+  function setIdpVerifcationInfo(nonce, info) {
+    // FirefoxOS has a bug where sessionStorage can be purged while the user
+    // is visiting their Idp. localStorage is safe. Instead of saving data
+    // to sessionStorage, which may go away, we have to save to localStorage
+    // in a way that avoids multi-window collisions. Create a per-window nonce.
+    // Save the nonce in a cross-browser compatible way (not as easy as it
+    // seems). Save the idpVerification info into localStorage using
+    // the nonce as a namespace. When the user returns from the Idp, look up
+    // the nonce and fetch the appropriate info.
+
+    if (!info) {
+      info = nonce;
+      nonce = generateRandomString(8);
+    }
+
+    // The nonce is a bit tricky. Since sessionStorage is not reliable in
+    // FirefoxOS, we need an alternate method. window.name survives across page
+    // redirects in FirefoxOS, but not in IE8. In IE8, when the user redirects
+    // to their primary, window.name is reset to "__persona_dialog". In IE8,
+    // sessionStorage survives redirects to the Idp. So, we save to both.
+    win.name = win.sessionStorage.idpNonce = nonce;
+
+    // save the date to allow expired info to be purged.
+    if (!info.created)
+      info.created = new Date().toString();
+
+    storage['idpVerification' + nonce] = JSON.stringify(info);
+  }
+
+  function clearIdpVerificationInfo() {
+    var nonce = getIdpVerificationNonce();
+
+    if (nonce) {
+      var storageKey = 'idpVerification' + nonce;
+      storage.removeItem(storageKey);
+    }
+
+    // clear any expired info
+    for (var i = 0; i < localStorage.length; ++i) {
+      var key = localStorage.key(i);
+      if (/^idpVerification/.test(key)) {
+        var info;
+        try {
+          info = JSON.parse(storage.getItem(key));
+        }
+        catch(e) {
+          storage.removeItem(key);
+          continue;
+        }
+
+        if (!(info && info.created)) {
+          storage.removeItem(key);
+          continue;
+        }
+
+        var createdTime = new Date(info.created).getTime();
+        var earliestValidTime = new Date().getTime() - IDP_INFO_LIFESPAN_MS;
+
+        if (createdTime < earliestValidTime)
+          storage.removeItem(key);
+      }
+    }
+  }
+
+
   return {
     /**
      * Add an email address and optional key pair.
@@ -612,7 +726,28 @@ BrowserID.Storage = (function() {
      * see issue #1637 for full details.
      * @method setDefaultValues
      */
-    setDefaultValues: setDefaultValues
+    setDefaultValues: setDefaultValues,
+
+    /**
+     * Info used after verifying ownership of an address with an Idp.
+     */
+    idpVerification: {
+      /**
+       * Get post-Idp verification info for this window
+       * @throws JSON.parse error if invalid JSON.
+       */
+      get: getIdpVerificationInfo,
+      /**
+       * Set post-Idp verification info for this window
+       */
+      set: setIdpVerifcationInfo,
+      /**
+       * Clear post-Idp verification info for this window as well as expired
+       * data
+       */
+      clear: clearIdpVerificationInfo,
+      INFO_LIFESPAN_MS: IDP_INFO_LIFESPAN_MS
+    }
     // BEGIN TRANSITION CODE
     /**
      * Upgrade the site->user logged in info from the loggedIn namespace to be

--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -444,19 +444,6 @@ BrowserID.Storage = (function() {
     storage.emailToUserID = JSON.stringify(allInfo);
   }
 
-  // generate a random string for use as a per-window nonce.
-  function generateRandomString(length) {
-    var chars =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-    var str = "";
-    for (var i = 0; i < length; ++i) {
-      str += chars.charAt(Math.ceil(Math.random() * chars.length));
-    }
-
-    return str;
-  }
-
   function getIdpVerificationNonce() {
     var nonce = sessionStorage.idpNonce || win.name;
     var und;
@@ -503,7 +490,7 @@ BrowserID.Storage = (function() {
 
     if (!info) {
       info = nonce;
-      nonce = generateRandomString(8);
+      nonce = String(Math.random());
     }
 
     // The nonce is a bit tricky. Since sessionStorage is not reliable in

--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -16,6 +16,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
       helpers = bid.Helpers,
       dialogHelpers = helpers.Dialog,
       complete = helpers.complete,
+      storage = bid.Storage,
       CANCEL_SELECTOR = ".cancel";
 
   function submit(callback) {
@@ -27,8 +28,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
     // if the user is not authenticated, results in an error.
     self.publish("primary_user_authenticating");
 
-    // set up some information about what we're doing
-    win.sessionStorage.primaryVerificationFlow = JSON.stringify({
+    storage.idpVerification.set({
       add: add,
       email: email,
       // native is used when the user returns from the primary to prevent

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -207,6 +207,39 @@
     testHelpers.testUndefined(storage.site.get(TEST_ORIGIN, "logged_in"), "sites with email no longer logged in");
   });
 
+  test("idpVerification functions, set, get, clear", function() {
+    storage.idpVerification.set({
+      email: "testuser@testuser.com",
+      'native': true
+    });
+
+    var info = storage.idpVerification.get();
+    equal(info.email, "testuser@testuser.com");
+    equal(info['native'], true);
+
+    storage.idpVerification.clear();
+    info = storage.idpVerification.get();
+    equal(typeof info, "undefined");
+  });
+
+  test("idpVerification - clear old info", function() {
+    var now = new Date().getTime();
+    // Set the start date to one second past the lifetime.
+    var expiredTime = now - storage.idpVerification.INFO_LIFESPAN_MS - 1;
+    var expiredDate = new Date();
+    expiredDate.setTime(expiredTime);
+    storage.idpVerification.set("expired", {
+      email: "expired@testuser.com",
+      created: expiredDate.toString()
+    });
+
+    sessionStorage.idpNonce = "hacked_in_for_testing";
+
+    storage.idpVerification.clear();
+    var info = storage.idpVerification.get("expired");
+    equal(typeof info, "undefined");
+  });
+
   // BEGIN TRANSITION CODE
   test("upgradeLoggedInInfo upgrades old loggedInInfo and removes namespace",
       function() {

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -14,6 +14,7 @@
       screens = bid.Screens,
       xhr = bid.Mocks.xhr,
       user = bid.User,
+      storage = bid.Storage,
       HTTP_TEST_DOMAIN = "http://testdomain.org",
       HTTPS_TEST_DOMAIN = "https://testdomain.org",
       TESTEMAIL = "testuser@testuser.com",
@@ -47,9 +48,7 @@
     location: {
     },
 
-    navigator: {},
-
-    sessionStorage: {}
+    navigator: {}
   };
 
   function createController(config) {
@@ -197,7 +196,7 @@
 
   asyncTest("initialization with #AUTH_RETURN and add=false - trigger start with correct params", function() {
     winMock.location.hash = "#AUTH_RETURN";
-    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+    storage.idpVerification.set({
       add: false,
       email: TESTEMAIL
     });
@@ -224,7 +223,7 @@
 
   asyncTest("initialization with #AUTH_RETURN and add=true - trigger start with correct params", function() {
     winMock.location.hash = "#AUTH_RETURN";
-    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+    storage.idpVerification.set({
       add: true,
       email: TESTEMAIL
     });
@@ -252,7 +251,7 @@
 
   asyncTest("#AUTH_RETURN while authenticated should call usedAddressAsPrimary", function() {
     winMock.location.hash = "#AUTH_RETURN";
-    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+    storage.idpVerification.set({
       add: false,
       email: TESTEMAIL
     });
@@ -280,7 +279,7 @@
 
   asyncTest("#AUTH_RETURN with add=true should not call usedAddressAsPrimary", function() {
     winMock.location.hash = "#AUTH_RETURN";
-    winMock.sessionStorage.primaryVerificationFlow = JSON.stringify({
+    storage.idpVerification.set({
       add: true,
       email: TESTEMAIL
     });

--- a/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/test/cases/dialog/js/modules/verify_primary_user.js
@@ -13,6 +13,7 @@
       xhr = bid.Mocks.xhr,
       WindowMock = bid.Mocks.WindowMock,
       win,
+      storage = bid.Storage,
       mediator = bid.Mediator,
       modules = bid.Modules;
 
@@ -91,7 +92,7 @@
 
   });
 
-  asyncTest("submit with `add: false` option opens a new tab with proper URL (updated for sessionStorage)", function() {
+  asyncTest("submit with `add: false` option opens a new tab with proper URL", function() {
     xhr.useResult("primaryUnknown");
 
     var messageTriggered = false;
@@ -114,8 +115,7 @@
           equal(messageTriggered, true);
           // make sure the data used when returning from the primary is as
           // expected.
-          var dataUsedOnReturnFromPrimary =
-              JSON.parse(win.sessionStorage.primaryVerificationFlow);
+          var dataUsedOnReturnFromPrimary = storage.idpVerification.get();
           equal(dataUsedOnReturnFromPrimary['native'], true);
           equal(dataUsedOnReturnFromPrimary.add, false);
           equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");
@@ -126,7 +126,7 @@
     });
   });
 
-  asyncTest("submit with `add: true` option opens a new tab with proper URL (updated for sessionStorage)", function() {
+  asyncTest("submit with `add: true` option opens a new tab with proper URL", function() {
 
     xhr.useResult("primaryUnknown");
     createController({
@@ -143,8 +143,7 @@
 
           // make sure the data used when returning from the primary is as
           // expected.
-          var dataUsedOnReturnFromPrimary =
-              JSON.parse(win.sessionStorage.primaryVerificationFlow);
+          var dataUsedOnReturnFromPrimary = storage.idpVerification.get();
           equal(dataUsedOnReturnFromPrimary['native'], true);
           equal(dataUsedOnReturnFromPrimary.add, true);
           equal(dataUsedOnReturnFromPrimary.email, "unregistered@testuser.com");


### PR DESCRIPTION
@jedp, @jrgm - here is the other half of the FirefoxOS series of PRs!

Background: sessionStorage can be wiped on FirefoxOS when authenticating with the IdP. We need to store a momento with dialog bootstrapping info for when the user returns from the IdP.
- store primary IdP verification flow info in localStorage with a nonce
- Store the nonce in window.name for FirefoxOS, sessionStorage for IE8.
- When returning from the IdP, look for nonce, load info from localStorage.

fixes #3572
