### PR TITLE
Change the default rpBackground color to match the footer.

### DIFF
--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -295,7 +295,7 @@ section > .contents {
 
 
 .rpBackground {
-  background-color: #ccc;
+  background-color: #ebeced;
 }
 
 #signIn .table {


### PR DESCRIPTION
@callahad - I give you the review.

The note from Shorelander is:

>  Hi Shane,
> 
>  I don't think we should add the noise back. As far as default colors, if the darker grey is default then I would
>  suggest lightening it up. Still darker than the left, but lighter than it is now.
> 
>  Thanks
> 
> ```
>  Stephen
> ```

fixes #3677
