### PR TITLE
Issue 3666 context out of xhr

### DIFF
--- a/resources/static/common/js/helpers.js
+++ b/resources/static/common/js/helpers.js
@@ -71,11 +71,10 @@
       _.each(args, function(arg, index) {
         if (index > 0) msg += ", ";
 
-        var type = Object.prototype.toString.apply(arg);
-        if (type === "[object String]") {
+        if (helpers.isString(arg)) {
           msg += arg;
         }
-        else if (type === "[object Object]") {
+        else if (helpers.isObject(arg)) {
           try {
             msg += JSON.stringify(arg, null, 2);
           } catch(err) {
@@ -83,7 +82,7 @@
             msg += "<<object>>";
           }
         }
-        else if (type === "[object Function]") {
+        else if (helpers.isFunction(arg)) {
           msg += "<<function>>";
         }
         else {
@@ -103,6 +102,22 @@
   }
 
   _.extend(helpers, {
+    isObject: function(arg) {
+      return Object.prototype.toString.apply(arg) === "[object Object]";
+    },
+
+    isString: function(arg) {
+      return Object.prototype.toString.apply(arg) === "[object String]";
+    },
+
+    isFunction: function(arg) {
+      return Object.prototype.toString.apply(arg) === "[object Function]";
+    },
+
+    isArray: function(arg) {
+      return Object.prototype.toString.apply(arg) === "[object Array]";
+    },
+
     /**
      * Get an email from a DOM element and validate it.
      * @method getAndValidateEmail

--- a/resources/static/common/js/modules/xhr.js
+++ b/resources/static/common/js/modules/xhr.js
@@ -36,6 +36,13 @@ BrowserID.Modules.XHR = (function() {
     /**
      * Low level request
      * @method request
+     * @param {object} config
+     *   {string} config.url
+     *   {string} [config.type]
+     *   {object} [config.data]
+     *   {function} [config.success]
+     *   {function} [config.error]
+     * @returns {object} xhr object
      */
     request: makeRequest,
 
@@ -44,8 +51,10 @@ BrowserID.Modules.XHR = (function() {
      * @method get
      * @param {object} config
      *   {string} config.url
+     *   {object} [config.data]
      *   {function} [config.success]
      *   {function} [config.error]
+     * @returns {object} xhr object
      */
     get: get,
 
@@ -54,8 +63,11 @@ BrowserID.Modules.XHR = (function() {
      * @method post
      * @param {object} config
      *   {string} config.url
+     *   {object} config.data
+     *   {string} config.data.csrf
      *   {function} [config.success]
      *   {function} [config.error]
+     * @returns {object} xhr object
      */
     post: post,
 
@@ -163,7 +175,7 @@ BrowserID.Modules.XHR = (function() {
       type: "GET",
       defer_success: true
     });
-    this.request(options);
+    return this.request(options);
   }
 
   function post(options) {
@@ -185,7 +197,7 @@ BrowserID.Modules.XHR = (function() {
                   "missing csrf token from POST request");
     }
 
-    this.request(options);
+    return this.request(options);
   }
 
   function abortAll() {

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -6,7 +6,8 @@ BrowserID.Network = (function() {
   /*globals require:true*/
 
   var bid = BrowserID,
-      complete = bid.Helpers.complete,
+      helpers = bid.Helpers,
+      complete = helpers.complete,
       context,
       mediator = bid.Mediator,
       XHR = bid.Modules.XHR,
@@ -176,6 +177,8 @@ BrowserID.Network = (function() {
 
     setContext: function(field, value) {
       if (arguments.length === 1) {
+        if (!helpers.isObject(field)) throw new Error("invalid context");
+
         // an object was passed in for the context. Used for testing.
         setContext(field);
       }

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -32,7 +32,7 @@ BrowserID.Network = (function() {
   }
 
   function withContext(done, onFailure) {
-    if (typeof context !== "undefined") return complete(done, context);
+    if (context) return complete(done, context);
 
     // session_context always checks for a javascript readable cookie,
     // this allows our javascript code in the dialog and communication iframe

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -62,7 +62,7 @@ BrowserID.Network = (function() {
       local_time: new Date().getTime()
     });
 
-    mediator.publish("context_info", newContext);
+    mediator.publish("context_info", context);
   }
 
   function clearContext() {

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -259,7 +259,6 @@ BrowserID.State = (function() {
       }
       else if(self.newFxAccountEmail) {
         startAction(false, "doStageUser", info);
-// TODO         startAction(false, "doStageResetPassword", info); ???
       }
       complete(info.complete);
     });

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -261,6 +261,7 @@ BrowserID.State = (function() {
         startAction(false, "doStageUser", info);
 // TODO         startAction(false, "doStageResetPassword", info); ???
       }
+      complete(info.complete);
     });
 
     handleState("user_staged", handleEmailStaged.curry("doConfirmUser"));

--- a/resources/static/test/cases/common/js/helpers.js
+++ b/resources/static/test/cases/common/js/helpers.js
@@ -192,5 +192,6 @@
     equal(helpers.isArray(new Array()), true);
     equal(helpers.isArray({}), false);
     equal(helpers.isArray(""), false);
+    equal(helpers.isArray(arguments), false);
   });
 }());

--- a/resources/static/test/cases/common/js/helpers.js
+++ b/resources/static/test/cases/common/js/helpers.js
@@ -162,4 +162,35 @@
 
     window.console = nativeConsole;
   });
+
+  test("isObject", function() {
+    equal(helpers.isObject({}), true);
+    equal(helpers.isObject(new Object()), true);
+    equal(helpers.isObject(""), false);
+    equal(helpers.isObject([]), false);
+  });
+
+  test("isString", function() {
+    equal(helpers.isString(""), true);
+    equal(helpers.isString(new String()), true);
+    equal(helpers.isString({}), false);
+    equal(helpers.isString([]), false);
+  });
+
+  test("isFunction", function() {
+    var someFunc = function() {};
+    equal(helpers.isFunction(someFunc), true);
+    equal(helpers.isFunction(function named() {}), true);
+    equal(helpers.isFunction(new Function()), true);
+    equal(helpers.isFunction({}), false);
+    equal(helpers.isFunction([]), false);
+  });
+
+  test("isArray", function() {
+    var someFunc = function() {};
+    equal(helpers.isArray([]), true);
+    equal(helpers.isArray(new Array()), true);
+    equal(helpers.isArray({}), false);
+    equal(helpers.isArray(""), false);
+  });
 }());

--- a/resources/static/test/cases/common/js/modules/xhr.js
+++ b/resources/static/test/cases/common/js/modules/xhr.js
@@ -101,6 +101,41 @@
     });
   });
 
+  asyncTest("post with missing CSRF token", function() {
+    var errorInfo;
+    mediator.subscribe("xhr_error", function(msg, info) {
+      errorInfo = info;
+    });
+
+    var completeInfo;
+    mediator.subscribe("xhr_complete", function(msg, info) {
+      completeInfo = info;
+    });
+
+    xhr.post({
+      url: "/wsapi/authenticate_user",
+      success: testHelpers.unexpectedSuccess,
+      error: function(info) {
+        ok(errorInfo);
+        equal(errorInfo.network.url, "/wsapi/authenticate_user");
+        equal(errorInfo.network.errorThrown,
+            "missing csrf token from POST request");
+
+        ok(info);
+        equal(info.network.url, "/wsapi/authenticate_user");
+        equal(info.network.errorThrown,
+            "missing csrf token from POST request");
+
+        ok(completeInfo);
+        equal(completeInfo.network.url, "/wsapi/authenticate_user");
+        equal(completeInfo.network.errorThrown,
+            "missing csrf token from POST request");
+
+        start();
+      }
+    });
+  });
+
   asyncTest("post with delay", function() {
     transport.setDelay(100);
 
@@ -115,6 +150,7 @@
     });
 
     xhr.post({
+      data: { csrf: "csrf" },
       url: "/wsapi/authenticate_user",
       success: function() {
         ok(delayInfo, "xhr_delay called with delay info");
@@ -143,6 +179,7 @@
     transport.useResult("ajaxError");
 
     xhr.post({
+      data: { csrf: "csrf" },
       url: "/wsapi/authenticate_user",
       error: function(info) {
         ok(errorInfo, "xhr_error called with delay info");
@@ -168,6 +205,7 @@
     });
 
     xhr.post({
+      data: { csrf: "csrf" },
       url: "/wsapi/authenticate_user",
       error: testHelpers.unexpectedXHRFailure,
       success: function() {
@@ -189,7 +227,7 @@
     xhr.get({
       url: "/slow_request",
       error: testHelpers.unexpectedXHRFailure,
-      success: function() { ok(false) }
+      success: function() { ok(false); }
     });
 
     xhr.abortAll();

--- a/resources/static/test/cases/common/js/modules/xhr.js
+++ b/resources/static/test/cases/common/js/modules/xhr.js
@@ -233,4 +233,32 @@
     xhr.abortAll();
   });
 
+  asyncTest("success responses not called after module stops", function() {
+    xhr.get({
+      url: "/wsapi/session_context",
+      error: testHelpers.unexpectedXHRFailure,
+      // the module is stopped, this should not be called.
+      success: testHelpers.unexpectedSuccess
+    });
+
+    xhr.stop();
+
+    setTimeout(start, 100);
+  });
+
+  asyncTest("error responses not called after module stops", function() {
+    transport.useResult("contextAjaxError");
+    xhr.get({
+      url: "/wsapi/session_context",
+      error: testHelpers.unexpectedXHRFailure,
+      // the module is stopped, this should not be called.
+      success: testHelpers.unexpectedSuccess
+    });
+
+    xhr.stop();
+
+    setTimeout(start, 100);
+  });
+
+
 }());

--- a/resources/static/test/cases/common/js/modules/xhr.js
+++ b/resources/static/test/cases/common/js/modules/xhr.js
@@ -39,7 +39,7 @@
       completeInfo = info;
     });
 
-    xhr.get({
+    var req = xhr.get({
       url: "/wsapi/session_context",
       error: testHelpers.unexpectedXHRFailure,
       success: function(info) {
@@ -51,6 +51,8 @@
         start();
       }
     });
+
+    ok(req);
   });
 
   asyncTest("get with xhr error", function() {
@@ -149,7 +151,7 @@
       completeInfo = info;
     });
 
-    xhr.post({
+    var req = xhr.post({
       data: { csrf: "csrf" },
       url: "/wsapi/authenticate_user",
       success: function() {
@@ -163,6 +165,8 @@
 
       error: testHelpers.unexpectedXHRFailure
     });
+
+    ok(req);
   });
 
   asyncTest("post with xhr error", function() {

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -553,18 +553,22 @@
   asyncTest("cookiesEnabled with onComplete exception thrown - should not call onComplete a second time", function() {
     // Since we are manually throwing an exception, it must be caught
     // below.
-    try {
-      network.cookiesEnabled(function(status) {
-        // if there is a problem, this callback will be called a second time
-        // with a false status.
-        equal(status, true, "cookies are enabled, correct status");
-        start();
+    network.withContext(function() {
+      var err;
+      try {
+        network.cookiesEnabled(function(status) {
+          // if there is a problem, this callback will be called a second time
+          // with a false status.
+          equal(status, true, "cookies are enabled, correct status");
+          start();
 
-        throw "callback exception";
-      }, testHelpers.unexpectedXHRFailure);
-    } catch(e) {
-      equal(e, "callback exception", "correct exception caught");
-    }
+          throw "callback exception";
+        }, testHelpers.unexpectedXHRFailure);
+      } catch(e) {
+        err = e;
+      }
+      equal(err, "callback exception", "correct exception caught");
+    }, testHelpers.unexpectedXHRFailure);
   });
 
   asyncTest("prolongSession with authenticated user, success - call complete", function() {

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -1317,9 +1317,10 @@
     makeCert(emailAddr, startIssuer, function (cert) {
       storage.addEmail(emailAddr, { cert: cert, unverified: unverified });
       addressInfo.email = emailAddr;
-      var newInfo = lib.checkForInvalidCerts(emailAddr, addressInfo);
-      ok(!storage.getEmail(emailAddr).cert, "cert was cleared up");
-      start();
+      lib.checkForInvalidCerts(emailAddr, addressInfo, function(newInfo) {
+        ok(!storage.getEmail(emailAddr).cert, "cert was cleared up");
+        start();
+      });
     });
   }
 


### PR DESCRIPTION
@6a68 - yo dude, I am trying to pull the context stuff out of xhr and move it into network.js. It has gone well, but I could use some collaboration time.

Specifically, https://github.com/shane-tomlinson/browserid/compare/issue_3666_context_out_of_xhr?expand=1#L1R53.  I want to change this to:

`get({`

but doing so has repercussions that I did not foresee. The old code requested session_context and returned results would be returned immediately instead of being deferred. This is the _only_ request that acted like this. I want to make this request consistent with all other requests and have its completion deferred. 

Some tests depend on this behavior, the tests are in `user.js` and `state.js`. You can see in the first commit the changes I had to make to the tests. I was a bit uncomfortable doing this without some input to see if the scope of the PR is expanding too far.

This is a continuation of mozilla/browserid#3655 to address mozilla/browserid#3666.
