### PR TITLE
Fix responses of aborted xhr requests when user closes dialog or browses away from RP.

### DIFF
--- a/resources/static/common/js/lib/micrajax.js
+++ b/resources/static/common/js/lib/micrajax.js
@@ -34,10 +34,10 @@ window.Micrajax = (function() {
 
   function onReadyStateChange(xhrObject, callback) {
     try {
-      if (xhrObject.readyState == 4) {
+      if (xhrObject.readyState === 4) {
         xhrObject.onreadystatechange = noOp;
 
-        callback && callback(xhrObject.responseText, xhrObject.status);
+        callback && callback(xhrObject.responseText, xhrObject.status, xhrObject.statusText);
       }
     } catch(e) {}
   }
@@ -134,6 +134,8 @@ window.Micrajax = (function() {
     else {
       throw "could not get XHR object";
     }
+
+    return xhrObject;
   }
 
   var Micrajax = {
@@ -142,9 +144,11 @@ window.Micrajax = (function() {
           success = options.success,
           mockXHR = { readyState: 0 };
 
-      sendRequest(options, function(responseText, status) {
+      var xhrObject = sendRequest(options, function(responseText, status, statusText) {
         mockXHR.status = status;
         mockXHR.responseText = responseText;
+        if (!mockXHR.statusText)
+          mockXHR.statusText = status !== 0 ? statusText : "error";
         mockXHR.readyState = 4;
 
         if (status >= 200 && status < 300 || status === 304) {
@@ -162,6 +166,11 @@ window.Micrajax = (function() {
           error && error(mockXHR, status, responseText);
         }
       });
+
+      mockXHR.abort = function() {
+        mockXHR.statusText = "aborted";
+        xhrObject.abort();
+      };
 
       return mockXHR;
     }

--- a/resources/static/common/js/xhr.js
+++ b/resources/static/common/js/xhr.js
@@ -10,7 +10,16 @@ BrowserID.XHR = (function() {
       BROWSERID_VERSION = BrowserID.CODE_VERSION,
       context,
       csrf_token,
-      time_until_delay;
+      time_until_delay,
+      outstandingRequests = {};
+
+  /**
+   * Abort any outstanding XHR requests if the user browses away or reloads.
+   * This prevents the onlogout message from being sent if XHR requests fail
+   * because the user browses away from the current page.
+   * See issue #2423
+   */
+  window.onbeforeunload = abortAll;
 
   function clearContext() {
     csrf_token = context = undefined;
@@ -47,6 +56,9 @@ BrowserID.XHR = (function() {
   }
 
   function xhrComplete(reqInfo) {
+    outstandingRequests[reqInfo.eventTime] = null;
+    delete outstandingRequests[reqInfo.eventTime];
+
     reqInfo.duration = new Date() - reqInfo.eventTime;
     mediator.publish("xhr_complete", reqInfo);
   }
@@ -71,6 +83,7 @@ BrowserID.XHR = (function() {
             delayTimeout = null;
           }
 
+          reqInfo.resp = resp;
           xhrComplete(reqInfo);
           if(options.defer_success) {
             _.defer(successCB.curry(resp, jqXHR, textResponse));
@@ -85,7 +98,25 @@ BrowserID.XHR = (function() {
             delayTimeout = null;
           }
 
+          reqInfo.resp = resp;
           xhrComplete(reqInfo);
+
+          /**
+           * XHR request was aborted. Don't do anything. A request can be
+           * aborted when:
+           * 1. user shuts the dialog while an XHR request is in flight
+           * 2. user browses away from an RP while an XHR request in the
+           *        communication_iframe is in flight.
+           * We cannot prevent these from happening, we can only abort XHR
+           * requests when it does happen and clean up afterwards.
+           * See issues #3618, #2423, #2560.
+           *
+           * We differentiate aborted requests from other errors because
+           * a status code of 0 can be returned for other XHR issues like
+           * illegal cross domain requests or when the user has no
+           * connectivity.
+           */
+          if (resp.statusText === "aborted") return;
           _.defer(xhrError.curry(errorCB, reqInfo, resp, jqXHR, textResponse));
         };
 
@@ -102,7 +133,9 @@ BrowserID.XHR = (function() {
     }
 
     mediator.publish("xhr_start", reqInfo);
-    transport.ajax(req);
+    var xhrObj = transport.ajax(req);
+    outstandingRequests[reqInfo.eventTime] = xhrObj;
+    return xhrObj;
   }
 
   function get(options) {
@@ -147,6 +180,11 @@ BrowserID.XHR = (function() {
     }, options.error);
   }
 
+  function abortAll() {
+    for (var eventTime in outstandingRequests) {
+      outstandingRequests[eventTime].abort();
+    }
+  }
 
   return {
     /**
@@ -191,7 +229,13 @@ BrowserID.XHR = (function() {
      * Clear the current context
      * @method clearContext
      */
-    clearContext: clearContext
+    clearContext: clearContext,
+
+    /**
+     * Abort all outstanding XHR requests
+     * @method abortAll
+     */
+    abortAll: abortAll
   };
 }());
 

--- a/resources/static/common/js/xhr.js
+++ b/resources/static/common/js/xhr.js
@@ -17,9 +17,17 @@ BrowserID.XHR = (function() {
    * Abort any outstanding XHR requests if the user browses away or reloads.
    * This prevents the onlogout message from being sent if XHR requests fail
    * because the user browses away from the current page.
-   * See issue #2423
+   * See issue #2423.
+   *
+   * Note, we are using low level event handler functions here so that the
+   * entire DOM module does not have to be included into the
+   * communication_iframe.
    */
-  window.onbeforeunload = abortAll;
+  if (window.addEventListener) {
+    window.addEventListener("beforeunload", abortAll, false);
+  } else if (window.attachEvent) {
+    window.attachEvent("onbeforeunload", abortAll);
+  }
 
   function clearContext() {
     csrf_token = context = undefined;

--- a/resources/static/test/cases/common/js/xhr.js
+++ b/resources/static/test/cases/common/js/xhr.js
@@ -177,7 +177,7 @@
     });
   });
 
-  asyncTest("xhrObj.abort aborts outstanding requests, triggers xhr_complete",
+  asyncTest("abortAll aborts outstanding requests, triggers xhr_complete",
       function() {
     mediator.subscribe("xhr_complete", function(msg, info) {
       equal(info.network.url, "/slow_request");

--- a/resources/static/test/cases/common/js/xhr.js
+++ b/resources/static/test/cases/common/js/xhr.js
@@ -177,4 +177,21 @@
     });
   });
 
+  asyncTest("xhrObj.abort aborts outstanding requests, triggers xhr_complete",
+      function() {
+    mediator.subscribe("xhr_complete", function(msg, info) {
+      equal(info.network.url, "/slow_request");
+      equal(info.resp.statusText, "aborted");
+      start();
+    });
+
+    xhr.get({
+      url: "/slow_request",
+      error: testHelpers.unexpectedXHRFailure,
+      success: function() { ok(false) }
+    });
+
+    xhr.abortAll();
+  });
+
 }());


### PR DESCRIPTION
@seanmonstar and @6a68 - yo dudes, I could use some help/review on this!
- Add an abort method to the XHR object.
- Keep track of all outstanding XHR requests. In the window.onbeforeunload handler, abort all outstanding requests.
- errors no longer logged on the KPIs when the user closes the dialog
- onlogout no longer called in the communication_iframe for aborted XHR requests
- onlogout called in the communication_iframe for all other XHR errors.

changes to micrajax were pushed to origin repo - https://github.com/stomlinson/micrajax, https://github.com/stomlinson/micrajax/commit/2364453e387b914d556c53de8ab01188e067146f

fixes #2423
fixes #3618
fixes #3619
