### PR TITLE
Override .form_selection a font size. Fixes Issue #3634

### DIFF
--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -381,7 +381,7 @@
       vertical-align: middle;
   }
 
-  .tospp {
+  .tospp, .tospp a {
     font-size: 8.375pt;
   }
 


### PR DESCRIPTION
```
.form_section a {
  font-size: 13px;
}
```

Needs to be overriden, for TOS/PP links to be the same size as their paragraph.
