### PR TITLE
support csv list for --platform, and update readme with current output of --help

### DIFF
--- a/automation-tests/README.md
+++ b/automation-tests/README.md
@@ -111,12 +111,13 @@ Sauce.
       --lp, --list-platforms  list available platforms to test on                           
       --env, -e               target environment: dev/stage/prod or the name of an ephemeral
       --local, -l             run tests locally (instead of on saucelabs)                   
-      --parallel, -p          the number of tests to run at the same time                   
-      --platform              the browser/os to test (globs supported)                      
+      --parallel, -p          the number of tests to run at the same time                     [default: "10"]
+      --platform              the browser/os to test (globs and csv supported)              
       --iterations, -i        the number of times to repeat specified tests                   [default: "1"]
       --list-tests, --lt      list available tests                                          
       --tests, -t             which test(s) to run (globs supported)                          [default: "*"]
       --output, -o            desired ouput format.  one of console, json, xunit              [default: "console"]
+      --ignore-tests, --it    test(s) to ignore (csv supported)                             
 
 ## Running tests: Disabling tests
 

--- a/automation-tests/scripts/run-all.js
+++ b/automation-tests/scripts/run-all.js
@@ -39,7 +39,7 @@ var argv = require('optimist')
   .check(function(a) {
     if (!a.parallel) a.parallel = parseInt(process.env.RUNNERS, 10) || 10;
   })
-  .describe('platform', 'the browser/os to test (globs supported)')
+  .describe('platform', 'the browser/os to test (globs and csv supported)')
   .alias('iterations', 'i')
   .describe('iterations', 'the number of times to repeat specified tests')
   .default("iterations", "1")
@@ -145,9 +145,17 @@ function startTesting() {
   function getTestedPlatforms(platform_glob) {
     var platforms = {};
 
-    Object.keys(supported_platforms).forEach(function(p) {
-      if (glob(p, platform_glob)) platforms[p] = supported_platforms[p];
-    });
+    // see if it's CSV (but don't match a glob brace expansion)
+    if (platform_glob.indexOf(',') > 0 && platform_glob.indexOf('{') !== 0) {
+      var platformList = platform_glob.split(',');
+      Object.keys(supported_platforms).forEach(function(p) {
+        if (platformList.indexOf(p) !== -1) platforms[p] = supported_platforms[p];
+      });
+    } else {
+      Object.keys(supported_platforms).forEach(function(p) {
+        if (glob(p, platform_glob)) platforms[p] = supported_platforms[p];
+      });
+    }
 
     return platforms;
   }


### PR DESCRIPTION
A convenience. A quoted glob like "--platform `'{linux_foo,win7_bar}'`" would (and still) works, but who wants to type that?
