### PR TITLE
Make the main sign in area the same color as the arrow.

### DIFF
--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -299,7 +299,7 @@ section > .contents {
 }
 
 #signIn .table {
-    background-color: #fafafa;
+    background-color: #f9f9f9;
     box-shadow: 0px 0px 20px -11px #000;
     padding: 0 20px;
 }


### PR DESCRIPTION
The arrow is #f9f9f9 whereas the form area was #fafafa.

This helps, but does not eliminate #3677.
