### PR TITLE
Remove transition code added in #3398 (877281c).

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -36,21 +36,6 @@ BrowserID.Storage = (function() {
   // issues do not become a factor. See issue #2206
   setDefaultValues();
 
-  // BEGIN TRANSITION CODE
-  /** Transition code is to handle the moving data from the .loggedIn
-   * namespace to the .site namespace. It can safely be removed one month after
-   * this is merged when people's Persona sessions have expired.
-   */
-  function upgradeLoggedInInfo() {
-    var allInfo = JSON.parse(storage.loggedIn || "{}");
-    for (var site in allInfo) {
-      siteSet(site, "logged_in", allInfo[site]);
-    }
-    storage.removeItem("loggedIn");
-  }
-  upgradeLoggedInInfo();
-  // END TRANSITION CODE
-
   function emailsStorageKey(issuer) {
     return issuer || "default";
   }
@@ -735,13 +720,5 @@ BrowserID.Storage = (function() {
       clear: clearIdpVerificationInfo,
       INFO_LIFESPAN_MS: IDP_INFO_LIFESPAN_MS
     }
-    // BEGIN TRANSITION CODE
-    /**
-     * Upgrade the site->user logged in info from the loggedIn namespace to be
-     * under the site namespace.
-     */
-    ,
-    upgradeLoggedInInfo: upgradeLoggedInInfo
-    // END TRANSITION CODE
   };
 }());

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -240,27 +240,5 @@
     equal(typeof info, "undefined");
   });
 
-  // BEGIN TRANSITION CODE
-  test("upgradeLoggedInInfo upgrades old loggedInInfo and removes namespace",
-      function() {
-      localStorage.loggedIn = JSON.stringify({
-        'testrp.com': 'testuser@testuser.com'
-      });
-
-      storage.upgradeLoggedInInfo();
-      equal(storage.site.get("testrp.com", "logged_in"),
-          'testuser@testuser.com');
-
-      equal(localStorage.getItem('loggedIn'), null);
-
-      try {
-        // make sure re-invoking upgrade path does not cause an error.
-        storage.upgradeLoggedInInfo();
-      } catch(e) {
-        ok(false, "unexpected error");
-      }
-  });
-  // END TRANSITION CODE
-
 }());
 


### PR DESCRIPTION
@shane-tomlinson, to be merged after the train is branched.

Poking at storage-related stuff for #1500, I noticed some transition code more than a month old, should be ripe for plucking out of the codebase.

All tests passing. Let me know if I've missed anything. This is essentially a revert of 877281c5.
