### PR TITLE
record linux, mysql, and phantomjs versions on each travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ before_script:
 language: node_js
 
 before_install:
+ - "uname -a"
+ - "[ -e /etc/lsb-release ] && cat /etc/lsb-release"
+ - "phantomjs --version"
+ - "mysql -NBe 'select version()'"
  - sudo apt-get install libgmp3-dev
  - "mysql -e 'create database browserid;'"
 


### PR DESCRIPTION
While pondering an upgrade of mysql from 5.1.x to 5.6.x, it occurred to me
that we should know more about versions of linux, mysql, and phantomjs that we
use with travis, so this will dump that information for future
reference. (Travis uses Ubuntu so /etc/lsb-release will be there, but it checks
first if it exists).
