### PR TITLE
Change {win7,linux}_firefox to release version 22

### DIFF
--- a/automation-tests/config/sauce-platforms.js
+++ b/automation-tests/config/sauce-platforms.js
@@ -4,15 +4,15 @@
 //
 const platforms = {
   // Firefox
-  "win7_firefox_21": {
-    platform:'Windows 2008',
-    browserName:'firefox',
-    version:'21'
+  "win7_firefox_22": {
+    platform: 'Windows 7',
+    browserName: 'firefox',
+    version: '22'
   },
-  "linux_firefox_21": {
+  "linux_firefox_22": {
     platform: 'Linux',
     browserName: 'firefox',
-    version: '21'
+    version: '22'
   },
   "osx_firefox_21": {
     platform: 'Mac 10.6',
@@ -77,4 +77,4 @@ const defaultCapabilities = {
 
 exports.platforms = platforms;
 exports.defaultCapabilities = defaultCapabilities;
-exports.defaultPlatform = "win7_firefox_21";
+exports.defaultPlatform = "win7_firefox_22";


### PR DESCRIPTION
This changes the firefox version to the current release
(22). Unfortunately, sauce does not provide osx/22, so did not update
that. It also changes s/Windows 2008/Window 7/; the documented versions
have changed (again), but the name change is moot since you will get the
same VM by either name.

With this change, I don't have different failure rates with running the
tests.
