### PR TITLE
Fix compress blowing up when pushing to an ephemeral instance.

### DIFF
--- a/scripts/compress
+++ b/scripts/compress
@@ -76,7 +76,7 @@ generate_version_js(function(err) {
 
       // remove translation files from default and debug languages.  #1905
       [ config.get('debug_lang'), config.get('default_lang') ].forEach(function(l) {
-        var file = '/i18n/' + i18n.localeFrom(l) + '/client.json';
+        var file = '/i18n/' + i18n.localeFrom(l) + '/client.js';
         var ix = all[resource].indexOf(file);
         if (-1 !== ix) all[resource].splice(ix, 1);
       });


### PR DESCRIPTION
@ozten, @6a68 - could you guys see if this is the right fix? With this change, I can push to ephemeral instances without a problem.
- i18n-abide now works with .js files, not .json files.

fix #3672
