### PR TITLE
Issue 3689 edit email field

### DIFF
--- a/automation-tests/tests/new-user/new-user-secondary-test.js
+++ b/automation-tests/tests/new-user/new-user-secondary-test.js
@@ -42,6 +42,13 @@ var new_secondary_123done_two_browsers = {
   "switch to the persona dialog": function(done) {
     browser.wwin(CSS['persona.org'].windowName, done);
   },
+  "enter incorrect email, cancel set password screen": function(done) {
+    browser.chain({onError: done})
+      .wtype(CSS['dialog'].emailInput, "incorrect_email@restmail.net")
+      .wclick(CSS['dialog'].newEmailNextButton)
+      .wclick(CSS['dialog'].submitCancelButton)
+      .wclear(CSS['dialog'].emailInput, done);
+  },
   "go through signup flow": function(done) {
     dialog.signInAsNewUser({
       browser: browser,

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -102,7 +102,8 @@ BrowserID.State = (function() {
         // after a user verifies an address but is not authenticated
         // to the password level.
         redirectToState("authenticate", {
-          email: self.stagedEmail
+          email: self.stagedEmail,
+          email_mutable: false
         });
       }
       else {
@@ -449,6 +450,7 @@ BrowserID.State = (function() {
             redirectToState("stage_transition_to_secondary", info);
           }
           else {
+            addressInfo.email_mutable = false;
             redirectToState("authenticate", addressInfo);
           }
         }
@@ -468,6 +470,7 @@ BrowserID.State = (function() {
             if (authentication !== "password") {
               // user must authenticate with their password, kick them over to
               // the authenticate screen to enter the password.
+              addressInfo.email_mutable = false;
               redirectToState("authenticate", addressInfo);
             }
             else {

--- a/resources/static/test/cases/dialog/js/misc/state.js
+++ b/resources/static/test/cases/dialog/js/misc/state.js
@@ -537,7 +537,10 @@
     mediator.publish("email_chosen", {
       email: TEST_EMAIL,
       complete: function() {
-        testActionStarted("doAuthenticate");
+        testActionStarted("doAuthenticate", {
+          email: TEST_EMAIL,
+          email_mutable: false
+        });
         start();
       }
     });
@@ -566,7 +569,8 @@
       email: TEST_EMAIL,
       complete: function() {
         testActionStarted("doAuthenticate", {
-          email: TEST_EMAIL
+          email: TEST_EMAIL,
+          email_mutable: false
         });
         start();
       }

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -140,12 +140,32 @@
     });
   });
 
-  asyncTest("email declared in options - email cannot be changed, " +
+  asyncTest("mutable email declared in options - email can be changed, " +
+      "focus email field", function() {
+    controller.destroy();
+    $(EMAIL_SELECTOR).val("");
+
+    createController({
+      email: "registered@testuser.com",
+      email_mutable: true,
+      ready: function() {
+        equal($(EMAIL_SELECTOR).val(), "registered@testuser.com", "email prefilled");
+        testElementHasClass("body", "start");
+        testElementNotHasClass("body", "returning");
+        testElementNotHasClass("body", "emailImmutable");
+        start();
+      }
+    });
+  });
+
+  asyncTest("immutable email declared in options - email cannot be changed, " +
       "straight to password field", function() {
     controller.destroy();
     $(EMAIL_SELECTOR).val("");
 
-    createController({ email: "registered@testuser.com",
+    createController({
+      email: "registered@testuser.com",
+      email_mutable: false,
       ready: function() {
         equal($(EMAIL_SELECTOR).val(), "registered@testuser.com", "email prefilled");
         testElementHasClass("body", "returning");


### PR DESCRIPTION
@6a68 - When ripping out requiredEmail, I made some assumptions in the authenticate module that were incorrect. I assumed that if the email was specified when the module started, it meant that the email address was immutable. This is not the case. A new user who enters an email address, goes to the set password screen, and then cancels and goes back to the authenticate screen should still be able to edit the email address.

Users who must authenticate post-email-verification, on assertion->password credential upgrade, or on transition_to_secondary must enter the password, but in this case the email is immutable.

So, I pass in whether the email is mutable or not from the state machine.

An ephemeral instance (with the fix contained in #3702) has already been pushed to run selenium tests against is set up - https://cancel-set-password.personatest.org

fixes #3689 
