### PR TITLE
Prevent .onmatch from being called if an assertion is generated in the dialog

### DIFF
--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -123,7 +123,7 @@
     pause = true;
   });
 
-  chan.bind("dialog_complete", function(trans, params) {
+  chan.bind("dialog_complete", function(trans, checkAuthStatus) {
     pause = false;
     // The dialog has closed, so that we get results from users who only open
     // the dialog a single time, send the KPIs immediately. Note, this does not
@@ -145,9 +145,11 @@
       }
     } catch(e) {}
 
-    // the dialog running can change authentication status,
-    // lets manually purge our network cache
-    network.clearContext();
-    checkAndEmit();
+    if (checkAuthStatus) {
+      // the dialog running can change authentication status,
+      // lets manually purge our network cache
+      user.clearContext();
+      checkAndEmit();
+    }
   });
 }());

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -390,7 +390,10 @@
           if (!err && r && r.email) {
             commChan.notify({ method: 'loggedInUser', params: r.email });
           }
-          commChan.notify({ method: 'dialog_complete' });
+          // do not check the authentication status in the dialog if an
+          // assertion has been generated. onmatch is incorrectly called
+          // if an assertion has already been generated. See #3170
+          commChan.notify({ method: 'dialog_complete', params: !r.assertion });
         }
 
         // clear the window handle


### PR DESCRIPTION
@seanmonstar or @shane-tomlinson, mind having a look?

Shane's old fix from months ago, rebased against current dev & reopened. This fixes #3170 for me locally, and all tests are passing.
