### PR TITLE
Define `undefined` to explicitly be undefined in case an RP or IdP has accidentally redefined undefined.

### DIFF
--- a/resources/static/provisioning_api.js
+++ b/resources/static/provisioning_api.js
@@ -9,6 +9,9 @@
 (function() {
   "use strict";
 
+  // Define undefined in case the IdP has accidentally redefined undefined.
+  var undefined;
+
   // local embedded copy of jschannel: http://github.com/mozilla/jschannel
   /**
    * js_channel is a very lightweight abstraction on top of

--- a/scripts/create_include.js
+++ b/scripts/create_include.js
@@ -25,12 +25,17 @@ module.exports = function(done) {
     mkdirp.sync(output_dir);
     var target = path.join(output_dir, 'include.js');
 
-    fs.writeFileSync(target, fs.readFileSync(path.join(dir, '_header.js')));
-    fs.appendFileSync(target, '\n(function() {\n');
-    fs.appendFileSync(target, fs.readFileSync(path.join(dir, '_jschannel.js')));
-    fs.appendFileSync(target, fs.readFileSync(path.join(dir, '_winchan.js')));
-    fs.appendFileSync(target, fs.readFileSync(path.join(dir, '_include.js')));
-    fs.appendFileSync(target, '}());\n');
+    var output = "";
+    output += fs.readFileSync(path.join(dir, '_header.js'));
+    output += '\n(function() {\n';
+    // define undefined in case the RP has accidentally redefined undefined.
+    output += '\tvar undefined;\n';
+    output += fs.readFileSync(path.join(dir, '_jschannel.js'));
+    output += fs.readFileSync(path.join(dir, '_winchan.js'));
+    output += fs.readFileSync(path.join(dir, '_include.js'));
+    output += '}());\n';
+
+    fs.writeFileSync(target, output);
   } catch(e) {
     console.error(String(e));
     done && done(e);


### PR DESCRIPTION
@seanmonstar and @callahad - mind reviewing?

fixes #3598
