### PR TITLE
Issue 3701 no oncancel

### DIFF
--- a/automation-tests/tests/api-tests/oncancel.js
+++ b/automation-tests/tests/api-tests/oncancel.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/*jshint sub:true */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const
+path = require('path'),
+CSS = require('../../pages/css.js'),
+runner = require('../../lib/runner.js'),
+persona_urls = require('../../lib/urls.js'),
+testSetup = require('../../lib/test-setup.js');
+
+var browser;
+
+runner.run(module, {
+  "setup all the things": function(done) {
+    testSetup.setup({ b:1 }, function(err, fix) {
+      if (fix) {
+        browser = fix.b[0];
+      }
+      done(err);
+    });
+  },
+
+  "create a new selenium session": function(done) {
+    testSetup.newBrowserSession(browser, done);
+  },
+
+  "open 123done, load up dialog": function(done) {
+    browser.chain({ onError: done })
+      .get(persona_urls["123done"])
+      .wclick(CSS['123done.org'].signinButton)
+      .wwin(CSS["persona.org"].windowName)
+      .wfind(CSS['dialog'].emailInput, done);
+  },
+
+  "close dialog": function(done) {
+    browser.closeCurrentBrowserWindow(done);
+  },
+
+  "ensure the sign in button is re-enabled and is clickable": function(done) {
+    browser.chain({ onError: done })
+      .wclick(CSS['123done.org'].signinButton)
+      .wwin(CSS["persona.org"].windowName)
+      .wfind(CSS['dialog'].emailInput, done);
+  }
+}, {
+  suiteName: path.basename(__filename),
+  cleanup: function(done) { testSetup.teardown(done); }
+});
+
+

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -390,10 +390,18 @@
           if (!err && r && r.email) {
             commChan.notify({ method: 'loggedInUser', params: r.email });
           }
-          // do not check the authentication status in the dialog if an
-          // assertion has been generated. onmatch is incorrectly called
-          // if an assertion has already been generated. See #3170
-          commChan.notify({ method: 'dialog_complete', params: !r.assertion });
+          // prevent the authentication status check if an assertion is
+          // generated in the dialog or the dialog returned with an error.
+          // This prevents .onmatch from being fired for:
+          // 1. assertion already generated in the dialog
+          // 2. user is signed in to the site, opens the dialog, then cancels
+          // the dialog without generating an assertion.
+          // See #3170 & #3701
+          var checkAuthStatus = !(err || r && r.assertion);
+          commChan.notify({
+            method: 'dialog_complete',
+            params: checkAuthStatus
+          });
         }
 
         // clear the window handle


### PR DESCRIPTION
@6a68 and @seanmonstar - yo, yesterday's onmatch "fix" broke "oncancel". I fixed the fix, and added a Selenium test.

I think it would behoove us to create some specialized selenium tests to exercise the various callbacks.

Ah yes, an ephemeral instance "https://no-oncancel.personatest.org" is available to test against.

fixes #3701 
