### PR TITLE
Issue 3681 update l10n env

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -9,7 +9,7 @@
     "bin/static"
   ],
   "env": {
-    "CONFIG_FILES": "$HOME/code/config/production.json,$HOME/code/config/aws.json,$HOME/config.json"
+    "CONFIG_FILES": "$HOME/code/config/production.json,$HOME/code/config/aws.json,$HOME/config.json,$HOME/code/config/l10n-all.json"
   },
   "hooks": {
     "postdeploy": "scripts/awsbox_remote/post_deploy.sh",

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,12 @@
-current train:
+train-2013.07.17:
+  * Simplify tooltip copy and replace tooltips with inline notifications: #3154, #3607
+  * [FXOS] Make TOS/PP links same size as surrounding text: #3634
+  * Ensure dialog hides the 'checking with your email provider' screen after that check completes: #3638
+  * Remove eval() from i18n workflow by passing i18n-abide .js, not .json files: #3672, #2501
+  * Fix lockdown & rpm build errors by bumping i18n-abide version number to semver-compatible string: #3658, #3639
+  * Refactor xhr code into a module, removing global state, and squashing an intermittent unit testing bug: #3647
+  * Prevent Chrome from logging spurious KPI errors by aborting in-flight xhrs on page unload: #2423, #3618
+  * On each Travis-CI run, record linux, mysql, and phantomjs versions for future reference: #3626
 
 train-2013.07.03:
   * [FXOS] Add support for primary IdPs to FirefoxOS: #3572, #3592, #3566, #3567

--- a/docs/L10N_PREVIEW_ENV.md
+++ b/docs/L10N_PREVIEW_ENV.md
@@ -1,0 +1,15 @@
+How do you build an environment where you can allow translators to preview their l10n changes?
+
+Glad you asked!  It's easy!
+
+1. checkout the git branch you want to deploy (current train in testing probably)
+2. build a fast vm: scripts/deploy.js create translate -t c1.medium
+3. cherry pick the magic commit that patches your config and turns it into a preview env,
+   `git cp origin l10n_preview_builder`
+4. (if that don't patch cleanly, yer gonna need to update it)
+5. push it up to your vm: `git push translate HEAD:master
+6. now add a cron job with `crontab -e`:
+
+    PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/aws/bin:/usr/local/bin:/home/app/node_modules/.bin:/home/app/bin
+    MAILTO=<YOU>@mozilla.com
+    */5 * * * * $HOME/code/scripts/update_translations.sh | tee $HOME/last_translation_update.txt 2>&1

--- a/scripts/awsbox_remote/post_deploy.sh
+++ b/scripts/awsbox_remote/post_deploy.sh
@@ -8,6 +8,7 @@ else
     echo ">> no keypair needed.  you gots one"
 fi
 
+echo ">> updating strings"
 node scripts/l10n-update.js
 
 echo ">> generating ver.txt"
@@ -16,4 +17,7 @@ git log --pretty=%h -1 > ../code/resources/static/ver.txt
 cd ../code
 
 echo ">> generating production resources"
+env CONFIG_FILES=config/aws.json scripts/compress
+
+echo ">> generating localized production resources"
 scripts/compress

--- a/scripts/update_translations.sh
+++ b/scripts/update_translations.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ ! -d $HOME/code/locale ] ; then
+    cd $HOME/code
+    svn co https://svn.mozilla.org/projects/l10n-misc/trunk/browserid/locale
+fi
+
+cd $HOME/code/locale/
+
+X=`svn status -u | wc -l`
+
+if [ "x$X" != "x1" ] ; then
+    echo "oh boy, new translations.  time to update translate.personatest.org"
+    # trigger a redeployment
+    cd $HOME/git
+    ../post-update.js
+    git log -2 --oneline master | tail -1 >> $HOME/ver.txt
+    cd $HOME/code/locale
+    svn info | egrep ^Revision: >> $HOME/ver.txt
+fi


### PR DESCRIPTION
@ozten mind reviewing? don't want to commit this, just looking for feedback.

I've updated the post-deploy script ([8bd6e6](https://github.com/6a68/browserid/commit/8bd6e6))) to use `scripts/l10n-update` instead of `compile-json.sh` in the svn repo.

I think we still need the [update-translations](https://github.com/6a68/browserid/blob/8bd6e6/scripts/update_translations.sh) script, which does bookkeeping stuff like appending the svn info to `ver.txt`--but is there anything else I've missed?
