### PR TITLE
Check for failures in provisioning after returning from an IdP.

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -104,6 +104,7 @@ var dialog_js = und.flatten([
     '/dialog/js/modules/verify_primary_user.js',
     '/dialog/js/modules/provision_primary_user.js',
     '/dialog/js/modules/primary_user_provisioned.js',
+    '/dialog/js/modules/primary_user_not_provisioned.js',
     '/dialog/js/modules/primary_offline.js',
     '/dialog/js/modules/generate_assertion.js',
     '/dialog/js/modules/is_this_your_computer.js',

--- a/resources/static/dialog/js/modules/actions.js
+++ b/resources/static/dialog/js/modules/actions.js
@@ -168,6 +168,10 @@ BrowserID.Modules.Actions = (function() {
       startService("primary_user_provisioned", info);
     },
 
+    doPrimaryUserNotProvisioned: function(info) {
+      startService("primary_user_not_provisioned", info);
+    },
+
     doPrimaryOffline: function(info) {
       startService("primary_offline", info);
     },

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -364,10 +364,11 @@ BrowserID.Modules.Dialog = (function() {
           params.email = primaryParams.email;
           params.add = primaryParams.add;
           params.type = "primary";
+          params.cancelled = false;
+        }
 
-          // FIXME: if it's AUTH_RETURN_CANCEL, we should short-circuit
-          // the attempt at provisioning. For now, we let provisioning
-          // be tried and fail.
+        if (hash.indexOf("#AUTH_RETURN_CANCEL") === 0) {
+          params.cancelled = true;
         }
 
         // no matter what, we clear the primary flow state for this window

--- a/resources/static/dialog/js/modules/primary_user_not_provisioned.js
+++ b/resources/static/dialog/js/modules/primary_user_not_provisioned.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+BrowserID.Modules.PrimaryUserNotProvisioned = (function() {
+  "use strict";
+
+  var bid = BrowserID,
+      complete = bid.Helpers.complete;
+
+  var Module = bid.Modules.PageModule.extend({
+    start: function(options) {
+      options = options || {};
+
+      var self=this;
+      Module.sc.start.call(self, options);
+
+      self.checkRequired(options, "idpName", "email");
+
+      self.renderError("primary_user_not_verified", {
+        email: options.email,
+        idpName: options.idpName,
+        // This is for the KPIs, not the error screen.
+        action: {
+          title: "Could not verify with primary"
+        }
+      });
+
+      complete(options.ready);
+    }
+  });
+
+  return Module;
+
+}());

--- a/resources/static/dialog/js/start.js
+++ b/resources/static/dialog/js/start.js
@@ -44,6 +44,7 @@
       moduleManager.register("verify_primary_user", modules.VerifyPrimaryUser);
       moduleManager.register("provision_primary_user", modules.ProvisionPrimaryUser);
       moduleManager.register("primary_user_provisioned", modules.PrimaryUserProvisioned);
+      moduleManager.register("primary_user_not_provisioned", modules.PrimaryUserNotProvisioned);
       moduleManager.register("primary_offline", modules.PrimaryOffline);
       moduleManager.register("generate_assertion", modules.GenerateAssertion);
       moduleManager.register("xhr_delay", modules.XHRDelay);

--- a/resources/static/dialog/views/primary_user_not_verified.ejs
+++ b/resources/static/dialog/views/primary_user_not_verified.ejs
@@ -12,7 +12,7 @@
 
 <p>
   <%-
-  format(gettext("This may be due to disabled 3rd party cookies. Please ensure 3rd party cookies are enabled or allow 3rd party cookies from %(idpName)s"), {
+  format(gettext("This may be due to your browser blocking third-party cookies.  Please ensure your browser\'s privacy preferences are set to accept third-party cookies for %(idpName)s and try again."), {
     idpName: idpName
   })
   %>

--- a/resources/static/dialog/views/primary_user_not_verified.ejs
+++ b/resources/static/dialog/views/primary_user_not_verified.ejs
@@ -1,0 +1,20 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<h2 id="primary_user_not_verified">
+  <%-
+  format(gettext("Cannot verify %(email)s"), {
+    email: _.escape(email)
+  })
+  %>
+</h2>
+
+<p>
+  <%-
+  format(gettext("This may be due to disabled 3rd party cookies. Please ensure 3rd party cookies are enabled or allow 3rd party cookies from %(idpName)s"), {
+    idpName: idpName
+  })
+  %>
+</p>
+

--- a/resources/static/dialog/views/primary_user_not_verified.ejs
+++ b/resources/static/dialog/views/primary_user_not_verified.ejs
@@ -3,15 +3,15 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <h2 id="primary_user_not_verified">
-  <%-
+  <%=
   format(gettext("Cannot verify %(email)s"), {
-    email: _.escape(email)
+    email: email
   })
   %>
 </h2>
 
 <p>
-  <%-
+  <%=
   format(gettext("This may be due to your browser blocking third-party cookies.  Please ensure your browser\'s privacy preferences are set to accept third-party cookies for %(idpName)s and try again."), {
     idpName: idpName
   })

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -330,17 +330,53 @@
     ok(actions.called.doVerifyPrimaryUser, "doVerifyPrimaryUser called");
   });
 
-  test("primary_user_unauthenticated after verification of new user - call doAuthenticate", function() {
-    mediator.publish("start", { email: TEST_EMAIL, type: "primary", add: false });
-    mediator.publish("primary_user_unauthenticated");
-    ok(actions.called.doAuthenticate, "doAuthenticate called");
+  asyncTest("primary_user_unauthenticated after user cancelled " +
+        "verification of new user - call doAuthenticate", function() {
+    mediator.publish("start", {
+      email: TEST_EMAIL,
+      type: "primary",
+      add: false,
+      cancelled: true
+    });
+    mediator.publish("primary_user_unauthenticated", {
+      complete: function() {
+        ok(actions.called.doAuthenticate, "doAuthenticate called");
+        start();
+      }
+    });
   });
 
-  test("primary_user_unauthenticated after verification of additional email to current user - call doPickEmail and doAddEmail", function() {
-    mediator.publish("start", { email: TEST_EMAIL, type: "primary", add: true });
-    mediator.publish("primary_user_unauthenticated");
-    ok(actions.called.doPickEmail, "doPickEmail called");
-    ok(actions.called.doAddEmail, "doAddEmail called");
+  asyncTest("primary_user_unauthenticated after user cancelled " +
+      "verification of additional email to current user - " +
+      "call doPickEmail and doAddEmail", function() {
+    mediator.publish("start", {
+      email: TEST_EMAIL,
+      type: "primary",
+      add: true,
+      cancelled: true
+    });
+    mediator.publish("primary_user_unauthenticated", {
+      complete: function() {
+        ok(actions.called.doPickEmail, "doPickEmail called");
+        ok(actions.called.doAddEmail, "doAddEmail called");
+        start();
+      }
+    });
+  });
+
+  asyncTest("primary_user_unauthenticated, no user cancel - " +
+      " - call doPrimaryUserNotProvisioned", function() {
+    mediator.publish("start", {
+      email: TEST_EMAIL,
+      type: "primary",
+      cancelled: false
+    });
+    mediator.publish("primary_user_unauthenticated", {
+      complete: function() {
+        ok(actions.called.doPrimaryUserNotProvisioned);
+        start();
+      }
+    });
   });
 
   test("primary_user_authenticating stops all modules", function() {

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -194,19 +194,13 @@
     });
   });
 
-  asyncTest("initialization with #AUTH_RETURN and add=false - trigger start with correct params", function() {
-    winMock.location.hash = "#AUTH_RETURN";
-    storage.idpVerification.set({
-      add: false,
-      email: TESTEMAIL
-    });
+  function testReturnFromIdP(verificationInfo, expectedParams) {
+    storage.idpVerification.set(verificationInfo);
 
     createController({
       ready: function() {
         mediator.subscribe("start", function(msg, info) {
-          equal(info.type, "primary", "correct type");
-          equal(info.email, TESTEMAIL, "email_chosen with correct email");
-          equal(info.add, false, "add is not specified with CREATE_EMAIL option");
+          testHelpers.testObjectValuesEqual(info, expectedParams);
           start();
         });
 
@@ -218,33 +212,44 @@
           // registered for the any services.
         }
       }
+    });
+  }
+
+  asyncTest("initialization with #AUTH_RETURN_CANCEL - " +
+      " trigger start with cancelled=true", function() {
+    winMock.location.hash = "#AUTH_RETURN_CANCEL";
+    testReturnFromIdP({
+      email: TESTEMAIL
+    }, {
+      cancelled: true,
+      type: "primary",
+      email: TESTEMAIL
+    });
+  });
+
+  asyncTest("initialization with #AUTH_RETURN and add=false - trigger start with correct params", function() {
+    winMock.location.hash = "#AUTH_RETURN";
+    testReturnFromIdP({
+      add: false,
+      email: TESTEMAIL
+    }, {
+      type: "primary",
+      email: TESTEMAIL,
+      add: false,
+      cancelled: false
     });
   });
 
   asyncTest("initialization with #AUTH_RETURN and add=true - trigger start with correct params", function() {
     winMock.location.hash = "#AUTH_RETURN";
-    storage.idpVerification.set({
+    testReturnFromIdP({
       add: true,
       email: TESTEMAIL
-    });
-
-    createController({
-      ready: function() {
-        mediator.subscribe("start", function(msg, info) {
-          equal(info.type, "primary", "correct type");
-          equal(info.email, TESTEMAIL, "email_chosen with correct email");
-          equal(info.add, true, "add is specified with ADD_EMAIL option");
-          start();
-        });
-
-        try {
-          controller.get(testHelpers.testOrigin, {}, function() {}, function() {});
-        }
-        catch(e) {
-          // do nothing, an exception will be thrown because no modules are
-          // registered for the any services.
-        }
-      }
+    }, {
+      type: "primary",
+      email: TESTEMAIL,
+      add: true,
+      cancelled: false
     });
   });
 

--- a/resources/static/test/cases/dialog/js/modules/primary_user_not_provisioned.js
+++ b/resources/static/test/cases/dialog/js/modules/primary_user_not_provisioned.js
@@ -1,0 +1,76 @@
+/*jshint browser: true*/
+/*globals  */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  "use strict";
+
+  var controller,
+      bid = BrowserID,
+      testHelpers = bid.TestHelpers;
+
+  module("dialog/js/modules/primary_user_not_provisioned", {
+    setup: function() {
+      testHelpers.setup();
+    },
+
+    teardown: function() {
+      if (controller) {
+        try {
+          controller.destroy();
+          controller = null;
+        } catch(e) {
+          // could already be destroyed from the close
+        }
+      }
+      testHelpers.setup();
+    }
+  });
+
+
+  function createController(config) {
+    controller = bid.Modules.PrimaryUserNotProvisioned.create();
+    config = config || {};
+    controller.start(config);
+  }
+
+  function testMissingOption(options, missingName) {
+    var error;
+
+    try {
+      createController(options);
+    }
+    catch(e) {
+      error = e;
+    }
+
+    equal(error.message, "missing config option: " + missingName);
+  }
+
+  test("starting the controller without email throws exception", function() {
+    testMissingOption({
+      idpName: "IdP"
+    }, "email");
+  });
+
+  test("starting the controller without idpName throws exception", function() {
+    testMissingOption({
+      email: "testuser@tesutser.com"
+    }, "idpName");
+  });
+
+  asyncTest("all options passed", function() {
+    createController({
+      email: "testuser@testuser.com",
+      idpName: "testuser.com",
+      ready: function() {
+        testHelpers.testElementExists("#primary_user_not_verified");
+        start();
+      }
+    });
+  });
+
+
+}());
+

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -178,6 +178,7 @@
     <script src="/dialog/js/modules/generate_assertion.js"></script>
     <script src="/dialog/js/modules/provision_primary_user.js"></script>
     <script src="/dialog/js/modules/primary_user_provisioned.js"></script>
+    <script src="/dialog/js/modules/primary_user_not_provisioned.js"></script>
     <script src="/dialog/js/modules/primary_offline.js"></script>
     <script src="/dialog/js/modules/verify_primary_user.js"></script>
     <script src="/dialog/js/modules/is_this_your_computer.js"></script>
@@ -244,6 +245,7 @@
     <script src="cases/dialog/js/modules/generate_assertion.js"></script>
     <script src="cases/dialog/js/modules/provision_primary_user.js"></script>
     <script src="cases/dialog/js/modules/primary_user_provisioned.js"></script>
+    <script src="cases/dialog/js/modules/primary_user_not_provisioned.js"></script>
     <script src="cases/dialog/js/modules/primary_offline.js"></script>
     <script src="cases/dialog/js/modules/verify_primary_user.js"></script>
     <script src="cases/dialog/js/modules/is_this_your_computer.js"></script>


### PR DESCRIPTION
- This is a standin for checking for disabled 3rd party cookies. If we expect
  provisioning to succeed, but it fails, this is probably due to disabled 3rd party cookies.

fixes #3520
