### PR TITLE
Train 2013.07.03 fix i18n-abide

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ train-2013.07.03:
   * Redirect legacy endpoints /signin, /signup, /forgot to homepage: #3467
   * Improve Travis-CI docs: #3599
   * Add SIGINT handler, so interrupted Selenium tests immediately dump useful output on POSIX systems: #3570
+  * (hotfix 2013.07.11)  Fix the lockdown error with i18n-abide -- fixes #3639
 
 train-2013.06.19:
   * Correctly transition users from primary IdP-based to fallback IdP-based accounts: #3551

--- a/lockdown.json
+++ b/lockdown.json
@@ -165,7 +165,7 @@
     "0.1.1": "d9d82735a5f85f950761ac3909ba9485ec0af4f1"
   },
   "i18n-abide": {
-    "0.0.8beta4": "b106bdaa156f90652e04b75ef6a1079c271a1b45"
+    "0.0.8-beta4": "b106bdaa156f90652e04b75ef6a1079c271a1b45"
   },
   "iconv-lite": {
     "0.2.7": "45be2390d27af4b7613aac4ee4d957e3f4cbdb54"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "etagify": "0.0.2",
     "express": "2.5.0",
     "gobbledygook": "0.0.3",
-    "i18n-abide": "0.0.8beta4",
+    "i18n-abide": "0.0.8-beta4",
     "lockdown": "0.0.4",
     "jwcrypto": "0.4.3",
     "mysql": "0.9.5",

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2013.07.03
-Release:       1%{?dist}_%{svnrev}
+Release:       2%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
Pull request to put the hyphens back in so lockdown doesn't freak out.  Thanks, Shane.
