### PR TITLE
Extend internal API to embed arbitrary payload data in assertion (WebRTC)

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -51,7 +51,7 @@ var types = {
   origin: function(x) {
     /* origin regex
     /^                          // beginning
-    (?:https?|app):\/\/         // starts with http://, https://, or app:// (b2g desktop)
+    (?:https?|app|rtcweb):\/\/  // starts with http://, https://, or app:// (b2g desktop), or rtcweb:// (RTC auth)
     (?=.{1,254}(?::|$))         // hostname must be within 1-254 characters
     (?:                         // match hostname part (<part>.<part>...)
       (?!-)                     // cannot start with a dash (allow it to start with a digit re issue #2042)
@@ -64,7 +64,7 @@ var types = {
     (:\d+)?                     // optional port
     $/i;                        // end; case-insensitive
     */
-    var regex = /^(?:https?|app):\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
+    var regex = /^(?:https?|app|rtcweb):\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
     if (typeof x !== 'string' || !x.match(regex)) {
       throw new Error("not a valid origin");
     }

--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -54,7 +54,8 @@ function compareAudiences(want, got) {
 
     // case 1 & 1a
     // (app:// urls are seen on FirefoxOS desktop and possibly mobile)
-    if (/^(?:https?|app):\/\//.test(got)) {
+    // (rtcweb:// urls are seen when authenticating WebRTC)
+    if (/^(?:https?|app|rtcweb):\/\//.test(got)) {
       var gu = normalizeParsedURL(url.parse(got));
       got_scheme = gu.protocol;
       got_domain = gu.hostname;

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1343,9 +1343,11 @@ BrowserID.User = (function() {
      * @param {string} audience - Audience to use for the assertion.
      * @param {function} [onComplete] - Called with assertion, null otw.
      * @param {function} [onFailure] - Called on error.
+     * @param {object} [payload] - optional extra payload for assertion
      */
-    getAssertion: function(email, audience, onComplete, onFailure) {
+    getAssertion: function(email, audience, onComplete, onFailure, payload) {
       var storedID = storage.getEmail(email, issuer),
+          payload = payload || {},
           assertion,
           self=this;
 
@@ -1365,7 +1367,8 @@ BrowserID.User = (function() {
             // raise "script has become unresponsive" errors.
             setTimeout(function() {
               jwcrypto.assertion.sign(
-                {}, {audience: audience, expiresAt: expirationDate},
+                payload,
+                {audience: audience, expiresAt: expirationDate},
                 sk,
                 function(err, signedAssertion) {
                   assertion = jwcrypto.cert.bundle([idInfo.cert], signedAssertion);

--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -118,9 +118,13 @@
       // first, check the required email field, if that is not specified, go
       // check if an email is associated with this site. If that is not
       // available, there is not enough information to continue.
-      var requiredEmail = options.requiredEmail || storage.site.get(origin, "email");
+      // if options.origin is available, check login from that url instead of origin for assertion
+      var login_origin = options.origin || origin;
+      var requiredEmail = options.requiredEmail
+                       || storage.site.get(login_origin, "logged_in"); //get the logged in user (required for silent get)
       if(requiredEmail) {
-        getSilent(origin, requiredEmail, complete);
+        // always get assertion for origin passed, never options.origin
+        getSilent(origin, requiredEmail, complete, options.payload);
       }
       else {
         complete();
@@ -156,7 +160,7 @@
   /*
    * Get an assertion without user interaction - internal use
    */
-  function getSilent(origin, email, callback) {
+  function getSilent(origin, email, callback, payload) {
     function complete(assertion) {
       assertion = assertionObjectToString(assertion);
       callback && callback(assertion || null);
@@ -169,7 +173,7 @@
       if(authenticated) {
         user.getAssertion(email, user.getOrigin(), function(assertion) {
           complete(assertion || null);
-        }, complete.curry(null));
+        }, complete.curry(null), payload);
       }
       else {
         complete(null);

--- a/tests/verifier-test.js
+++ b/tests/verifier-test.js
@@ -63,7 +63,8 @@ suite.addBatch({
     'http://fakesite.com:80 and http://fakesite.com:8000': matchesAudience(false),
     'https://fakesite.com:443 and https://fakesite.com:9000': matchesAudience(false),
 
-    'app://browser.gaiamobile.org and app://browser.gaiamobile.org:80': matchesAudience(true)
+    'app://browser.gaiamobile.org and app://browser.gaiamobile.org:80': matchesAudience(true),
+    'rtcweb://peerconnection and rtcweb://peerconnection': matchesAudience(true)
   }
 });
 


### PR DESCRIPTION
The internal API is extended to allow the signing of arbitrary data (`payload`) to be included in the assertion. This is done to support the signing of a WebRTC PeerConnection **fingerprint** (the `payload`), used in the PeerConnection Identity module of WebRTC as specified at: http://dev.w3.org/2011/webrtc/editor/webrtc.html#identity

The assertions given from internal API will be included in the `offer` and `answer` SDP objects returned from `RTCPeerConnection.createOffer()` and `RTCPeerConnection.createAnswer()`

These changes are necessary to ensure BrowserID supports the WebRTC Identity specification to be landed in future web browsers.

/cc @warner @shane-tomlinson
