### PR TITLE
3705: allow siteLogo parameter to include domain if served via https

### DIFF
--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -111,6 +111,7 @@ var dialog_js = und.flatten([
     '/dialog/js/modules/set_password.js',
     '/dialog/js/modules/rp_info.js',
     '/dialog/js/modules/inline_tospp.js',
+    '/dialog/js/modules/validate_rp_params.js',
     '/dialog/js/start.js'
   ]]);
 

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -97,6 +97,48 @@ BrowserID.Modules.Dialog = (function() {
     this.publish("window_unload");
   }
 
+  function publishKpis(rpAPI) {
+    /*jshint validthis: true*/
+
+    // By default, a dialog is an orphan. It is only not an orphan if an
+    // assertion is generated. When an assertion is generated, orphaned will
+    // be set to false (currently in state.js).
+    var kpis = {
+      orphaned: true,
+      rp_api: rpAPI || "unknown"
+    };
+
+    // only publish the kpi's in aggregate.
+    this.publish("kpi_data", kpis);
+  }
+
+  function validateRpParams(origin_url, paramsFromRP) {
+    /*jshint validthis: true*/
+    var self=this;
+
+    startValidator.call(self);
+
+    var params;
+    try {
+      paramsFromRP.origin_url = origin_url;
+      params = self.validator.validate(paramsFromRP);
+    } catch(e) {
+      // note: renderError accepts HTML and cheerfully injects it into a
+      // frame with a powerful origin. So convert 'e' first.
+      self.renderError("error", {
+        action: {
+          title: "error in " + _.escape(origin_url),
+          message: "improper usage of API: " + _.escape(e)
+        }
+      });
+
+      throw e;
+    }
+
+    return params;
+  }
+
+
   var Dialog = bid.Modules.PageModule.extend({
     start: function(options) {
       var self=this;
@@ -144,35 +186,16 @@ BrowserID.Modules.Dialog = (function() {
 
       user.setOrigin(origin_url);
 
-      // By default, a dialog is an orphan. It is only not an orphan if an
-      // assertion is generated. When an assertion is generated, orphaned will
-      // be set to false (currently in state.js).
-      var kpis = {
-        orphaned: true
-      };
-
       if (self.startExternalDependencies) {
         startActions.call(self, success, error);
         startStateMachine.call(self);
       }
 
-      // The validator is always started.
-      startValidator.call(self);
-
       var params;
       try {
-        paramsFromRP.origin_url = origin_url;
-        params = self.validator.validate(paramsFromRP);
+        params = validateRpParams.call(self, origin_url, paramsFromRP);
       } catch(e) {
-        // note: renderError accepts HTML and cheerfully injects it into a
-        // frame with a powerful origin. So convert 'e' first.
-        self.renderError("error", {
-          action: {
-            title: "error in " + _.escape(origin_url),
-            message: "improper usage of API: " + _.escape(e)
-          }
-        });
-
+        // input parameter validation failure. Stop.
         return e;
       }
 
@@ -184,14 +207,10 @@ BrowserID.Modules.Dialog = (function() {
       if (params.startTime)
         self.publish("start_time", params.startTime);
 
-      if (params.rpAPI)
-        kpis.rp_api = params.rpAPI;
+      publishKpis.call(self, params.rpAPI);
 
       if (params.returnTo)
         user.setReturnTo(params.returnTo);
-
-      // only publish the kpi's in aggregate.
-      self.publish("kpi_data", kpis);
 
 
       // XXX Perhaps put this into the state machine.

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -249,7 +249,7 @@ BrowserID.Modules.Dialog = (function() {
       user.setOrigin(origin_url);
 
       // By default, a dialog is an orphan. It is only not an orphan if an
-      // assertion is generated. When an asseriton is generated, orphaned will
+      // assertion is generated. When an assertion is generated, orphaned will
       // be set to false (currently in state.js).
       var kpis = {
         orphaned: true

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -304,14 +304,16 @@ BrowserID.Modules.Dialog = (function() {
         }
 
         if (paramsFromRP.siteLogo) {
-          // Until we have our head around the dangers of data uris and images
-          // that come from other domains, only allow absolute paths from the
-          // origin.
-          params.siteLogo = fixupAbsolutePath(origin_url, paramsFromRP.siteLogo);
+          // Regularize URL; throws error if input is relative.
+          params.siteLogo = fixupURL(origin_url, paramsFromRP.siteLogo);
           // To avoid mixed content errors, only allow siteLogos to be served
           // from https RPs
           /*jshint newcap:false*/
           if (URLParse(origin_url).scheme !== "https") {
+            throw new Error("only https sites can specify a siteLogo");
+          }
+          // XXX eliminate previous? This test has some overlap with it.
+          if (URLParse(params.siteLogo).scheme !== "https") {
             throw new Error("only https sites can specify a siteLogo");
           }
         }

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -9,34 +9,39 @@ BrowserID.Modules.Dialog = (function() {
   var bid = BrowserID,
       user = bid.User,
       errors = bid.Errors,
-      dom = bid.DOM,
-      helpers = bid.Helpers,
       storage = bid.Storage,
-      win = window,
-      startExternalDependencies = true,
-      channel,
       sc;
 
   function startActions(onsuccess, onerror) {
-    var actions = BrowserID.Modules.Actions.create();
+    /*jshint validthis: true*/
+    var actions = this.actions = bid.Modules.Actions.create();
     actions.start({
       onsuccess: onsuccess,
       onerror: onerror
     });
-    return actions;
   }
 
-  function startStateMachine(controller) {
+  function startStateMachine() {
+    /*jshint validthis: true*/
     // start this directly because it should always be running.
-    var machine = BrowserID.State.create();
+    var machine = this.stateMachine = bid.State.create();
     machine.start({
-      controller: controller
+      controller: this.actions
+    });
+  }
+
+  function startValidator() {
+    /*jshint validthis: true*/
+    var validator = this.validator = bid.Modules.ValidateRpParams.create();
+    validator.start({
+      window: this.window
     });
   }
 
   function startChannel() {
     /*jshint validthis: true*/
     var self = this,
+        win = self.window,
         hash = win.location.hash;
 
     // first, we see if there is a local channel
@@ -68,7 +73,7 @@ BrowserID.Modules.Dialog = (function() {
     }
 
     try {
-      channel = WinChan.onOpen(function(origin, args, cb) {
+      self.channel = WinChan.onOpen(function(origin, args, cb) {
         // XXX this is called whenever the primary provisioning iframe gets
         // added.  If there are no args, then do not do self.get.
         if(args) {
@@ -86,127 +91,10 @@ BrowserID.Modules.Dialog = (function() {
     }
   }
 
-  function stopChannel() {
-    channel && channel.detach();
-  }
 
   function onWindowUnload() {
     /*jshint validthis: true*/
     this.publish("window_unload");
-  }
-
-  function fixupURL(origin, url) {
-    var u;
-    if (typeof(url) !== "string")
-      throw new Error("urls must be strings: (" + url + ")");
-    /*jshint newcap:false*/
-    if (/^http(s)?:\/\//.test(url)) u = URLParse(url);
-    else if (/^\/[^\/]/.test(url)) u = URLParse(origin + url);
-    else throw new Error("relative urls not allowed: (" + url + ")");
-    // encodeURI limits our return value to [a-z0-9:/?%], excluding <script>
-    var encodedURI = encodeURI(u.validate().normalize().toString());
-
-    // All browsers have a max length of URI that they can handle. IE8 has the
-    // shortest total length at 2083 bytes.  IE8 can handle a path length of
-    // 2048 bytes. See http://support.microsoft.com/kb/q208427
-
-    // Check the total encoded URI length
-    if (encodedURI.length > bid.URL_MAX_LENGTH)
-      throw new Error("urls must be < " + bid.URL_MAX_LENGTH + " characters");
-
-    // Check just the path portion.  encode the path to make sure the full
-    // length is checked.
-    if (encodeURI(u.path).length > bid.PATH_MAX_LENGTH)
-      throw new Error("path portion of a url must be < " + bid.PATH_MAX_LENGTH + " characters");
-
-    return encodedURI;
-  }
-
-  function fixupAbsolutePath(origin_url, path) {
-    // Ensure URL is an absolute path (not a relative path or a scheme-relative URL)
-    if (/^\/[^\/]/.test(path))  return fixupURL(origin_url, path);
-
-    throw new Error("must be an absolute path: (" + path + ")");
-  }
-
-  function fixupReturnTo(origin_url, path) {
-    // "/" is a valid returnTo, but it is not a valid path for any other
-    // parameter. If the path is "/", allow it, otherwise pass the path down
-    // the normal checks.
-    var returnTo = path === "/" ?
-      origin_url + path :
-      fixupAbsolutePath(origin_url, path);
-    return returnTo;
-  }
-
-  function fixupIssuer(issuer) {
-    // An issuer should not have a scheme on the front of it.
-    // The URL parser requires a scheme. Prepend the scheme to do the
-    // verification.
-    /*jshint newcap:false*/
-    var u = URLParse("http://" + issuer);
-    if (u.host !== issuer) {
-      var encodedURI = encodeURI(u.validate().normalize().toString());
-      throw new Error("invalid issuer: " + encodedURI);
-    }
-
-    return issuer;
-  }
-
-  function validateBackgroundColor(value) {
-
-    if (value.substr(0, 1) === '#') {
-      value = value.substr(1);
-    }
-
-    // Check if this is valid hex color
-    if (!value.match(/^[0-9a-fA-F]{3}$|^[0-9a-fA-F]{6}$/)) {
-      throw new Error('invalid backgroundColor: ' + value);
-    }
-
-    if (value.length === 6) {
-      return value;
-    }
-
-    // Normalize 3- to 6-character hex color
-    var bits = [];
-    for (var i = 0; i < 3; i++) {
-      bits.push(value.charAt(i) + value.charAt(i));
-    }
-
-    return bits.join('');
-
-  }
-
-  function validateRPAPI(rpAPI) {
-    var VALID_RP_API_VALUES = [
-      "watch_without_onready",
-      "watch_with_onready",
-      "get",
-      "getVerifiedEmail",
-      "internal"
-    ];
-
-    if (_.indexOf(VALID_RP_API_VALUES, rpAPI) === -1) {
-      throw new Error("invalid value for rp_api: " + rpAPI);
-    }
-  }
-
-  function validateStartTime(startTime) {
-    var parsedTime = parseInt(startTime, 10);
-    if (typeof parsedTime !== "number" || isNaN(parsedTime)) {
-      throw new Error("invalid value for start_time: " + startTime);
-    }
-
-    return parsedTime;
-  }
-
-  function validateBoolean(bool, name) {
-    if (typeof bool !== "boolean") {
-      throw new Error("invalid value for " + name + ": " + bool);
-    }
-
-    return bool;
   }
 
   var Dialog = bid.Modules.PageModule.extend({
@@ -215,7 +103,7 @@ BrowserID.Modules.Dialog = (function() {
 
       options = options || {};
 
-      win = options.window || window;
+      self.window = options.window || window;
 
       // startExternalDependencies is used in unit testing and can only be set
       // by the creator/starter of this module.  If startExternalDependencies
@@ -223,14 +111,14 @@ BrowserID.Modules.Dialog = (function() {
       // are not started.  These dependencies can interfere with the ability to
       // unit test this module because they can throw exceptions and show error
       // messages.
-      startExternalDependencies = true;
+      self.startExternalDependencies = true;
       if (typeof options.startExternalDependencies === "boolean") {
-        startExternalDependencies = options.startExternalDependencies;
+        self.startExternalDependencies = options.startExternalDependencies;
       }
 
       sc.start.call(self, options);
 
-      if (startExternalDependencies) {
+      if (self.startExternalDependencies) {
         startChannel.call(self);
       }
 
@@ -238,13 +126,21 @@ BrowserID.Modules.Dialog = (function() {
     },
 
     stop: function() {
-      stopChannel();
+      var self=this;
+      if (self.channel)
+        self.channel.detach();
+
+      if (self.actions)
+        self.actions.stop();
+
+      if (self.validator)
+        self.validator.stop();
+
       sc.stop.call(this);
     },
 
     get: function(origin_url, paramsFromRP, success, error) {
-      var self=this,
-          hash = win.location.hash;
+      var self=this;
 
       user.setOrigin(origin_url);
 
@@ -255,140 +151,18 @@ BrowserID.Modules.Dialog = (function() {
         orphaned: true
       };
 
-
-      if (startExternalDependencies) {
-        var actions = startActions.call(self, success, error);
-        startStateMachine.call(self, actions);
+      if (self.startExternalDependencies) {
+        startActions.call(self, success, error);
+        startStateMachine.call(self);
       }
 
-      // Security Note: paramsFromRP is the output of a JSON.parse on an
-      // RP-controlled string. Most of these fields are expected to be simple
-      // printable strings (hostnames, usernames, and URLs), but we cannot
-      // rely upon the RP to do that. In particular we must guard against
-      // these strings containing <script> tags. We will populate a new
-      // object ("params") with suitably type-checked properties.
-      var params = {};
-      params.hostname = user.getHostname();
+      // The validator is always started.
+      startValidator.call(self);
 
-      // verify params
+      var params;
       try {
-        var startTime = paramsFromRP.start_time;
-        if (startTime) {
-          startTime = validateStartTime(startTime);
-          self.publish("start_time", startTime);
-        }
-
-        self.publish("channel_established");
-
-        var rpAPI = paramsFromRP.rp_api;
-        if (rpAPI) {
-          // throws if an invalid rp_api value
-          validateRPAPI(rpAPI);
-          kpis.rp_api = rpAPI;
-        }
-
-        if (paramsFromRP.requiredEmail) {
-          helpers.log("requiredEmail has been deprecated");
-        }
-
-        // support old parameter names if new parameter names not defined.
-        if (paramsFromRP.tosURL && !paramsFromRP.termsOfService)
-          paramsFromRP.termsOfService = paramsFromRP.tosURL;
-
-        if (paramsFromRP.privacyURL && !paramsFromRP.privacyPolicy)
-          paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
-
-        if (paramsFromRP.termsOfService && paramsFromRP.privacyPolicy) {
-          params.termsOfService = fixupURL(origin_url, paramsFromRP.termsOfService);
-          params.privacyPolicy = fixupURL(origin_url, paramsFromRP.privacyPolicy);
-        }
-
-        var validLogoSchemes = {"https": 1, 'data': 1};
-        // 'data:image/png;base64,iV...' -> ['data:image/png;base64,iV...', 'image', 'png', ...]
-        // ... therefore mimetype -> [1]/[2]
-        var dataUriRegex = /^data:(.+)\/(.+);base64,(.*)$/;
-        var dataMatches = null;
-        // who needs a shared mimetype parsing library?
-        var imageMimeTypes = {'png': 1, 'gif': 1, 'jpg': 1, 'jpeg':1, 'svg': 1}
-        if (paramsFromRP.siteLogo) {
-          dataMatches = paramsFromRP.siteLogo.match(dataUriRegex);
-          if (dataMatches) {
-	    if ((dataMatches[1].toLowerCase() === 'image')
-                 &&
-                (dataMatches[2].toLowerCase() in imageMimeTypes)) {
-                ; // Good to go.
-            } else {
-              throw new Error("bad data URI for siteLogo: " + paramsFromRP.siteLogo.slice(0, 15) + " ...");
-            }
-	  } else {
-            // Regularize URL; throws error if input is relative.
-            params.siteLogo = fixupURL(origin_url, paramsFromRP.siteLogo);
-            /*jshint newcap:false*/
-            if (!(URLParse(params.siteLogo).scheme in validLogoSchemes)) {
-              // This is kind of misleading as URLParse won't actually recognize
-              // the data scheme.
-              throw new Error("siteLogos can only be served from " + _.keys(validLogoSchemes).join(' and ') + " schemes.");
-            }
-          }
-        }
-
-        if (paramsFromRP.backgroundColor) {
-          var backgroundColor = validateBackgroundColor(paramsFromRP.backgroundColor);
-          if (backgroundColor) params.backgroundColor = backgroundColor;
-        }
-
-        if (paramsFromRP.siteName) {
-          params.siteName = _.escape(paramsFromRP.siteName);
-        }
-
-        // returnTo is used for post verification redirection.  Redirect back
-        // to the path specified by the RP.
-        if (paramsFromRP.returnTo) {
-          var returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
-          user.setReturnTo(returnTo);
-        }
-
-        // forceAuthentication is used by the Marketplace to ensure that the
-        // user knows the password to this account. We ignore any active session.
-        if (paramsFromRP.experimental_forceAuthentication) {
-          params.forceAuthentication = validateBoolean(
-              paramsFromRP.experimental_forceAuthentication,
-              "experimental_forceAuthentication");
-        }
-
-        // forceIsuser is used by the Marketplace to disable primary support
-        // and replace fxos.login.persona.org as the issuer of certs
-        if (paramsFromRP.experimental_forceIssuer) {
-          params.forceIssuer =
-              fixupIssuer(paramsFromRP.experimental_forceIssuer);
-        }
-
-        // allowUnverified means that the user doesn't need to have
-        // verified their email address in order to send an assertion.
-        // if the user *has* verified, it will be a verified assertion.
-        if (paramsFromRP.experimental_allowUnverified) {
-          params.allowUnverified = validateBoolean(
-              paramsFromRP.experimental_allowUnverified,
-              "experimental_allowUnverified");
-        }
-
-        if (hash.indexOf("#AUTH_RETURN") === 0) {
-          var primaryParams = storage.idpVerification.get();
-          if (!primaryParams)
-            throw new Error("Could not get IdP Verification Info");
-
-          params.email = primaryParams.email;
-          params.add = primaryParams.add;
-          params.type = "primary";
-          params.cancelled = false;
-        }
-
-        if (hash.indexOf("#AUTH_RETURN_CANCEL") === 0) {
-          params.cancelled = true;
-        }
-
-        // no matter what, we clear the primary flow state for this window
-        storage.idpVerification.clear();
+        paramsFromRP.origin_url = origin_url;
+        params = self.validator.validate(paramsFromRP);
       } catch(e) {
         // note: renderError accepts HTML and cheerfully injects it into a
         // frame with a powerful origin. So convert 'e' first.
@@ -401,17 +175,31 @@ BrowserID.Modules.Dialog = (function() {
 
         return e;
       }
-      // after this point, "params" can be relied upon to contain safe data
+
+      // after this point, "params" and "paramsFromRP" can be relied upon
+      // to contain safe data
+
+      if (params.startTime)
+        self.publish("start_time", params.startTime);
+
+      if (params.rpAPI)
+        kpis.rp_api = params.rpAPI;
+
+      // only publish the kpi's in aggregate.
+      self.publish("kpi_data", kpis);
+
 
       // XXX Perhaps put this into the state machine.
-      self.bind(win, "unload", onWindowUnload);
+      self.bind(self.window, "unload", onWindowUnload);
+
+      self.publish("channel_established");
+
+      // no matter what, we clear the primary flow state for this window
+      storage.idpVerification.clear();
 
       function start() {
         self.publish("start", params);
       }
-
-      // only publish the kpi's in aggregate.
-      self.publish("kpi_data", kpis);
 
       if (params.type === "primary" && !params.add) {
         // at this point, we will only have type of primary if we're

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -112,7 +112,7 @@ BrowserID.Modules.Dialog = (function() {
     this.publish("kpi_data", kpis);
   }
 
-  function validateRpParams(origin_url, paramsFromRP) {
+  function validateRpParams(originURL, paramsFromRP) {
     /*jshint validthis: true*/
     var self=this;
 
@@ -120,14 +120,14 @@ BrowserID.Modules.Dialog = (function() {
 
     var params;
     try {
-      paramsFromRP.origin_url = origin_url;
+      paramsFromRP.originURL = originURL;
       params = self.validator.validate(paramsFromRP);
     } catch(e) {
       // note: renderError accepts HTML and cheerfully injects it into a
       // frame with a powerful origin. So convert 'e' first.
       self.renderError("error", {
         action: {
-          title: "error in " + _.escape(origin_url),
+          title: "error in " + _.escape(originURL),
           message: "improper usage of API: " + _.escape(e)
         }
       });
@@ -180,10 +180,10 @@ BrowserID.Modules.Dialog = (function() {
       sc.stop.call(this);
     },
 
-    get: function(origin_url, paramsFromRP, success, error) {
+    get: function(originURL, paramsFromRP, success, error) {
       var self=this;
 
-      user.setOrigin(origin_url);
+      user.setOrigin(originURL);
 
       if (self.startExternalDependencies) {
         startActions.call(self, success, error);
@@ -192,7 +192,7 @@ BrowserID.Modules.Dialog = (function() {
 
       var params;
       try {
-        params = validateRpParams.call(self, origin_url, paramsFromRP);
+        params = validateRpParams.call(self, originURL, paramsFromRP);
       } catch(e) {
         // input parameter validation failure. Stop.
         return e;

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -122,20 +122,20 @@ BrowserID.Modules.Dialog = (function() {
     return encodedURI;
   }
 
-  function fixupAbsolutePath(origin_url, path) {
+  function fixupAbsolutePath(originURL, path) {
     // Ensure URL is an absolute path (not a relative path or a scheme-relative URL)
-    if (/^\/[^\/]/.test(path))  return fixupURL(origin_url, path);
+    if (/^\/[^\/]/.test(path))  return fixupURL(originURL, path);
 
     throw new Error("must be an absolute path: (" + path + ")");
   }
 
-  function fixupReturnTo(origin_url, path) {
+  function fixupReturnTo(originURL, path) {
     // "/" is a valid returnTo, but it is not a valid path for any other
     // parameter. If the path is "/", allow it, otherwise pass the path down
     // the normal checks.
     var returnTo = path === "/" ?
-      origin_url + path :
-      fixupAbsolutePath(origin_url, path);
+      originURL + path :
+      fixupAbsolutePath(originURL, path);
     return returnTo;
   }
 
@@ -209,7 +209,7 @@ BrowserID.Modules.Dialog = (function() {
     return bool;
   }
 
-  function validateSiteLogo(origin_url, inputLogoUri) {
+  function validateSiteLogo(originURL, inputLogoUri) {
     // return a regularized logo URI if inputLogoUri is valid,
     // else throw an Error. Valid logo URIs can take only these forms:
     //   1) data:image/EXT;base64,...
@@ -241,7 +241,7 @@ BrowserID.Modules.Dialog = (function() {
     }
 
     // Regularize URL; throws error if input is relative.
-    outputLogoUri = fixupURL(origin_url, inputLogoUri);
+    outputLogoUri = fixupURL(originURL, inputLogoUri);
     /*jshint newcap:false*/
     if (URLParse(outputLogoUri).scheme !== 'https') {
       throw new Error("siteLogos can only be served from https and data schemes.");
@@ -282,11 +282,11 @@ BrowserID.Modules.Dialog = (function() {
       sc.stop.call(this);
     },
 
-    get: function(origin_url, paramsFromRP, success, error) {
+    get: function(originURL, paramsFromRP, success, error) {
       var self=this,
           hash = win.location.hash;
 
-      user.setOrigin(origin_url);
+      user.setOrigin(originURL);
 
       // By default, a dialog is an orphan. It is only not an orphan if an
       // assertion is generated. When an assertion is generated, orphaned will
@@ -339,12 +339,12 @@ BrowserID.Modules.Dialog = (function() {
           paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
 
         if (paramsFromRP.termsOfService && paramsFromRP.privacyPolicy) {
-          params.termsOfService = fixupURL(origin_url, paramsFromRP.termsOfService);
-          params.privacyPolicy = fixupURL(origin_url, paramsFromRP.privacyPolicy);
+          params.termsOfService = fixupURL(originURL, paramsFromRP.termsOfService);
+          params.privacyPolicy = fixupURL(originURL, paramsFromRP.privacyPolicy);
         }
 
         if (paramsFromRP.siteLogo) {
-          params.siteLogo = validateSiteLogo(origin_url, paramsFromRP.siteLogo);
+          params.siteLogo = validateSiteLogo(originURL, paramsFromRP.siteLogo);
         }
 
         if (paramsFromRP.backgroundColor) {
@@ -359,7 +359,7 @@ BrowserID.Modules.Dialog = (function() {
         // returnTo is used for post verification redirection.  Redirect back
         // to the path specified by the RP.
         if (paramsFromRP.returnTo) {
-          var returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
+          var returnTo = fixupReturnTo(originURL, paramsFromRP.returnTo);
           user.setReturnTo(returnTo);
         }
 
@@ -409,7 +409,7 @@ BrowserID.Modules.Dialog = (function() {
         // frame with a powerful origin. So convert 'e' first.
         self.renderError("error", {
           action: {
-            title: "error in " + _.escape(origin_url),
+            title: "error in " + _.escape(originURL),
             message: "improper usage of API: " + _.escape(e)
           }
         });

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -179,11 +179,16 @@ BrowserID.Modules.Dialog = (function() {
       // after this point, "params" and "paramsFromRP" can be relied upon
       // to contain safe data
 
+      params.hostname = user.getHostname();
+
       if (params.startTime)
         self.publish("start_time", params.startTime);
 
       if (params.rpAPI)
         kpis.rp_api = params.rpAPI;
+
+      if (params.returnTo)
+        user.setReturnTo(params.returnTo);
 
       // only publish the kpi's in aggregate.
       self.publish("kpi_data", kpis);

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -309,18 +309,18 @@ BrowserID.Modules.Dialog = (function() {
         var dataUriRegex = /^data:(.+)\/(.+);base64,(.*)$/;
         var dataMatches = null;
         // who needs a shared mimetype parsing library?
-        var imageMimeTypes = {'png': 1, 'gif': 1, 'jpg': 1, 'jpeg':1, 'svg': 1}
+        var imageMimeTypes = {'png': 1, 'gif': 1, 'jpg': 1, 'jpeg':1, 'svg': 1};
         if (paramsFromRP.siteLogo) {
           dataMatches = paramsFromRP.siteLogo.match(dataUriRegex);
           if (dataMatches) {
-	    if ((dataMatches[1].toLowerCase() === 'image')
+            if ((dataMatches[1].toLowerCase() === 'image')
                  &&
                 (dataMatches[2].toLowerCase() in imageMimeTypes)) {
                 ; // Good to go.
             } else {
               throw new Error("bad data URI for siteLogo: " + paramsFromRP.siteLogo.slice(0, 15) + " ...");
             }
-	  } else {
+          } else {
             // Regularize URL; throws error if input is relative.
             params.siteLogo = fixupURL(origin_url, paramsFromRP.siteLogo);
             /*jshint newcap:false*/

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -30,7 +30,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
       var self = this,
           hash = self.window.location.hash;
 
-      var origin_url = paramsFromRP.origin_url;
+      var originURL = paramsFromRP.originURL;
 
       // Security Note: paramsFromRP is the output of a JSON.parse on an
       // RP-controlled string. Most of these fields are expected to be simple
@@ -64,12 +64,12 @@ BrowserID.Modules.ValidateRpParams = (function() {
         paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
 
       if (paramsFromRP.termsOfService && paramsFromRP.privacyPolicy) {
-        params.termsOfService = fixupURL(origin_url, paramsFromRP.termsOfService);
-        params.privacyPolicy = fixupURL(origin_url, paramsFromRP.privacyPolicy);
+        params.termsOfService = fixupURL(originURL, paramsFromRP.termsOfService);
+        params.privacyPolicy = fixupURL(originURL, paramsFromRP.privacyPolicy);
       }
 
       if (paramsFromRP.siteLogo) {
-        params.siteLogo = validateSiteLogo(origin_url, paramsFromRP.siteLogo);
+        params.siteLogo = validateSiteLogo(originURL, paramsFromRP.siteLogo);
       }
 
       if (paramsFromRP.backgroundColor) {
@@ -84,7 +84,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
       // returnTo is used for post verification redirection.  Redirect back
       // to the path specified by the RP.
       if (paramsFromRP.returnTo) {
-        params.returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
+        params.returnTo = fixupReturnTo(originURL, paramsFromRP.returnTo);
       }
 
       // forceAuthentication is used by the Marketplace to ensure that the
@@ -161,20 +161,20 @@ BrowserID.Modules.ValidateRpParams = (function() {
     return encodedURI;
   }
 
-  function fixupAbsolutePath(origin_url, path) {
+  function fixupAbsolutePath(originURL, path) {
     // Ensure URL is an absolute path (not a relative path or a scheme-relative URL)
-    if (/^\/[^\/]/.test(path))  return fixupURL(origin_url, path);
+    if (/^\/[^\/]/.test(path))  return fixupURL(originURL, path);
 
     throw new Error("must be an absolute path: (" + path + ")");
   }
 
-  function fixupReturnTo(origin_url, path) {
+  function fixupReturnTo(originURL, path) {
     // "/" is a valid returnTo, but it is not a valid path for any other
     // parameter. If the path is "/", allow it, otherwise pass the path down
     // the normal checks.
     var returnTo = path === "/" ?
-      origin_url + path :
-      fixupAbsolutePath(origin_url, path);
+      originURL + path :
+      fixupAbsolutePath(originURL, path);
     return returnTo;
   }
 

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -1,0 +1,279 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+BrowserID.Modules.ValidateRpParams = (function() {
+  "use strict";
+
+  /**
+   * This module validates parameters that come from the RP.
+   * the validate method is called with paramsFromRP and returns params, a list
+   * of cleaned parameters than can be assumed to be safe.
+   */
+
+  var bid = BrowserID,
+      user = bid.User,
+      storage = bid.Storage,
+      helpers = bid.Helpers,
+      sc;
+
+  var Module = bid.Modules.Module.extend({
+    start: function(options) {
+      var self = this;
+
+      self.window = options.window || window;
+
+      sc.start.call(self);
+    },
+    validate: function(paramsFromRP) {
+      var self = this,
+          hash = self.window.location.hash;
+
+      var origin_url = paramsFromRP.origin_url;
+
+      // Security Note: paramsFromRP is the output of a JSON.parse on an
+      // RP-controlled string. Most of these fields are expected to be simple
+      // printable strings (hostnames, usernames, and URLs), but we cannot
+      // rely upon the RP to do that. In particular we must guard against
+      // these strings containing <script> tags. We will populate a new
+      // object ("params") with suitably type-checked properties.
+      var params = {};
+      params.hostname = user.getHostname();
+
+      // verify params
+      var startTime = paramsFromRP.start_time;
+      if (startTime) {
+        params.startTime = validateStartTime(startTime);
+      }
+
+      var rpAPI = paramsFromRP.rp_api;
+      if (rpAPI) {
+        // throws if an invalid rp_api value
+        params.rpAPI = validateRPAPI(rpAPI);
+      }
+
+      if (paramsFromRP.requiredEmail) {
+        helpers.log("requiredEmail has been deprecated");
+      }
+
+      // support old parameter names if new parameter names not defined.
+      if (paramsFromRP.tosURL && !paramsFromRP.termsOfService)
+        paramsFromRP.termsOfService = paramsFromRP.tosURL;
+
+      if (paramsFromRP.privacyURL && !paramsFromRP.privacyPolicy)
+        paramsFromRP.privacyPolicy = paramsFromRP.privacyURL;
+
+      if (paramsFromRP.termsOfService && paramsFromRP.privacyPolicy) {
+        params.termsOfService = fixupURL(origin_url, paramsFromRP.termsOfService);
+        params.privacyPolicy = fixupURL(origin_url, paramsFromRP.privacyPolicy);
+      }
+
+      var validLogoSchemes = {"https": 1, 'data': 1};
+      // 'data:image/png;base64,iV...' -> ['data:image/png;base64,iV...', 'image', 'png', ...]
+      // ... therefore mimetype -> [1]/[2]
+      var dataUriRegex = /^data:(.+)\/(.+);base64,(.*)$/;
+      var dataMatches = null;
+      // who needs a shared mimetype parsing library?
+      var imageMimeTypes = {'png': 1, 'gif': 1, 'jpg': 1, 'jpeg':1, 'svg': 1}
+      if (paramsFromRP.siteLogo) {
+        dataMatches = paramsFromRP.siteLogo.match(dataUriRegex);
+        if (dataMatches) {
+    if ((dataMatches[1].toLowerCase() === 'image')
+               &&
+              (dataMatches[2].toLowerCase() in imageMimeTypes)) {
+              ; // Good to go.
+          } else {
+            throw new Error("bad data URI for siteLogo: " + paramsFromRP.siteLogo.slice(0, 15) + " ...");
+          }
+  } else {
+          // Regularize URL; throws error if input is relative.
+          params.siteLogo = fixupURL(origin_url, paramsFromRP.siteLogo);
+          /*jshint newcap:false*/
+          if (!(URLParse(params.siteLogo).scheme in validLogoSchemes)) {
+            // This is kind of misleading as URLParse won't actually recognize
+            // the data scheme.
+            throw new Error("siteLogos can only be served from " + _.keys(validLogoSchemes).join(' and ') + " schemes.");
+          }
+        }
+      }
+
+      if (paramsFromRP.backgroundColor) {
+        var backgroundColor = validateBackgroundColor(paramsFromRP.backgroundColor);
+        if (backgroundColor) params.backgroundColor = backgroundColor;
+      }
+
+      if (paramsFromRP.siteName) {
+        params.siteName = _.escape(paramsFromRP.siteName);
+      }
+
+      // returnTo is used for post verification redirection.  Redirect back
+      // to the path specified by the RP.
+      if (paramsFromRP.returnTo) {
+        var returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
+        user.setReturnTo(returnTo);
+      }
+
+      // forceAuthentication is used by the Marketplace to ensure that the
+      // user knows the password to this account. We ignore any active session.
+      if (paramsFromRP.experimental_forceAuthentication) {
+        params.forceAuthentication = validateBoolean(
+            paramsFromRP.experimental_forceAuthentication,
+            "experimental_forceAuthentication");
+      }
+
+      // forceIsuser is used by the Marketplace to disable primary support
+      // and replace fxos.login.persona.org as the issuer of certs
+      if (paramsFromRP.experimental_forceIssuer) {
+        params.forceIssuer =
+            fixupIssuer(paramsFromRP.experimental_forceIssuer);
+      }
+
+      // allowUnverified means that the user doesn't need to have
+      // verified their email address in order to send an assertion.
+      // if the user *has* verified, it will be a verified assertion.
+      if (paramsFromRP.experimental_allowUnverified) {
+        params.allowUnverified = validateBoolean(
+            paramsFromRP.experimental_allowUnverified,
+            "experimental_allowUnverified");
+      }
+
+      if (hash.indexOf("#AUTH_RETURN") === 0) {
+        var primaryParams = storage.idpVerification.get();
+        if (!primaryParams)
+          throw new Error("Could not get IdP Verification Info");
+
+        params.email = primaryParams.email;
+        params.add = primaryParams.add;
+        params.type = "primary";
+        params.cancelled = false;
+      }
+
+      if (hash.indexOf("#AUTH_RETURN_CANCEL") === 0) {
+        params.cancelled = true;
+      }
+
+      return params;
+    }
+  });
+
+  sc = Module.sc;
+
+  function fixupURL(origin, url) {
+    var u;
+    if (typeof(url) !== "string")
+      throw new Error("urls must be strings: (" + url + ")");
+    /*jshint newcap:false*/
+    if (/^http(s)?:\/\//.test(url)) u = URLParse(url);
+    else if (/^\/[^\/]/.test(url)) u = URLParse(origin + url);
+    else throw new Error("relative urls not allowed: (" + url + ")");
+    // encodeURI limits our return value to [a-z0-9:/?%], excluding <script>
+    var encodedURI = encodeURI(u.validate().normalize().toString());
+
+    // All browsers have a max length of URI that they can handle. IE8 has the
+    // shortest total length at 2083 bytes.  IE8 can handle a path length of
+    // 2048 bytes. See http://support.microsoft.com/kb/q208427
+
+    // Check the total encoded URI length
+    if (encodedURI.length > bid.URL_MAX_LENGTH)
+      throw new Error("urls must be < " + bid.URL_MAX_LENGTH + " characters");
+
+    // Check just the path portion.  encode the path to make sure the full
+    // length is checked.
+    if (encodeURI(u.path).length > bid.PATH_MAX_LENGTH)
+      throw new Error("path portion of a url must be < " + bid.PATH_MAX_LENGTH + " characters");
+
+    return encodedURI;
+  }
+
+  function fixupAbsolutePath(origin_url, path) {
+    // Ensure URL is an absolute path (not a relative path or a scheme-relative URL)
+    if (/^\/[^\/]/.test(path))  return fixupURL(origin_url, path);
+
+    throw new Error("must be an absolute path: (" + path + ")");
+  }
+
+  function fixupReturnTo(origin_url, path) {
+    // "/" is a valid returnTo, but it is not a valid path for any other
+    // parameter. If the path is "/", allow it, otherwise pass the path down
+    // the normal checks.
+    var returnTo = path === "/" ?
+      origin_url + path :
+      fixupAbsolutePath(origin_url, path);
+    return returnTo;
+  }
+
+  function fixupIssuer(issuer) {
+    // An issuer should not have a scheme on the front of it.
+    // The URL parser requires a scheme. Prepend the scheme to do the
+    // verification.
+    /*jshint newcap:false*/
+    var u = URLParse("http://" + issuer);
+    if (u.host !== issuer) {
+      var encodedURI = encodeURI(u.validate().normalize().toString());
+      throw new Error("invalid issuer: " + encodedURI);
+    }
+
+    return issuer;
+  }
+
+  function validateBackgroundColor(value) {
+
+    if (value.substr(0, 1) === '#') {
+      value = value.substr(1);
+    }
+
+    // Check if this is valid hex color
+    if (!value.match(/^[0-9a-fA-F]{3}$|^[0-9a-fA-F]{6}$/)) {
+      throw new Error('invalid backgroundColor: ' + value);
+    }
+
+    if (value.length === 6) {
+      return value;
+    }
+
+    // Normalize 3- to 6-character hex color
+    var bits = [];
+    for (var i = 0; i < 3; i++) {
+      bits.push(value.charAt(i) + value.charAt(i));
+    }
+
+    return bits.join('');
+
+  }
+
+  function validateRPAPI(rpAPI) {
+    var VALID_RP_API_VALUES = [
+      "watch_without_onready",
+      "watch_with_onready",
+      "get",
+      "getVerifiedEmail",
+      "internal"
+    ];
+
+    if (_.indexOf(VALID_RP_API_VALUES, rpAPI) === -1) {
+      throw new Error("invalid value for rp_api: " + rpAPI);
+    }
+
+    return rpAPI;
+  }
+
+  function validateStartTime(startTime) {
+    var parsedTime = parseInt(startTime, 10);
+    if (typeof parsedTime !== "number" || isNaN(parsedTime)) {
+      throw new Error("invalid value for start_time: " + startTime);
+    }
+
+    return parsedTime;
+  }
+
+  function validateBoolean(bool, name) {
+    if (typeof bool !== "boolean") {
+      throw new Error("invalid value for " + name + ": " + bool);
+    }
+
+    return bool;
+  }
+
+  return Module;
+
+}());
+

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -11,9 +11,9 @@ BrowserID.Modules.ValidateRpParams = (function() {
    */
 
   var bid = BrowserID,
-      user = bid.User,
       storage = bid.Storage,
       helpers = bid.Helpers,
+      complete = helpers.complete,
       sc;
 
   var Module = bid.Modules.Module.extend({
@@ -23,6 +23,8 @@ BrowserID.Modules.ValidateRpParams = (function() {
       self.window = options.window || window;
 
       sc.start.call(self);
+
+      complete(options.ready);
     },
     validate: function(paramsFromRP) {
       var self = this,
@@ -37,7 +39,6 @@ BrowserID.Modules.ValidateRpParams = (function() {
       // these strings containing <script> tags. We will populate a new
       // object ("params") with suitably type-checked properties.
       var params = {};
-      params.hostname = user.getHostname();
 
       // verify params
       var startTime = paramsFromRP.start_time;
@@ -108,8 +109,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
       // returnTo is used for post verification redirection.  Redirect back
       // to the path specified by the RP.
       if (paramsFromRP.returnTo) {
-        var returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
-        user.setReturnTo(returnTo);
+        params.returnTo = fixupReturnTo(origin_url, paramsFromRP.returnTo);
       }
 
       // forceAuthentication is used by the Marketplace to ensure that the

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -229,7 +229,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
     var dataMatches = null; // is this a valid data URI?
     var outputLogoUri;
     // Ideally we'd be loading this from a canonical constants library.
-    var imageMimeTypes = {'png': 1, 'gif': 1, 'jpg': 1, 'jpeg':1, 'svg': 1};
+    var imageMimeTypes = ['png', 'gif', 'jpg', 'jpeg', 'svg'];
     // This regex converts valid input of the form:
     //   'data:image/png;base64,iV...'
     // into an array that looks like:
@@ -241,7 +241,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
     if (dataMatches) {
       if ((dataMatches[1].toLowerCase() === 'image')
            &&
-          (dataMatches[2].toLowerCase() in imageMimeTypes)) {
+          (imageMimeTypes.indexOf(dataMatches[2].toLowerCase()) > -1)) {
         return inputLogoUri; // Good to go.
       }
       throw new Error("Bad data URI for siteLogo: " + inputLogoUri.slice(0, 15) + " ...");

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -476,7 +476,7 @@
     testExpectGetFailure({siteLogo: URL});
   });
 
-  asyncTest("get with local https: siteLogo - allowed", function() {    
+  asyncTest("get with local https: siteLogo - allowed", function() {
     createController({
       ready: function() {
         var siteLogo = HTTPS_TEST_DOMAIN + "://logo.png";
@@ -490,7 +490,7 @@
     });
   });
 
-  asyncTest("get with arbitrary domain https: siteLogo - allowed", function() {    
+  asyncTest("get with arbitrary domain https: siteLogo - allowed", function() {
     createController({
       ready: function() {
         var startInfo;
@@ -510,7 +510,7 @@
         start();
       }
     });
-  }); 
+  });
 
   asyncTest("get with absolute path and http RP - not allowed", function() {
     var siteLogo = '/i/card.png';
@@ -739,4 +739,3 @@
   });
 
 }());
-

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -100,10 +100,6 @@
     testExpectGetFailure(options, "relative urls not allowed: (" + path + ")");
   }
 
-  function testMustBeAbsolutePath(options, path) {
-    testExpectGetFailure(options, "must be an absolute path: (" + path + ")");
-  }
-
   function testExpectGetSuccess(options, expected, domain, done) {
     createController({
       ready: function() {
@@ -330,71 +326,16 @@
   });
 
 
-  asyncTest("get with relative termsOfService & valid privacyPolicy - print error screen", function() {
+  asyncTest("get with invalid RP parameter (termsOfService) - print error screen", function() {
     testRelativeURLNotAllowed({
       termsOfService: "relative.html",
       privacyPolicy: "/privacy.html"
     }, "relative.html");
   });
 
-  asyncTest("get with script containing termsOfService - print error screen", function() {
-    var URL = "relative.html<script>window.scriptRun=true;</script>";
-    testRelativeURLNotAllowed({
-      termsOfService: URL,
-      privacyPolicy: "/privacy.html"
-    }, URL);
-  });
-
-  asyncTest("get with valid termsOfService & relative privacyPolicy - print error screen", function() {
-    var URL = "relative.html";
-    testRelativeURLNotAllowed({
-      termsOfService: "/tos.html",
-      privacyPolicy: URL
-    }, URL);
-  });
-
-  asyncTest("get with valid termsOfService & privacyPolicy='/' - print error screen", function() {
-    var URL = "/";
-    testRelativeURLNotAllowed({
-      termsOfService: "/tos.html",
-      privacyPolicy: URL
-    }, URL);
-  });
-
-  asyncTest("get with valid termsOfService='/' and valid privacyPolicy - print error screen", function() {
-    var URL = "/";
-    testRelativeURLNotAllowed({
-      termsOfService: URL,
-      privacyPolicy: "/privacy.html"
-    }, URL);
-  });
-
-  asyncTest("get with script containing privacyPolicy - print error screen", function() {
-    var URL = "relative.html<script>window.scriptRun=true;</script>";
-    testRelativeURLNotAllowed({
-      termsOfService: "/tos.html",
-      privacyPolicy: URL
-    }, URL);
-  });
-
-  asyncTest("get with javascript protocol for privacyPolicy - print error screen", function() {
-    var URL = "javascript:alert(1)";
-    testRelativeURLNotAllowed({
-      termsOfService: "/tos.html",
-      privacyPolicy: URL
-    }, URL);
-  });
-
-  asyncTest("get with invalid httpg protocol for privacyPolicy - print error screen", function() {
-    var URL = "httpg://testdomain.com/privacy.html";
-    testRelativeURLNotAllowed({
-      termsOfService: "/tos.html",
-      privacyPolicy: URL
-    }, URL);
-  });
 
 
-  asyncTest("get with valid absolute termsOfService & privacyPolicy - go to start", function() {
+  asyncTest("get with valid RP parameters - go to start", function() {
     testExpectGetSuccess({
       termsOfService: "/tos.html",
       privacyPolicy: "/privacy.html"
@@ -405,338 +346,52 @@
     });
   });
 
-  asyncTest("get with valid fully qualified http termsOfService & privacyPolicy - go to start", function() {
+  asyncTest("get with valid rp_api parameters - go to start, set rp_api in KPIs", function() {
+    var receivedKPIs;
+    mediator.subscribe("kpi_data", function(msg, info) {
+      receivedKPIs = info;
+    });
+
     testExpectGetSuccess({
-      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
-      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+      rp_api: "get"
     },
     {
-      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
-      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+      rpAPI: "get"
+    }, HTTPS_TEST_DOMAIN, function() {
+      equal(receivedKPIs.rp_api, "get");
     });
   });
 
-
-  asyncTest("get with valid fully qualified https termsOfService & privacyPolicy - go to start", function() {
+  asyncTest("get with returnTo - set returnTo in user", function() {
     testExpectGetSuccess({
-      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
-      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+      returnTo: "/return.html"
     },
     {
-      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
-      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+      returnTo: HTTPS_TEST_DOMAIN + "/return.html"
+    }, HTTPS_TEST_DOMAIN, function() {
+      equal(user.getReturnTo(), HTTPS_TEST_DOMAIN + "/return.html");
     });
   });
 
-  asyncTest("get with valid termsOfService, tosURL & privacyPolicy, privacyURL - use termsOfService and privacyPolicy", function() {
-    testExpectGetSuccess({
-      termsOfService: "/tos.html",
-      tosURL: "/tos_deprecated.html",
-      privacyPolicy: "/privacy.html",
-      privacyURL: "/privacy_deprecated.html"
-    },
-    {
-      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
-      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
-    });
-  });
 
-  asyncTest("get with relative siteLogo - not allowed", function() {
-    var URL = "logo.png";
-    testExpectGetFailure({siteLogo: URL});
-  });
-
-  asyncTest("get with javascript: siteLogo - not allowed", function() {
-    var URL = "javascript:alert('xss')";
-    testExpectGetFailure({siteLogo: URL});
-  });
-
-  asyncTest("get with data:image/<whitelist>;... siteLogo - allowed", function() {
-    var URL = "data:image/png;base64,FAKEDATA";
-    createController({
-      ready: function() {
-        var siteLogo = URL
-        var retval = controller.get(HTTPS_TEST_DOMAIN, {
-          siteLogo: siteLogo
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
-    });
-  });
-
-  asyncTest("get with data:<not image>... siteLogo - not allowed", function() {
-    var URL = "data:text/html;base64,FAKEDATA";
-    testExpectGetFailure({siteLogo: URL});
-  });
-
-  asyncTest("get with http: siteLogo - not allowed", function() {
-    var URL = HTTP_TEST_DOMAIN + "://logo.png";
-    testExpectGetFailure({siteLogo: URL});
-  });
-
-  asyncTest("get with local https: siteLogo - allowed", function() {    
-    createController({
-      ready: function() {
-        var siteLogo = HTTPS_TEST_DOMAIN + "://logo.png";
-        var retval = controller.get(HTTPS_TEST_DOMAIN, {
-          siteLogo: siteLogo
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
-    });
-  });
-
-  asyncTest("get with arbitrary domain https: siteLogo - allowed", function() {    
-    createController({
-      ready: function() {
-        var startInfo;
-        mediator.subscribe("start", function(msg, info) {
-          startInfo = info;
-        });
-
-        var siteLogo = 'https://cdn.example.com/logo.png';
-        var retval = controller.get(HTTPS_TEST_DOMAIN, {
-          siteLogo: siteLogo
-        });
-        testHelpers.testObjectValuesEqual(startInfo, {
-          siteLogo: siteLogo
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
-    });
-  }); 
-
-  asyncTest("get with absolute path and http RP - not allowed", function() {
-    var siteLogo = '/i/card.png';
-    testExpectGetFailure({ siteLogo: siteLogo }, "siteLogos can only be served from https and data schemes.", HTTP_TEST_DOMAIN);
-  });
-
-  asyncTest("get with absolute path that is too long - not allowed", function() {
-    var siteLogo = '/' + testHelpers.generateString(bid.PATH_MAX_LENGTH);
-    testExpectGetFailure({ siteLogo: siteLogo }, "path portion of a url must be < " + bid.PATH_MAX_LENGTH + " characters");
-  });
-
-  asyncTest("get with absolute path causing too long of a URL - not allowed", function() {
-    var shortHTTPSDomain = "https://test.com";
-    // create a URL that is one character too long
-    var siteLogo = '/' + testHelpers.generateString(bid.URL_MAX_LENGTH - shortHTTPSDomain.length);
-    testExpectGetFailure({ siteLogo: siteLogo }, "urls must be < " + bid.URL_MAX_LENGTH + " characters");
-  });
-
-  asyncTest("get with absolute path and https RP - allowed URL but is properly escaped", function() {
-    createController({
-      ready: function() {
-        var startInfo;
-        mediator.subscribe("start", function(msg, info) {
-          startInfo = info;
-        });
-
-        var siteLogo = '/i/card.png" onerror="alert(\'xss\')" <script>alert(\'more xss\')</script>';
-        var retval = controller.get(HTTPS_TEST_DOMAIN, {
-          siteLogo: siteLogo
-        });
-
-        testHelpers.testObjectValuesEqual(startInfo, {
-          siteLogo: encodeURI(HTTPS_TEST_DOMAIN + siteLogo)
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
-    });
-  });
-
-  asyncTest("get with a scheme-relative siteLogo URL and https RP - allowed", function() {
-    var URL = "//example.com/image.png";
-    createController({
-      ready: function() {
-        var startInfo;
-        mediator.subscribe("start", function(msg, info) {
-          startInfo = info;
-        });
-
-        var siteLogo = HTTPS_TEST_DOMAIN + "/logo.png";
-        var retval = controller.get(HTTPS_TEST_DOMAIN, {
-          siteLogo: siteLogo
-        });
-
-        testHelpers.testObjectValuesEqual(startInfo, {
-          siteLogo: siteLogo
-        });
-        equal(typeof retval, "undefined", "no error expected");
-        testErrorNotVisible();
-        start();
-      }
-    });
-  });
-
-  // This sort of seems like a worthy test case
-  asyncTest("get with siteLogo='/' URL - not allowed", function() {
-    testExpectGetFailure({ siteLogo: "/" });
-  });
-
-  asyncTest("get with fully qualified returnTo - not allowed", function() {
-    var URL = HTTPS_TEST_DOMAIN + "/path";
-    testMustBeAbsolutePath({ returnTo: URL }, URL);
-  });
-
-  asyncTest("get with a scheme-relative returnTo URL - not allowed", function() {
-    var URL = '//example.com/return';
-    testMustBeAbsolutePath({ returnTo: URL }, URL);
-  });
-
-  asyncTest("get with absolute path returnTo - allowed", function() {
-    testExpectGetSuccess({ returnTo: "/path"}, {}, undefined, function() {
-      equal(user.getReturnTo(),
-        HTTPS_TEST_DOMAIN + "/path", "returnTo correctly set");
-    });
-  });
-
-  asyncTest("get with returnTo='/' - allowed", function() {
-    testExpectGetSuccess({ returnTo: "/"}, {}, undefined, function() {
-      equal(user.getReturnTo(),
-        HTTPS_TEST_DOMAIN + "/", "returnTo correctly set");
-    });
-  });
-
-  asyncTest("experimental_forceAuthentication", function() {
-    testExpectGetSuccess(
-      {experimental_forceAuthentication: true},
-      {forceAuthentication: true}
-    );
-  });
-
-  asyncTest("experimental_forceAuthentication invalid", function() {
-    testExpectGetFailure(
-      {experimental_forceAuthentication: "true"});
-  });
-
-  asyncTest("get with valid issuer - allowed", function() {
-    var issuer = "fxos.persona.org";
-    testExpectGetSuccess(
-      { experimental_forceIssuer: issuer },
-      { forceIssuer: issuer }
-    );
-  });
-
-  asyncTest("get with non hostname issuer - bzzzt", function() {
-    var issuer = "https://issuer.must.be.a.hostname";
-    testExpectGetFailure({ experimental_forceIssuer: issuer });
-  });
-
-  asyncTest("experimental_allowUnverified", function() {
-    testExpectGetSuccess(
-      {experimental_allowUnverified: true},
-      {allowUnverified: true}
-    );
-  });
-
-  asyncTest("experimental_allowUnverified invalid", function() {
-    testExpectGetFailure(
-      {experimental_allowUnverified: "true"});
-  });
-
-  asyncTest("get with valid rp_api - allowed", function() {
-    createController({
-      ready: function() {
-        mediator.subscribe("kpi_data", function(msg, info) {
-          equal(info.rp_api, "get");
-          equal(info.orphaned, true);
-          start();
-        });
-
-        controller.get(HTTPS_TEST_DOMAIN, {
-          rp_api: "get"
-        });
-      }
-    });
-  });
-
-  asyncTest("get with invalid rp_api - not allowed", function() {
-    testExpectGetFailure({
-      rp_api: "invalid_value"
-    }, "invalid value for rp_api: invalid_value");
-  });
-
-  asyncTest("get with invalid start_time - not allowed", function() {
-    testExpectGetFailure({
-      start_time: "invalid_value"
-    }, "invalid value for start_time: invalid_value");
-  });
-
-  asyncTest("get with numeric start_time, the numeric value of the specified date as the number of milliseconds since January 1, 1970, 00:00:00 UTC - allowed", function() {
+  asyncTest("get with start_time - publish start_time with start time", function() {
     var now = new Date().getTime();
 
-    createController({
-      ready: function() {
-        mediator.subscribe("start_time", function(msg, info) {
-          equal(info, now, "correct time passed");
-          start();
-        });
+    var receivedStartTime;
+    mediator.subscribe("start_time", function(msg, startTime) {
+      receivedStartTime = startTime;
+    });
 
-        controller.get(HTTPS_TEST_DOMAIN, {
-          start_time: now.toString()
-        });
-      }
+    testExpectGetSuccess({
+      start_time: now.toString()
+    },
+    {
+      startTime: now
+    }, HTTPS_TEST_DOMAIN, function() {
+      equal(receivedStartTime, now);
     });
   });
 
-  asyncTest("invalid backgroundColor - not allowed", function() {
-    testExpectGetFailure({
-      backgroundColor: "invalid_value"
-    }, "invalid backgroundColor: invalid_value");
-  });
-
-  asyncTest("incorrect length (2) backgroundColor - not allowed", function() {
-    testExpectGetFailure({
-      backgroundColor: "ab"
-    }, "invalid backgroundColor: ab");
-  });
-
-  asyncTest("incorrect length (4) backgroundColor - not allowed", function() {
-    testExpectGetFailure({
-      backgroundColor: "abcd"
-    }, "invalid backgroundColor: abcd");
-  });
-
-  asyncTest("incorrect length (5) backgroundColor - not allowed", function() {
-    testExpectGetFailure({
-      backgroundColor: "abcde"
-    }, "invalid backgroundColor: abcde");
-  });
-
-  asyncTest("incorrect length (7) backgroundColor - not allowed", function() {
-    testExpectGetFailure({
-      backgroundColor: "abcdeff"
-    }, "invalid backgroundColor: abcdeff");
-  });
-
-  asyncTest("valid 3 char backgroundColor - allowed & normalized", function() {
-    testExpectGetSuccess({backgroundColor: "abc"},
-                         {backgroundColor: "aabbcc"});
-  });
-
-  asyncTest("valid 3 char backgroundColor with hash - allowed & normalized",
-      function() {
-    testExpectGetSuccess({backgroundColor: "#123"},
-                         {backgroundColor: "112233"});
-  });
-
-  asyncTest("valid 6 char backgroundColor - allowed", function() {
-    testExpectGetSuccess({backgroundColor: "abcdef"},
-                         {backgroundColor: "abcdef"});
-  });
-
-  asyncTest("valid 6 char backgroundColor with hash - allowed", function() {
-    testExpectGetSuccess({backgroundColor: "#456DEF"},
-                         {backgroundColor: "456DEF"});
-  });
 
 }());
 

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -87,7 +87,7 @@
         }
 
         // If a parameter is not properly escaped, scriptRun will be true.
-        equal(typeof window.scriptRun, "undefined", "script was not run");
+        testHelpers.testUndefined(window.scriptRun);
 
         testErrorVisible();
         start();
@@ -115,7 +115,7 @@
         var retval = controller.get(domain || HTTPS_TEST_DOMAIN, options);
         testHelpers.testObjectValuesEqual(startInfo, expected);
 
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
 
         done && done();
@@ -323,7 +323,7 @@
           error = e;
         }
 
-        equal(typeof error, "undefined", "unexpected error thrown when unloading window (" + error + ")");
+        testHelpers.testUndefined(error);
         start();
       }
     });
@@ -459,7 +459,7 @@
         var retval = controller.get(HTTPS_TEST_DOMAIN, {
           siteLogo: siteLogo
         });
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
         start();
       }
@@ -483,7 +483,7 @@
         var retval = controller.get(HTTPS_TEST_DOMAIN, {
           siteLogo: siteLogo
         });
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
         start();
       }
@@ -505,7 +505,7 @@
         testHelpers.testObjectValuesEqual(startInfo, {
           siteLogo: siteLogo
         });
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
         start();
       }
@@ -545,7 +545,7 @@
         testHelpers.testObjectValuesEqual(startInfo, {
           siteLogo: encodeURI(HTTPS_TEST_DOMAIN + siteLogo)
         });
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
         start();
       }
@@ -569,7 +569,7 @@
         testHelpers.testObjectValuesEqual(startInfo, {
           siteLogo: siteLogo
         });
-        equal(typeof retval, "undefined", "no error expected");
+        testHelpers.testUndefined(retval);
         testErrorNotVisible();
         start();
       }

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -451,9 +451,23 @@
     testExpectGetFailure({siteLogo: URL});
   });
 
-  asyncTest("get with data-uri: siteLogo - not allowed", function() {
-    // XXX We want this to work (? modulo FAKEDATA ?)
-    var URL = "data:image/png,FAKEDATA";
+  asyncTest("get with data:image/<whitelist>;... siteLogo - allowed", function() {
+    var URL = "data:image/png;base64,FAKEDATA";
+    createController({
+      ready: function() {
+        var siteLogo = URL
+        var retval = controller.get(HTTPS_TEST_DOMAIN, {
+          siteLogo: siteLogo
+        });
+        equal(typeof retval, "undefined", "no error expected");
+        testErrorNotVisible();
+        start();
+      }
+    });
+  });
+
+  asyncTest("get with data:<not image>... siteLogo - not allowed", function() {
+    var URL = "data:text/html;base64,FAKEDATA";
     testExpectGetFailure({siteLogo: URL});
   });
 
@@ -500,7 +514,7 @@
 
   asyncTest("get with absolute path and http RP - not allowed", function() {
     var siteLogo = '/i/card.png';
-    testExpectGetFailure({ siteLogo: siteLogo }, "only https sites can specify a siteLogo", HTTP_TEST_DOMAIN);
+    testExpectGetFailure({ siteLogo: siteLogo }, "siteLogos can only be served from https and data schemes.", HTTP_TEST_DOMAIN);
   });
 
   asyncTest("get with absolute path that is too long - not allowed", function() {

--- a/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
@@ -1,0 +1,499 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  "use strict";
+  var controller,
+      bid = BrowserID,
+      testHelpers = bid.TestHelpers,
+      testErrorVisible = testHelpers.testErrorVisible,
+      testErrorNotVisible = testHelpers.testErrorNotVisible,
+      HTTP_TEST_DOMAIN = "http://testdomain.org",
+      HTTPS_TEST_DOMAIN = "https://testdomain.org",
+      TESTEMAIL = "testuser@testuser.com",
+      winMock;
+
+
+  function WinMock() {
+    this.location = {
+      hash: "#1234"
+    };
+
+    this.opener = {
+      frames: {
+        1234: {
+          BrowserID: {
+            Relay: {
+              registerClient: function() {
+              },
+
+              unregisterClient: function() {
+              }
+            }
+          }
+        }
+      }
+    };
+
+    this.navigator = {};
+  }
+
+
+  module("dialog/js/modules/validate_rp_params", {
+    setup: function() {
+      winMock = new WinMock();
+      testHelpers.setup();
+    },
+    teardown: function() {
+      if (controller) controller.destroy();
+      testHelpers.teardown();
+    }
+  });
+
+
+  function createController(config) {
+    // startExternalDependencies defaults to true, for most of our tests we
+    // want to turn this off to prevent the state machine, channel, and actions
+    // controller from starting up and throwing errors.  This allows us to test
+    // dialog as an individual unit.
+    var options = $.extend({
+      window: winMock
+    }, config);
+
+    controller = BrowserID.Modules.ValidateRpParams.create();
+    controller.start(options);
+  }
+
+  function testExpectValidationFailure(options, expectedErrorMessage, domain) {
+    _.extend(options, {
+      ready: function() {
+        options.origin_url = domain || HTTPS_TEST_DOMAIN;
+        try {
+          controller.validate(options);
+          ok(false);
+        } catch(error) {
+          if (expectedErrorMessage)
+            equal(error.message, expectedErrorMessage, "expected error: " + expectedErrorMessage);
+
+        }
+
+        // If a parameter is not properly escaped, scriptRun will be true.
+        equal(typeof window.scriptRun, "undefined", "script was not run");
+
+        start();
+      }
+    });
+    createController(options);
+  }
+
+  function testRelativeURLNotAllowed(options, path) {
+    testExpectValidationFailure(options, "relative urls not allowed: (" + path + ")");
+  }
+
+  function testMustBeAbsolutePath(options, path) {
+    testExpectValidationFailure(options, "must be an absolute path: (" + path + ")");
+  }
+
+  function testExpectValidationSuccess(options, expected, domain, done) {
+    createController({
+      ready: function() {
+        var startInfo;
+        options.origin_url = domain || HTTPS_TEST_DOMAIN;
+
+        try {
+          startInfo = controller.validate(options);
+        } catch(e) {
+          equal(false);
+        }
+
+        testHelpers.testObjectValuesEqual(startInfo, expected);
+
+        testErrorNotVisible();
+
+        done && done();
+
+        start();
+      }
+    });
+  }
+
+
+
+  asyncTest("get with relative termsOfService & valid privacyPolicy - print error screen", function() {
+    testRelativeURLNotAllowed({
+      termsOfService: "relative.html",
+      privacyPolicy: "/privacy.html"
+    }, "relative.html");
+  });
+
+  asyncTest("get with script containing termsOfService - print error screen", function() {
+    var URL = "relative.html<script>window.scriptRun=true;</script>";
+    testRelativeURLNotAllowed({
+      termsOfService: URL,
+      privacyPolicy: "/privacy.html"
+    }, URL);
+  });
+
+  asyncTest("get with valid termsOfService & relative privacyPolicy - print error screen", function() {
+    var URL = "relative.html";
+    testRelativeURLNotAllowed({
+      termsOfService: "/tos.html",
+      privacyPolicy: URL
+    }, URL);
+  });
+
+  asyncTest("get with valid termsOfService & privacyPolicy='/' - print error screen", function() {
+    var URL = "/";
+    testRelativeURLNotAllowed({
+      termsOfService: "/tos.html",
+      privacyPolicy: URL
+    }, URL);
+  });
+
+  asyncTest("get with valid termsOfService='/' and valid privacyPolicy - print error screen", function() {
+    var URL = "/";
+    testRelativeURLNotAllowed({
+      termsOfService: URL,
+      privacyPolicy: "/privacy.html"
+    }, URL);
+  });
+
+  asyncTest("get with script containing privacyPolicy - print error screen", function() {
+    var URL = "relative.html<script>window.scriptRun=true;</script>";
+    testRelativeURLNotAllowed({
+      termsOfService: "/tos.html",
+      privacyPolicy: URL
+    }, URL);
+  });
+
+  asyncTest("get with javascript protocol for privacyPolicy - print error screen", function() {
+    var URL = "javascript:alert(1)";
+    testRelativeURLNotAllowed({
+      termsOfService: "/tos.html",
+      privacyPolicy: URL
+    }, URL);
+  });
+
+  asyncTest("get with invalid httpg protocol for privacyPolicy - print error screen", function() {
+    var URL = "httpg://testdomain.com/privacy.html";
+    testRelativeURLNotAllowed({
+      termsOfService: "/tos.html",
+      privacyPolicy: URL
+    }, URL);
+  });
+
+
+  asyncTest("get with valid absolute termsOfService & privacyPolicy - go to start", function() {
+    testExpectValidationSuccess({
+      termsOfService: "/tos.html",
+      privacyPolicy: "/privacy.html"
+    },
+    {
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    });
+  });
+
+  asyncTest("get with valid fully qualified http termsOfService & privacyPolicy - go to start", function() {
+    testExpectValidationSuccess({
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+    },
+    {
+      termsOfService: HTTP_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTP_TEST_DOMAIN + "/privacy.html"
+    });
+  });
+
+
+  asyncTest("get with valid fully qualified https termsOfService & privacyPolicy - go to start", function() {
+    testExpectValidationSuccess({
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    },
+    {
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    });
+  });
+
+  asyncTest("get with valid termsOfService, tosURL & privacyPolicy, privacyURL - use termsOfService and privacyPolicy", function() {
+    testExpectValidationSuccess({
+      termsOfService: "/tos.html",
+      tosURL: "/tos_deprecated.html",
+      privacyPolicy: "/privacy.html",
+      privacyURL: "/privacy_deprecated.html"
+    },
+    {
+      termsOfService: HTTPS_TEST_DOMAIN + "/tos.html",
+      privacyPolicy: HTTPS_TEST_DOMAIN + "/privacy.html"
+    });
+  });
+
+  asyncTest("get with relative siteLogo - not allowed", function() {
+    var URL = "logo.png";
+    testExpectValidationFailure({siteLogo: URL});
+  });
+
+  asyncTest("get with javascript: siteLogo - not allowed", function() {
+    var URL = "javascript:alert('xss')";
+    testExpectValidationFailure({siteLogo: URL});
+  });
+
+  asyncTest("get with data:image/<whitelist>;... siteLogo - allowed", function() {
+    var URL = "data:image/png;base64,FAKEDATA";
+    createController({
+      ready: function() {
+        testExpectValidationSuccess({
+          siteLogo: URL
+        },
+        {
+          siteLogo: URL
+        });
+      }
+    });
+  });
+
+  asyncTest("get with data:<not image>... siteLogo - not allowed", function() {
+    var URL = "data:text/html;base64,FAKEDATA";
+    testExpectValidationFailure({siteLogo: URL});
+  });
+
+  asyncTest("get with http: siteLogo - not allowed", function() {
+    var URL = HTTP_TEST_DOMAIN + "/logo.png";
+    testExpectValidationFailure({siteLogo: URL});
+  });
+
+  asyncTest("get with local https: siteLogo - allowed", function() {
+    createController({
+      ready: function() {
+        var siteLogo = HTTPS_TEST_DOMAIN + "/logo.png";
+        testExpectValidationSuccess({
+          siteLogo: siteLogo
+        },
+        {
+          siteLogo: siteLogo
+        });
+      }
+    });
+  });
+
+  asyncTest("get with arbitrary domain https: siteLogo - allowed", function() {
+    createController({
+      ready: function() {
+        var siteLogo = 'https://cdn.example.com/logo.png';
+        testExpectValidationSuccess({
+          siteLogo: siteLogo
+        },
+        {
+          siteLogo: siteLogo
+        });
+      }
+    });
+  });
+
+  asyncTest("get with absolute path and http RP - not allowed", function() {
+    var siteLogo = '/i/card.png';
+    testExpectValidationFailure({ siteLogo: siteLogo }, "siteLogos can only be served from https and data schemes.", HTTP_TEST_DOMAIN);
+  });
+
+  asyncTest("get with absolute path that is too long - not allowed", function() {
+    var siteLogo = '/' + testHelpers.generateString(bid.PATH_MAX_LENGTH);
+    testExpectValidationFailure({ siteLogo: siteLogo }, "path portion of a url must be < " + bid.PATH_MAX_LENGTH + " characters");
+  });
+
+  asyncTest("get with absolute path causing too long of a URL - not allowed", function() {
+    var shortHTTPSDomain = "https://test.com";
+    // create a URL that is one character too long
+    var siteLogo = '/' + testHelpers.generateString(bid.URL_MAX_LENGTH - shortHTTPSDomain.length);
+    testExpectValidationFailure({ siteLogo: siteLogo }, "urls must be < " + bid.URL_MAX_LENGTH + " characters");
+  });
+
+  asyncTest("get with absolute path and https RP - allowed URL but is properly escaped", function() {
+    createController({
+      ready: function() {
+        var siteLogo = '/i/card.png" onerror="alert(\'xss\')" <script>alert(\'more xss\')</script>';
+        testExpectValidationSuccess({
+          siteLogo: siteLogo
+        },
+        {
+          siteLogo: encodeURI(HTTPS_TEST_DOMAIN + siteLogo)
+        });
+      }
+    });
+  });
+
+  asyncTest("get with a scheme-relative siteLogo URL and https RP - allowed", function() {
+    var URL = "//example.com/image.png";
+    createController({
+      ready: function() {
+        testExpectValidationSuccess({
+          siteLogo: URL
+        },
+        {
+          siteLogo: "https://example.com/image.png"
+        });
+      }
+    });
+  });
+
+  // This sort of seems like a worthy test case
+  asyncTest("get with siteLogo='/' URL - not allowed", function() {
+    testExpectValidationFailure({ siteLogo: "/" });
+  });
+
+  asyncTest("get with fully qualified returnTo - not allowed", function() {
+    var URL = HTTPS_TEST_DOMAIN + "/path";
+    testMustBeAbsolutePath({ returnTo: URL }, URL);
+  });
+
+  asyncTest("get with a scheme-relative returnTo URL - not allowed", function() {
+    var URL = '//example.com/return';
+    testMustBeAbsolutePath({ returnTo: URL }, URL);
+  });
+
+  asyncTest("get with absolute path returnTo - allowed", function() {
+    testExpectValidationSuccess({
+      returnTo: "/path"
+    }, {
+      returnTo: HTTPS_TEST_DOMAIN + "/path"
+    });
+  });
+
+  asyncTest("get with returnTo='/' - allowed", function() {
+    testExpectValidationSuccess({
+      returnTo: "/"
+    }, {
+      returnTo: HTTPS_TEST_DOMAIN + "/"
+    });
+  });
+
+  asyncTest("experimental_forceAuthentication", function() {
+    testExpectValidationSuccess(
+      {experimental_forceAuthentication: true},
+      {forceAuthentication: true}
+    );
+  });
+
+  asyncTest("experimental_forceAuthentication invalid", function() {
+    testExpectValidationFailure(
+      {experimental_forceAuthentication: "true"});
+  });
+
+  asyncTest("get with valid issuer - allowed", function() {
+    var issuer = "fxos.persona.org";
+    testExpectValidationSuccess(
+      { experimental_forceIssuer: issuer },
+      { forceIssuer: issuer }
+    );
+  });
+
+  asyncTest("get with non hostname issuer - bzzzt", function() {
+    var issuer = "https://issuer.must.be.a.hostname";
+    testExpectValidationFailure({ experimental_forceIssuer: issuer });
+  });
+
+  asyncTest("experimental_allowUnverified", function() {
+    testExpectValidationSuccess(
+      {experimental_allowUnverified: true},
+      {allowUnverified: true}
+    );
+  });
+
+  asyncTest("experimental_allowUnverified invalid", function() {
+    testExpectValidationFailure(
+      {experimental_allowUnverified: "true"});
+  });
+
+  asyncTest("get with valid rp_api - allowed", function() {
+    createController({
+      ready: function() {
+        testExpectValidationSuccess({
+          rp_api: "get"
+        }, {
+          rpAPI: "get"
+        });
+      }
+    });
+  });
+
+  asyncTest("get with invalid rp_api - not allowed", function() {
+    testExpectValidationFailure({
+      rp_api: "invalid_value"
+    }, "invalid value for rp_api: invalid_value");
+  });
+
+  asyncTest("get with invalid start_time - not allowed", function() {
+    testExpectValidationFailure({
+      start_time: "invalid_value"
+    }, "invalid value for start_time: invalid_value");
+  });
+
+  asyncTest("get with numeric start_time, the numeric value of the specified date as the number of milliseconds since January 1, 1970, 00:00:00 UTC - allowed", function() {
+    var now = new Date().getTime();
+
+    createController({
+      ready: function() {
+        testExpectValidationSuccess({
+          start_time: now.toString()
+        }, {
+          startTime: now
+        });
+      }
+    });
+  });
+
+  asyncTest("invalid backgroundColor - not allowed", function() {
+    testExpectValidationFailure({
+      backgroundColor: "invalid_value"
+    }, "invalid backgroundColor: invalid_value");
+  });
+
+  asyncTest("incorrect length (2) backgroundColor - not allowed", function() {
+    testExpectValidationFailure({
+      backgroundColor: "ab"
+    }, "invalid backgroundColor: ab");
+  });
+
+  asyncTest("incorrect length (4) backgroundColor - not allowed", function() {
+    testExpectValidationFailure({
+      backgroundColor: "abcd"
+    }, "invalid backgroundColor: abcd");
+  });
+
+  asyncTest("incorrect length (5) backgroundColor - not allowed", function() {
+    testExpectValidationFailure({
+      backgroundColor: "abcde"
+    }, "invalid backgroundColor: abcde");
+  });
+
+  asyncTest("incorrect length (7) backgroundColor - not allowed", function() {
+    testExpectValidationFailure({
+      backgroundColor: "abcdeff"
+    }, "invalid backgroundColor: abcdeff");
+  });
+
+  asyncTest("valid 3 char backgroundColor - allowed & normalized", function() {
+    testExpectValidationSuccess({backgroundColor: "abc"},
+                         {backgroundColor: "aabbcc"});
+  });
+
+  asyncTest("valid 3 char backgroundColor with hash - allowed & normalized",
+      function() {
+    testExpectValidationSuccess({backgroundColor: "#123"},
+                         {backgroundColor: "112233"});
+  });
+
+  asyncTest("valid 6 char backgroundColor - allowed", function() {
+    testExpectValidationSuccess({backgroundColor: "abcdef"},
+                         {backgroundColor: "abcdef"});
+  });
+
+  asyncTest("valid 6 char backgroundColor with hash - allowed", function() {
+    testExpectValidationSuccess({backgroundColor: "#456DEF"},
+                         {backgroundColor: "456DEF"});
+  });
+
+
+}());
+

--- a/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
@@ -67,7 +67,7 @@
   function testExpectValidationFailure(options, expectedErrorMessage, domain) {
     _.extend(options, {
       ready: function() {
-        options.origin_url = domain || HTTPS_TEST_DOMAIN;
+        options.originURL = domain || HTTPS_TEST_DOMAIN;
         try {
           controller.validate(options);
           ok(false);
@@ -98,7 +98,7 @@
     createController({
       ready: function() {
         var startInfo;
-        options.origin_url = domain || HTTPS_TEST_DOMAIN;
+        options.originURL = domain || HTTPS_TEST_DOMAIN;
 
         try {
           startInfo = controller.validate(options);

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -185,6 +185,7 @@
     <script src="/dialog/js/modules/set_password.js"></script>
     <script src="/dialog/js/modules/rp_info.js"></script>
     <script src="/dialog/js/modules/inline_tospp.js"></script>
+    <script src="/dialog/js/modules/validate_rp_params.js"></script>
 
     <script src="/pages/js/page_helpers.js"></script>
     <script src="/pages/js/verify_secondary_address.js"></script>

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -253,6 +253,7 @@
     <script src="cases/dialog/js/modules/set_password.js"></script>
     <script src="cases/dialog/js/modules/rp_info.js"></script>
     <script src="cases/dialog/js/modules/inline_tospp.js"></script>
+    <script src="cases/dialog/js/modules/validate_rp_params.js"></script>
 
     <!-- must go last or all other tests will fail. -->
     <script src="cases/dialog/js/modules/dialog.js"></script>


### PR DESCRIPTION
This delta:
- continues to insist on the https scheme (explicitly or via scheme-relative or domain-absolute URIs)
- continues to forbid relative URIs
- allows specification of any domain

callahad says next step is to think carefully about security corner cases. Along those lines:
- we are relying on the browser to correctly sandbox the response as an image
- what information could leak to an arbitrary domain that doesn't leak from the authorization requests to the IdP's domain?
