### PR TITLE
Clean up jshint warnings in ./automation-tests

### DIFF
--- a/automation-tests/lib/asserts.js
+++ b/automation-tests/lib/asserts.js
@@ -1,10 +1,10 @@
 // desc is optional textual description of the error
 exports.ok = function(fact, desc) { 
-  var defaultMsg = "assertion failed: '" + fact + "' is not truthy" 
+  var defaultMsg = "assertion failed: '" + fact + "' is not truthy";
   if (!fact) return desc || defaultMsg;
-}
+};
 exports.equal = function(lhs, rhs, desc) { 
   var defaultMsg = "assertion failed: actual '" + lhs 
                  + "' does not equal expected '" + rhs + "'";
   if (lhs != rhs) return desc || defaultMsg;
-}
+};

--- a/automation-tests/lib/asserts.js
+++ b/automation-tests/lib/asserts.js
@@ -6,5 +6,5 @@ exports.ok = function(fact, desc) {
 exports.equal = function(lhs, rhs, desc) { 
   var defaultMsg = "assertion failed: actual '" + lhs 
                  + "' does not equal expected '" + rhs + "'";
-  if (lhs != rhs) return desc || defaultMsg;
+  if (lhs !== rhs) return desc || defaultMsg;
 };

--- a/automation-tests/lib/personatestuser.js
+++ b/automation-tests/lib/personatestuser.js
@@ -1,3 +1,5 @@
+/*jshint sub: true */
+
 const utils = require("./utils.js"),
 urls = require('./urls.js'),
 request = require('request');

--- a/automation-tests/lib/personatestuser.js
+++ b/automation-tests/lib/personatestuser.js
@@ -18,7 +18,6 @@ exports.getVerifiedUser = function(args, cb) {
     args = {};
   }
   var timeout = args.timeout || DEFAULT_TIMEOUT;
-  var env = args.env || process.env['PERSONA_ENV'] || 'dev';
   var url = urls.personatestuser;
 
   request({ url: url, timeout: timeout, json:true}, function (error, response, body) {

--- a/automation-tests/lib/personatestuser.js
+++ b/automation-tests/lib/personatestuser.js
@@ -13,7 +13,7 @@ const DEFAULT_TIMEOUT = 40000;
 // args include .timeout (optional), .env (optional)
 // callback is cb(error, {email, password}, fullResponse)
 exports.getVerifiedUser = function(args, cb) {
-  if (arguments.length == 1) {
+  if (arguments.length === 1) {
     cb = args;
     args = {};
   }
@@ -22,7 +22,7 @@ exports.getVerifiedUser = function(args, cb) {
   var url = urls.personatestuser;
 
   request({ url: url, timeout: timeout, json:true}, function (error, response, body) {
-    if (!error && response.statusCode == 200) {
+    if (!error && response.statusCode === 200) {
       if (!body.email) { return cb(new Error('funky getVerifiedUser response')); }
       cb(error, {email: body.email, pass: body.pass}, body);
     } else {

--- a/automation-tests/lib/personatestuser.js
+++ b/automation-tests/lib/personatestuser.js
@@ -23,7 +23,7 @@ exports.getVerifiedUser = function(args, cb) {
 
   request({ url: url, timeout: timeout, json:true}, function (error, response, body) {
     if (!error && response.statusCode == 200) {
-      if (!body.email) { return cb(new Error('funky getVerifiedUser response')) }
+      if (!body.email) { return cb(new Error('funky getVerifiedUser response')); }
       cb(error, {email: body.email, pass: body.pass}, body);
     } else {
       cb(error || response.body);

--- a/automation-tests/lib/restmail.js
+++ b/automation-tests/lib/restmail.js
@@ -49,6 +49,6 @@ exports.getVerificationLink = function(args, cb) {
       } else {
         doneCB(false);
       }
-    })
+    });
   }, cb);
 };

--- a/automation-tests/lib/restmail.js
+++ b/automation-tests/lib/restmail.js
@@ -38,7 +38,7 @@ exports.getVerificationLink = function(args, cb) {
 
   utils.waitFor(poll, timeout, function(doneCB) {
     request(url, function (error, response, body) {
-      if (!error && response.statusCode == 200) {
+      if (!error && response.statusCode === 200) {
         var b = JSON.parse(body);
         var message = b[index];
         if (message && message.headers['x-browserid-verificationurl']) {

--- a/automation-tests/lib/results-aggregator.js
+++ b/automation-tests/lib/results-aggregator.js
@@ -165,7 +165,7 @@ ResultsAggregator.prototype.results = function() {
     errorDetails: this.failures,
     urls: this.urls
   };
-}
+};
 
 module.exports = ResultsAggregator;
 

--- a/automation-tests/lib/runner.js
+++ b/automation-tests/lib/runner.js
@@ -15,7 +15,7 @@ function register(suites) {
 function run(mod, suites, opts) {
   if (suites) register(suites);
 
-  rawSuites.forEach(function(suite, i) {
+  rawSuites.forEach(function(suite) {
     for (var vow in suite) {
       globalCount++;
       // vows with duplicate names cause great sadness; use a counter to ensure

--- a/automation-tests/lib/runner.js
+++ b/automation-tests/lib/runner.js
@@ -6,8 +6,8 @@ var alltests = {},
 
 // register just pushes suites onto a master list
 function register(suites) {
-  if (!suites.length) { suites = [suites] }
-  rawSuites = rawSuites.concat(suites)
+  if (!suites.length) suites = [suites];
+  rawSuites = rawSuites.concat(suites);
 }
 
 // run runs previously-registered suites. for convenience,

--- a/automation-tests/lib/test-finder.js
+++ b/automation-tests/lib/test-finder.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/*jshint sub: true */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -1,3 +1,5 @@
+/*jshint sub: true */
+
 const
 personatestuser = require('../lib/personatestuser.js'),
 Q = require('q'),

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -170,7 +170,7 @@ function setSessionOpts(opts) {
 
   // check for typos: throw error if requestedPlatform not found in list of supported sauce platforms
   var requestedPlatform = opts.platform || process.env['PERSONA_BROWSER'];
-  if (requestedPlatform && requestedPlatform != 'any' && !configPlatforms.platforms[requestedPlatform]) {
+  if (requestedPlatform && requestedPlatform !== 'any' && !configPlatforms.platforms[requestedPlatform]) {
     throw new Error('requested platform ' + requestedPlatform +
                     ' not found in list of available platforms');
   }

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -90,6 +90,7 @@ testSetup.browsers = [];
 //   secondUser = fixtures.personatestusers[1];
 // }
 testSetup.setup = function(opts, cb) {
+  /*jshint loopfunc: true */
   var fixtures = {},
     restmails = opts.restmails || opts.r,
     eyedeemails = opts.eyedeemails || opts.e,

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -68,10 +68,10 @@ testSetup.startup = function(opts) {
 
   var id = testSetup.browsers.push(browser);
   return id - 1;
-}
+};
 
 // store multiple browsers until we can switch between sessions via d
-testSetup.browsers = []
+testSetup.browsers = [];
 
 // opts could be of the form:
 // { browsers: 2, restmails: 1, eyedeemails: 1, personatestusers: 2
@@ -127,8 +127,8 @@ testSetup.setup = function(opts, cb) {
     // then the final promise will be resolved.
     for (var i = 0; i < personatestusers; i++) {
       var userPromise = Q.ncall(personatestuser.getVerifiedUser)
-        .then(function(user) { fixtures.personatestusers.push(user[0]) })
-        .fail(function(error) { return cb(error) });
+        .then(function(user) { fixtures.personatestusers.push(user[0]); })
+        .fail(function(error) { return cb(error); });
       promises.push(userPromise);
     }
   }
@@ -137,14 +137,14 @@ testSetup.setup = function(opts, cb) {
     Q.all(promises)
       .then(function() {
         fixtures = setupBrowsers(browsers, fixtures);
-        cb(null, fixtures)
+        cb(null, fixtures);
       })
-      .fail(function(error) { cb(error) });
+      .fail(function(error) { cb(error); });
   } else {
     fixtures = setupBrowsers(browsers, fixtures);
-    cb(null, fixtures)
+    cb(null, fixtures);
   }
-}
+};
 
 testSetup.newBrowserSession = function(b, cb) {
   b.newSession(testSetup.sessionOpts, cb);
@@ -156,7 +156,7 @@ testSetup.teardown = function(cb) {
   for (var i = 0, b; b = testSetup.browsers[i]; i++) enders.push(Q.ncall(b.quit, b));
   Q.all(enders)
     .fin(cb);
-}
+};
 
 
 /* private functions */
@@ -208,7 +208,7 @@ function setSessionOpts(opts) {
 }
 
 function setupBrowsers(browserCount, out) {
-  for (var i = 0; i < browserCount; i++) { testSetup.startup() }
+  for (var i = 0; i < browserCount; i++) { testSetup.startup(); }
   // just use the browsers array directly
   out.b = out.browsers = testSetup.browsers;
   return out;

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -23,7 +23,7 @@ var configPlatforms = process.env['PERSONA_NO_SAUCE'] ? localPlatforms : saucePl
 // this way, any code which wants to programatically interact with the
 // (internal) browserid HTTP API via libraries under tests/lib will be able
 // to do so.
-wsapi = require('../../tests/lib/wsapi.js'),
+var wsapi = require('../../tests/lib/wsapi.js');
 wsapi.configuration.browserid = persona_urls.persona;
 
 /* public API */

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -114,12 +114,12 @@ testSetup.setup = function(opts, cb) {
   if (testidps) {
     fixtures.t = fixtures.testidps = [];
     for (idx = 0; idx < testidps; idx++) {
-      var userPromise = Q.ncall(testidp.qCreateIdP)
+      var testIdpPromise = Q.ncall(testidp.qCreateIdP)
       .then(function (qRes) {
         fixtures.testidps.push(qRes);
       })
       .fail(function (error) {return cb(error);});
-      promises.push(userPromise);
+      promises.push(testIdpPromise);
     }
   }
   if (personatestusers) {

--- a/automation-tests/lib/test-setup.js
+++ b/automation-tests/lib/test-setup.js
@@ -96,23 +96,24 @@ testSetup.setup = function(opts, cb) {
     testidps = opts.testidps || opts.t,
     personatestusers = opts.personatestusers || opts.p,
     browsers = opts.browsers || opts.b,
-    promises = [];
+    promises = [],
+    idx = 0;
 
   if (restmails) {
     fixtures.r = fixtures.restmails = [];
-    for (var i = 0; i < restmails; i++) {
+    for (idx = 0; idx < restmails; idx++) {
       fixtures.restmails.push(restmail.randomEmail(10));
     }
   }
   if (eyedeemails) {
     fixtures.e = fixtures.eyedeemails = [];
-    for (var i = 0; i < eyedeemails; i++) {
+    for (idx = 0; idx < eyedeemails; idx++) {
       fixtures.eyedeemails.push(restmail.randomEmail(10, 'eyedee.me'));
     }
   }
   if (testidps) {
     fixtures.t = fixtures.testidps = [];
-    for (var i=0; i < testidps; i++) {
+    for (idx = 0; idx < testidps; idx++) {
       var userPromise = Q.ncall(testidp.qCreateIdP)
       .then(function (qRes) {
         fixtures.testidps.push(qRes);
@@ -125,7 +126,7 @@ testSetup.setup = function(opts, cb) {
     fixtures.p = fixtures.personatestusers = [];
     // after personatestuser returns, and pushes result onto list of users,
     // then the final promise will be resolved.
-    for (var i = 0; i < personatestusers; i++) {
+    for (idx = 0; idx < personatestusers; idx++) {
       var userPromise = Q.ncall(personatestuser.getVerifiedUser)
         .then(function(user) { fixtures.personatestusers.push(user[0]); })
         .fail(function(error) { return cb(error); });

--- a/automation-tests/lib/testidp.js
+++ b/automation-tests/lib/testidp.js
@@ -1,9 +1,9 @@
 /*jshint sub: true */
 
-var _ = require('underscore'),
-    request = require('request'),
-    restmail = require('./restmail.js'),
-    URLS = require('./urls');
+const
+request = require('request'),
+restmail = require('./restmail.js'),
+URLS = require('./urls');
 
 const TESTIDP_API = 'https://testidp.org/api/';
 

--- a/automation-tests/lib/testidp.js
+++ b/automation-tests/lib/testidp.js
@@ -1,3 +1,5 @@
+/*jshint sub: true */
+
 var _ = require('underscore'),
     request = require('request'),
     restmail = require('./restmail.js'),

--- a/automation-tests/lib/urls.js
+++ b/automation-tests/lib/urls.js
@@ -1,3 +1,5 @@
+/*jshint sub: true */
+
 // Depending on the environment variable PERSONA_ENV, we will change the
 // URLS for various sites used during testing.  This lets you target
 // different environments

--- a/automation-tests/lib/user.js
+++ b/automation-tests/lib/user.js
@@ -28,7 +28,7 @@ exports.verifyEmail = function(email, password, index, browser, done) {
 
     });
   });
-}
+};
 
 // The hope is to make this abstraction interchangable with the personatestuser
 // equivalent. Not there yet.

--- a/automation-tests/lib/wd-extensions.js
+++ b/automation-tests/lib/wd-extensions.js
@@ -158,7 +158,7 @@ wd.prototype.wwin = function(opts, cb) {
   // special case where just the callback was passed: go to the zeroth window
   if (arguments.length === 1 && typeof arguments[0] === 'function') {
     cb = arguments[0];
-    self.windowHandles(function(err, handles) {
+    self.windowHandles(function(err) {
       if (err) return cb(err);
       self.window(self._parentWindow, cb); // fire cb whether err is defined or not
     });

--- a/automation-tests/pages/123done.js
+++ b/automation-tests/pages/123done.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 assert = require('../lib/asserts.js'),
 restmail = require('../lib/restmail.js'),

--- a/automation-tests/pages/dialog.js
+++ b/automation-tests/pages/dialog.js
@@ -1,3 +1,5 @@
+/*jshint sub: true */
+
 const CSS = require('./css.js'),
     utils = require('../lib/utils.js')
 

--- a/automation-tests/pages/dialog.js
+++ b/automation-tests/pages/dialog.js
@@ -1,7 +1,7 @@
 /*jshint sub: true */
 
 const CSS = require('./css.js'),
-    utils = require('../lib/utils.js')
+    utils = require('../lib/utils.js');
 
 function verifyOpts(optionList, opts) {
   optionList.forEach(function(required) {

--- a/automation-tests/scripts/post-update.js
+++ b/automation-tests/scripts/post-update.js
@@ -24,9 +24,10 @@ function installDependencies(done) {
 }
 
 function getJSONConfig(name) {
+  var config;
   try {
     var configPath = path.join(__dirname, "..", "..", "..", name);
-    var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   } catch(e) {
     console.error("cannot read " + name + " or json is invalid");
     process.exit(1);

--- a/automation-tests/scripts/run-all.js
+++ b/automation-tests/scripts/run-all.js
@@ -162,7 +162,7 @@ function startTesting() {
 
   function getTheTests(platforms) {
     var testSet = test_finder.find(args.tests, '', '', args['ignore-tests']);
-    allTests = [];
+    var allTests = [];
 
     // make a copy of the test set for each platform, set the platform of each
     // test, and append the platform specific test set to overall list of
@@ -176,7 +176,7 @@ function startTesting() {
     }
     // handle multiple iterations
     var allTestsCopy = toolbelt.deepCopy(allTests);
-    for (var i = 1; i < parseInt(args.iterations); i++) {
+    for (var i = 1; i < parseInt(args.iterations, 10); i++) {
       allTests = allTests.concat(allTestsCopy);
     }
     return allTests;
@@ -232,7 +232,7 @@ function startTesting() {
     });
 
     testProcess.on('exit', function(code) {
-      var err = (code != 0 ? " (failed with exit code " + code + ")": null);
+      var err = (code !== 0 ? " (failed with exit code " + code + ")": null);
       done && done(err);
     });
   }
@@ -317,8 +317,8 @@ function startTesting() {
 
         // now if this is the console, let's output marks as tests start and complete
         if (args.output === 'console') {
-          aggregator.on('pass', function() { process.stdout.write(".") });
-          aggregator.on('fail', function() { process.stdout.write("!") });
+          aggregator.on('pass', function() { process.stdout.write("."); });
+          aggregator.on('fail', function() { process.stdout.write("!"); });
         }
       }
       return aggregator;
@@ -360,8 +360,8 @@ function startTesting() {
       successes += r.passed;
     });
     console.log("%s/%s tests passed%s", successes, total,
-                (successes != total) ? ", here are your failures:" : "");
-    if (successes != total) {
+                (successes !== total) ? ", here are your failures:" : "");
+    if (successes !== total) {
       aggregators.forEach(function(rp) {
         var r = rp.results();
         if (r.failed || r.unhandledMessages.length) {

--- a/automation-tests/tests/add-primary-to-primary.js
+++ b/automation-tests/tests/add-primary-to-primary.js
@@ -70,7 +70,7 @@ runner.run(module, {
       .wclickIfExists(CSS['dialog'].notMyComputerButton)
       .wwin()
       .wtext(CSS['123done.org'].currentlyLoggedInEmail, function(err, text) {
-        done(err || assert.equal(text, secondPrimaryEmail))
+        done(err || assert.equal(text, secondPrimaryEmail));
       });
   },
   //XXX This could be much more comprehensive by bringing up the dialog

--- a/automation-tests/tests/add-primary-to-primary.js
+++ b/automation-tests/tests/add-primary-to-primary.js
@@ -81,5 +81,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/add-primary-to-secondary.js
+++ b/automation-tests/tests/add-primary-to-secondary.js
@@ -88,5 +88,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -181,5 +181,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -35,44 +35,9 @@ function setup(done) {
   });
 }
 
-function getEmailIndex(email) {
-  emails = emails.sort(function(a, b) { return a === b ? 0 : a > b ? 1 : -1; });
-  var index = emails.indexOf(email);
-  return index;
-}
-
 function saveEmail(email) {
   emails.push(email);
   return email;
-}
-
-function removeEmail(email, done) {
-  browser.chain({onError: done})
-    .get(persona_urls['persona'])
-    .wclick(CSS['persona.org'].emailListEditButton)
-    .elementsByCssSelector(CSS['persona.org'].removeEmailButton, function(err, elements) {
-      var index = getEmailIndex(email);
-      var button = elements[index];
-
-      browser.chain({onError: done})
-        .clickElement(button)
-        // Give Chrome a bit to display the alert or else the command to
-        // accept the alert is fired too early.
-        .delay(500)
-        .acceptAlert(function() {
-          emails.splice(index, 1);
-
-          if (emails.length) {
-            // if there are emails remaining, click the done button
-            browser.wclick(CSS['persona.org'].emailListDoneButton, done);
-          }
-          else {
-            // if there are no emails remaining, the user will be logged out
-            browser.wfind(CSS['persona.org'].header.signIn, done);
-          }
-        });
-    });
-
 }
 
 function signIn123DoneWithSecondary(browser, email, password, done) {
@@ -107,41 +72,6 @@ function testEmailNotRegistered(browser, email, done) {
 }
 
 runner.run(module, {
-  // first checks to make sure removing the last email address on the
-  // account cancels the account
-  /*
-  "test removing the last email - get a secondary user account": function(done) {
-    setup(done);
-  },
-
-  "setup a browser": function(done) {
-    testSetup.newBrowserSession(browser, done);
-  },
-
-  "log in to 123done using secondaryEmail": function(done) {
-    signIn123DoneWithSecondary(browser, secondaryEmail,
-      secondaryPassword, done);
-  },
-
-  "go to main site, remove both email addresses to cancel the account": function(done) {
-    removeEmail(secondaryEmail, done);
-  },
-
-  "go to 123done, user should no longer be logged in": function(done) {
-    testUserNotSignedIn123Done(browser, done);
-  },
-
-  "user should now be signed out - cannot sign in with deleted addresses": function(done) {
-    testEmailNotRegistered(browser, secondaryEmail, done);
-  },
-
-  "quit the browser": function(done) {
-    browser.quit(function() {
-      done();
-    });
-  },
-
-*/
   // from here below tests an explicit cancel
 
   "test explicit cancel - get a secondary user": function(done) {

--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -103,8 +103,8 @@ function testEmailNotRegistered(browser, email, done) {
     .wwin(CSS['dialog'].windowName)
     .wtype(CSS['dialog'].emailInput, email)
     .wclick(CSS['dialog'].newEmailNextButton)
-    .wfind(CSS['dialog'].verifyPassword, done)
-}
+    .wfind(CSS['dialog'].verifyPassword, done);
+};
 
 runner.run(module, {
   // first checks to make sure removing the last email address on the

--- a/automation-tests/tests/cancel-account.js
+++ b/automation-tests/tests/cancel-account.js
@@ -104,7 +104,7 @@ function testEmailNotRegistered(browser, email, done) {
     .wtype(CSS['dialog'].emailInput, email)
     .wclick(CSS['dialog'].newEmailNextButton)
     .wfind(CSS['dialog'].verifyPassword, done);
-};
+}
 
 runner.run(module, {
   // first checks to make sure removing the last email address on the

--- a/automation-tests/tests/change-password-test.js
+++ b/automation-tests/tests/change-password-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/frontend-qunit-test.js
+++ b/automation-tests/tests/frontend-qunit-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 assert = require('../lib/asserts.js'),
 utils = require('../lib/utils.js'),

--- a/automation-tests/tests/frontend-qunit-test.js
+++ b/automation-tests/tests/frontend-qunit-test.js
@@ -97,5 +97,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/health-check-tests.js
+++ b/automation-tests/tests/health-check-tests.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/health-check-tests.js
+++ b/automation-tests/tests/health-check-tests.js
@@ -30,7 +30,7 @@ var startup = function(b, email, cb) {
     .wwin(CSS['dialog'].windowName)
     .wtype(CSS['dialog'].emailInput, email)
     .wclick(CSS['dialog'].newEmailNextButton, cb);
-}
+};
 
 var setup = {
   "setup stuff": function(done) {
@@ -42,7 +42,7 @@ var setup = {
         primaryEmail = testIdp.getRandomEmail();
         theEmail = fixtures.restmails[0];
       }
-      done(err)
+      done(err);
     });
   }
 };
@@ -57,7 +57,7 @@ var primaryTest = {
   },
 
   "go to personaorg, click sign in, type testidp addy, click next": function(done) {
-    startup(browser, primaryEmail, done)
+    startup(browser, primaryEmail, done);
   },
   "switch to testidp dialog, submit password, click ok": function(done) {
     browser.chain({onError: done})

--- a/automation-tests/tests/idp-transition/broken-primary.js
+++ b/automation-tests/tests/idp-transition/broken-primary.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 // This test excercised codepaths when primaries become unreachable.  It
 // uses testidp.org to create programatically controlled IdPs that can
 // be turned on or off.

--- a/automation-tests/tests/idp-transition/broken-primary.js
+++ b/automation-tests/tests/idp-transition/broken-primary.js
@@ -104,5 +104,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/idp-transition/broken-primary.js
+++ b/automation-tests/tests/idp-transition/broken-primary.js
@@ -24,8 +24,6 @@ testSetup = require('../../lib/test-setup.js');
 var browser;
 var testidp;
 
-var email1, email2;
-
 runner.run(module, {
   "setup": function(done) {
     testSetup.setup({browsers: 1, testidps: 1}, function(err, fixtures) {

--- a/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 assert = require('../../lib/asserts.js'),
 CSS = require('../../pages/css.js'),

--- a/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
@@ -15,7 +15,7 @@ restmail = require('../../lib/restmail.js'),
 runner = require('../../lib/runner.js'),
 testSetup = require('../../lib/test-setup.js');
 
-var browser, testUser, testIdp;
+var browser, testUser, testIdp, noAuthTestUser;
 
 runner.run(module, {
   "setup": function(done) {

--- a/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-shuts-down-single-email.js
@@ -35,7 +35,7 @@ runner.run(module, {
   "load 123done and wait for the signin button to be visible": function(done) {
     browser.get(persona_urls["123done"], done);
   },
-  "click the signin button": function(done, el) {
+  "click the signin button": function(done) {
     browser.wclick(CSS['123done.org'].signinButton, done);
   },
   "switch to the dialog when it opens": function(done) {

--- a/automation-tests/tests/idp-transition/primary-starts-up-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-starts-up-single-email.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 // This test excercised codepaths when primaries come on line.  It
 // uses testidp.org to create programatically controlled IdPs that can
 // be turened on or off.  Both the cases where a user has an

--- a/automation-tests/tests/idp-transition/primary-starts-up-single-email.js
+++ b/automation-tests/tests/idp-transition/primary-starts-up-single-email.js
@@ -172,5 +172,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/idp-transition/transition-to-secondary-forgot-password.js
+++ b/automation-tests/tests/idp-transition/transition-to-secondary-forgot-password.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 assert = require('../../lib/asserts.js'),
 CSS = require('../../pages/css.js'),

--- a/automation-tests/tests/idp-transition/transition-to-secondary.js
+++ b/automation-tests/tests/idp-transition/transition-to-secondary.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 assert = require('../../lib/asserts.js'),
 CSS = require('../../pages/css.js'),

--- a/automation-tests/tests/new-user/new-user-primary-test.js
+++ b/automation-tests/tests/new-user/new-user-primary-test.js
@@ -130,5 +130,5 @@ runner.run(
   [primary_123done, primary_mfb, primary_personaorg],
   {
     suiteName: path.basename(__filename),
-    cleanup: function(done) { testSetup.teardown(done) }
+    cleanup: function(done) { testSetup.teardown(done); }
   });

--- a/automation-tests/tests/new-user/new-user-primary-test.js
+++ b/automation-tests/tests/new-user/new-user-primary-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../../lib/asserts.js'),

--- a/automation-tests/tests/new-user/new-user-primary-test.js
+++ b/automation-tests/tests/new-user/new-user-primary-test.js
@@ -51,7 +51,7 @@ var primary_123done = {
   "load 123done, click sign in": function(done) {
     browser.chain({onError: done})
       .get(persona_urls['123done'])
-      .wclick(CSS['123done.org'].signinButton, done)
+      .wclick(CSS['123done.org'].signinButton, done);
   },
   "sign in a new testIdp user": function(done) {
     dialogTestIdpFlow(browser, primaryEmail, done);
@@ -77,7 +77,7 @@ var mcss = CSS['myfavoritebeer.org'],
     "go to mfb, click sign in, switch to dialog": function(done) {
       browser.chain({onError: done})
         .get(persona_urls['myfavoritebeer'])
-        .wclick(mcss.signinButton, done)
+        .wclick(mcss.signinButton, done);
     },
     "sign in using testIdp": function(done) {
       dialogTestIdpFlow(browser, primaryEmail_mfb, done);
@@ -115,7 +115,7 @@ var pcss = CSS['persona.org'],
         .wclick(CSS['testidp.org'].loginButton)
         .wwin()
         .wtext(pcss.accountEmail, function(err, text) {
-          done(err || assert.equal(porg_primaryEmail.toLowerCase(), text)) // note
+          done(err || assert.equal(porg_primaryEmail.toLowerCase(), text)); // note
         });
     },
     "log out": function(done) {

--- a/automation-tests/tests/new-user/new-user-secondary-test.js
+++ b/automation-tests/tests/new-user/new-user-secondary-test.js
@@ -85,8 +85,8 @@ var new_secondary_123done_two_browsers = {
   "tear down both browsers": function(done) {
     browser.quit(function(err) {
       secondBrowser.quit(function(err2) {
-        done(err || err2)
-      })
+        done(err || err2);
+      });
     });
   }
 };
@@ -128,14 +128,14 @@ var new_secondary_mfb_two_browsers = {
       .wwin()
       .wtext(CSS['myfavoritebeer.org'].currentlyLoggedInEmail, function(err, text) {
         assert.equal(text, mfbEmail);
-        done()
+        done();
       });
   },
   "shut down browsers": function(done) {
     browser.quit(function(err) {
       secondBrowser.quit(function(err2) {
-        done(err || err2)
-      })
+        done(err || err2);
+      });
     });
   }
 };
@@ -165,7 +165,7 @@ var new_secondary_personaorg = {
       browser.chain({onError: done})
         .wwin()
         .get(link)
-        .wtext(CSS['persona.org'].accountEmail, done)
+        .wtext(CSS['persona.org'].accountEmail, done);
     },
     "shut down zee browzr": function(done) {
       browser.quit(done);

--- a/automation-tests/tests/new-user/new-user-secondary-test.js
+++ b/automation-tests/tests/new-user/new-user-secondary-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../../lib/asserts.js'),

--- a/automation-tests/tests/new-user/new-user-secondary-test.js
+++ b/automation-tests/tests/new-user/new-user-secondary-test.js
@@ -177,5 +177,5 @@ runner.run(
   [new_secondary_123done_two_browsers, new_secondary_mfb_two_browsers, new_secondary_personaorg],
   {
     suiteName: path.basename(__filename),
-    cleanup: function(done) { testSetup.teardown(done) }
+    cleanup: function(done) { testSetup.teardown(done); }
   });

--- a/automation-tests/tests/public-terminals.js
+++ b/automation-tests/tests/public-terminals.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/public-terminals.js
+++ b/automation-tests/tests/public-terminals.js
@@ -68,6 +68,8 @@ runner.run(module, {
       .wfind(CSS['persona.org'].accountManagerHeader, done);
   },
   'hack localStorage to simulate 60 seconds of inactivity': function(done) {
+    /*jshint evil:true */
+
     // JSON.parse to get user id, JSON.parse usersCOmputer, rewind time,
     // stringify and finally set as local storage.
     var rewindOneMinute = '(function() { ' +
@@ -84,7 +86,7 @@ runner.run(module, {
     browser.chain({onError: done})
       .wclick(CSS['persona.org'].header.signIn)
       .wfind(CSS['persona.org'].accountManagerHeader) // make sure we're logged in
-      .eval(rewindOneMinute, function(err, out) {
+      .eval(rewindOneMinute, function(err) {
         // you can echo out eval's return value for debugging
         // console.error(out);
         done(err);

--- a/automation-tests/tests/public-terminals.js
+++ b/automation-tests/tests/public-terminals.js
@@ -108,5 +108,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/public-terminals.js
+++ b/automation-tests/tests/public-terminals.js
@@ -87,23 +87,23 @@ runner.run(module, {
       .eval(rewindOneMinute, function(err, out) {
         // you can echo out eval's return value for debugging
         // console.error(out);
-        done(err)
-      })
+        done(err);
+      });
   },
   'go to 123done, click log in, click "thats my email" button': function(done) {
     browser.chain({onError: done})
       .get(persona_urls['123done'])
       .wclick(CSS['123done.org'].signinButton)
       .wwin(CSS['persona.org'].windowName)
-      .wclick(CSS['dialog'].signInButton, done)
+      .wclick(CSS['dialog'].signInButton, done);
   },
   // TODO here's where the two tests differ: extract setup vows from assert vows
   // TODO figure out which cases to cover now that we've hacked localStorage
   'click "this is my computer" and the session should last a long time': function(done) {
-    browser.wclick(CSS['dialog'].myComputerButton, done)
+    browser.wclick(CSS['dialog'].myComputerButton, done);
   },
   "until we decide what to do, at least end the session properly": function(done) {
-    browser.quit(done)
+    browser.quit(done);
   }
 },
 {

--- a/automation-tests/tests/remove-email.js
+++ b/automation-tests/tests/remove-email.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/reset-password-test.js
+++ b/automation-tests/tests/reset-password-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/reset-password-test.js
+++ b/automation-tests/tests/reset-password-test.js
@@ -21,8 +21,7 @@ NEW_PASSWORD = "password";
 
 var browser, verificationBrowser, theUser;
 
-var verifyEmail = user.verifyEmail,
-    getVerifiedUser = user.getVerifiedUser;
+var getVerifiedUser = user.getVerifiedUser;
 
 runner.run(module, {
   "setup": function(done) {

--- a/automation-tests/tests/returning-user.js
+++ b/automation-tests/tests/returning-user.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/returning-user.js
+++ b/automation-tests/tests/returning-user.js
@@ -68,7 +68,7 @@ runner.run(module, {
       .wclick(CSS['dialog'].addNewEmailButton)
       .wtype(CSS['dialog'].choosePassword, secondary.split('@')[0])
       .wtype(CSS['dialog'].verifyPassword, secondary.split('@')[0])
-      .wclick(CSS['dialog'].createUserButton, done)
+      .wclick(CSS['dialog'].createUserButton, done);
   },
   "get verification link": function(done) {
     restmail.getVerificationLink({ email: secondary }, done);
@@ -79,7 +79,7 @@ runner.run(module, {
       .get(link)
       .wtext(CSS['123done.org'].currentlyLoggedInEmail, function(err, text) {
         done(err || assert.equal(text, secondary));
-      })
+      });
   },
   "go to mfb, open dialog for first login": function(done) {
     browser.chain({onError: done})
@@ -106,7 +106,7 @@ runner.run(module, {
       .wwin()
       .wclick(CSS['myfavoritebeer.org'].logout)
       .wclick(CSS['myfavoritebeer.org'].signinButton)
-      .wwin(CSS['persona.org'].windowName, done)
+      .wwin(CSS['persona.org'].windowName, done);
   },
   // this time, the first radio should be selected
   "check first radio is selected":function(done, el) {

--- a/automation-tests/tests/returning-user.js
+++ b/automation-tests/tests/returning-user.js
@@ -87,7 +87,7 @@ runner.run(module, {
       .wclick(CSS['myfavoritebeer.org'].signinButton)
       .wwin(CSS['persona.org'].windowName, done);
   },
-  "check first radio is not selected":function(done, el) {
+  "check first radio is not selected": function(done) {
     browser.wgetAttribute(CSS['dialog'].firstEmail, 'selected', function(err, val) {
       done(err || assert.ok(!val));
     });
@@ -109,7 +109,7 @@ runner.run(module, {
       .wwin(CSS['persona.org'].windowName, done);
   },
   // this time, the first radio should be selected
-  "check first radio is selected":function(done, el) {
+  "check first radio is selected": function(done) {
     browser.wgetAttribute(CSS['dialog'].firstEmail, 'selected', function(err, val) {
       done(err || assert.ok(val));
     });

--- a/automation-tests/tests/returning-user.js
+++ b/automation-tests/tests/returning-user.js
@@ -122,5 +122,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/sign-in-test.js
+++ b/automation-tests/tests/sign-in-test.js
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*jshint sub: true */
+
 const
 path = require('path'),
 assert = require('../lib/asserts.js'),

--- a/automation-tests/tests/sign-in-test.js
+++ b/automation-tests/tests/sign-in-test.js
@@ -89,5 +89,5 @@ runner.run(module, {
 },
 {
   suiteName: path.basename(__filename),
-  cleanup: function(done) { testSetup.teardown(done) }
+  cleanup: function(done) { testSetup.teardown(done); }
 });

--- a/automation-tests/tests/sign-in-test.js
+++ b/automation-tests/tests/sign-in-test.js
@@ -34,7 +34,7 @@ runner.run(module, {
   "load 123done and wait for the signin button to be visible": function(done) {
     browser.get(persona_urls["123done"], done);
   },
-  "click the signin button": function(done, el) {
+  "click the signin button": function(done) {
     browser.wclick(CSS['123done.org'].signinButton, done);
   },
   "switch to the dialog when it opens": function(done) {


### PR DESCRIPTION
I like jshint, but opinions may vary. Anyways, this cleans up jshint warnings in ./automation-tests.
- it grandfathers use of 'foo["bar"]' since we use a lot of it
- cleans up a bunch of whiny stuff about semicolons
- removes some dead code jshint pointed out
- fix a couple of leaks to global of variables.
- prefers strict equality tests

I don't see any significant difference in test pass/fail rates on chrome, ff{win,linux}, ie9 and ie10.
