### PR TITLE
Explicitly set rejectUnauthorized to false when using https.request()

### DIFF
--- a/lib/http_forward.js
+++ b/lib/http_forward.js
@@ -42,6 +42,7 @@ exports.forward = function(dest, req, res, cb) {
     path: u.path,
     method: req.method,
     headers: req.headers,
+    rejectUnauthorized: true,
     agent: false
   }, function(pres) {
 

--- a/lib/primary.js
+++ b/lib/primary.js
@@ -150,6 +150,7 @@ var fetchWellKnown = function (currentDomain, principalDomain, clientCB) {
     req = https.get({
       host: currentDomain,
       path: WELL_KNOWN_URL + "?domain=" + principalDomain,
+      rejectUnauthorized: true,
       agent: false
     }, handleResponse);
   }

--- a/lib/wsapi.js
+++ b/lib/wsapi.js
@@ -273,6 +273,7 @@ exports.requestToDBWriter = function(opts, cb) {
     path: opts.path,
     method: opts.method || "GET",
     headers: opts.headers,
+    rejectUnauthorized: true,
     agent: false
   }, function(res) {
     var respBody = "";

--- a/lib/wsapi/authenticate_user.js
+++ b/lib/wsapi/authenticate_user.js
@@ -130,6 +130,7 @@ function incrementAuthCount(req, res, uid) {
     port: u.port,
     path: '/wsapi/increment_failed_auth_tries?' + querystring.stringify({userid: uid}),
     method: "GET",
+    rejectUnauthorized: true,
     agent: false
   }, function(pres) {
     pres.on('end', function() {
@@ -158,6 +159,7 @@ function resetFailedAuthCount(req, res, uid) {
     port: u.port,
     path: '/wsapi/reset_failed_auth_tries',
     method: "GET",
+    rejectUnauthorized: true,
     agent: false,
     headers: {
       'Cookie': res._headers['set-cookie']
@@ -201,6 +203,7 @@ function updateHash(req, res, uid, hash) {
     port: u.port,
     path: '/wsapi/update_password',
     method: "POST",
+    rejectUnauthorized: true,
     agent: false,
     headers: {
       'Cookie': res._headers['set-cookie'],

--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -66,6 +66,7 @@ var store = function (kpi_json, cb) {
         hostname: db_url.host,
         path: db_url.path,
         method: 'POST',
+        rejectUnauthorized: true,
         agent: false,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/lib/wsapi_client.js
+++ b/lib/wsapi_client.js
@@ -108,6 +108,7 @@ exports.get = function(cfg, path, context, getArgs, cb) {
       port: uObj.port,
       path: path,
       headers: headers,
+      rejectUnauthorized: true,
       agent: false // disable node.js connection pooling
     }, function(res) {
       extractCookies(context, res);
@@ -188,6 +189,7 @@ exports.post = function(cfg, path, context, postArgs, cb) {
         path: path,
         headers: headers,
         method: "POST",
+        rejectUnauthorized: true,
         agent: false // disable node.js connection pooling
       }, function(res) {
         extractCookies(context, res);

--- a/scripts/verify-assertion.js
+++ b/scripts/verify-assertion.js
@@ -130,6 +130,7 @@ function postToVerifier(audience, bundle, verifier, callback) {
     hostname: hostname,
     path: '/verify',
     method: 'POST',
+    rejectUnauthorized: true,
     agent: false,
     headers: {
       'content-type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
This is the default in node 0.10 but not in 0.8. That older version
needs both `agent: false` and `rejectUnauthorized: true` before it
will reject invalid TLS certificates.

http://nodejs.org/api/https.html#https_https_request_options_callback

In production, this is normally not needed because our squid proxy
is also set to reject invalid certificates, but setting it like
this means less surprises when we upgrade to node 0.10 and protects
anybody that might be running our code without a proxy on the old
version of node.

https://bugzilla.mozilla.org/show_bug.cgi?id=901650
