### PR TITLE
Remove unneccesary(?) var app = undefined;

### DIFF
--- a/bin/browserid
+++ b/bin/browserid
@@ -29,9 +29,7 @@ addP3PHeader = require('../lib/p3p.js'),
 forward = require('../lib/http_forward.js'),
 toobusy = require('../lib/busy_middleware.js');
 
-var app = undefined;
-
-app = express.createServer();
+var app = express.createServer();
 
 logger.info("browserid server starting up");
 

--- a/bin/dbwriter
+++ b/bin/dbwriter
@@ -35,9 +35,7 @@ cachify.setup(
     root: path.join(__dirname, "..", "resources", "static")
   });
 
-var app = undefined;
-
-app = express.createServer();
+var app = express.createServer();
 
 logger.info("dbwriter starting up");
 

--- a/bin/router
+++ b/bin/router
@@ -25,9 +25,7 @@ addP3PHeader = require('../lib/p3p.js'),
 shutdown = require('../lib/shutdown'),
 toobusy = require('../lib/busy_middleware.js');
 
-var app = undefined;
-
-app = express.createServer();
+var app = express.createServer();
 
 logger.info("router server starting up");
 

--- a/bin/static
+++ b/bin/static
@@ -33,9 +33,7 @@ toobusy = require('../lib/busy_middleware.js'),
 addP3PHeader = require('../lib/p3p.js'),
 shutdown = require('../lib/shutdown.js');
 
-var app = undefined;
-
-app = express.createServer();
+var app = express.createServer();
 
 logger.info("static starting up");
 


### PR DESCRIPTION
Perhaps someone can explain why there is a need for the additional `var app = undefined;` in these modules?
