### PR TITLE
'native' is a reserved word.

### DIFF
--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -33,7 +33,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
       email: email,
       // native is used when the user returns from the primary to prevent
       // WinChan from establishing the postMessage channel.
-      native: win.document.location.hash === "#NATIVE"
+      'native': win.document.location.hash === "#NATIVE"
     });
 
     var url = helpers.toURL(auth_url, { email: email });


### PR DESCRIPTION
@6a68 - this is another instance of #3534. Could you give this a review?

Android 2.3.6 pukes when it used as the key to an object. When it is wrapped in quotes, everything is fine.

fixes #3595
