### PR TITLE
train-2013.06.19 - document hotfixes for primary idp, and bump rpm version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@ train-2013.06.19:
   * UI tweaks: #3426
   * Upgrade to awsbox 0.4.5, with improved security and error handling: #3483
   * Show client local timestamp on dialog error screen: #3478
+  * (hotfix 2013.06.28) Support localization of TOS and PP, Polish: #3580, #3586
+  * (hotfix 2013.06.28) FirefoxOS primary idp support: #3567, #3592, #3601
 
 train-2013.06.05:
   * Fix primary IdP support on FirefoxOS: #3461

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2013.06.19
-Release:       1%{?dist}_%{svnrev}
+Release:       2%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
train-2013.06.19 - document hotfixes for primary idp, and bump rpm version
