### PR TITLE
Redirect flow

### DIFF
--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -91,6 +91,12 @@ pre {
     </li><li>
       <input type="checkbox" id="allowUnverified">
       <label for="allowUnverified">Allow Unverified</label>
+    </li><li>
+      <input type="checkbox" id="allowRedirect">
+      <label for="allowRedirect">Allow Persona via Redirect</label>
+    </li><li>
+      <input type="checkbox" id="forceRedirect">
+      <label for="forceRedirect">Force Persona via Redirect</label>
     </li>
   </ul>
     <button class="assertion">Get an assertion</button>
@@ -217,6 +223,8 @@ $(document).ready(function() {
       experimental_forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
       experimental_forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
       experimental_allowUnverified: $('#allowUnverified').attr('checked') ? true : false,
+      allowRedirect: $('#allowRedirect').attr('checked') ? true : false,
+      forceRedirect: $('#forceRedirect').attr('checked') ? true : false,
       oncancel: function() {
         loggit("oncancel");
         $(".specify button.assertion").removeAttr('disabled');

--- a/example/rp/index.html
+++ b/example/rp/index.html
@@ -91,12 +91,6 @@ pre {
     </li><li>
       <input type="checkbox" id="allowUnverified">
       <label for="allowUnverified">Allow Unverified</label>
-    </li><li>
-      <input type="checkbox" id="allowRedirect">
-      <label for="allowRedirect">Allow Persona via Redirect</label>
-    </li><li>
-      <input type="checkbox" id="forceRedirect">
-      <label for="forceRedirect">Force Persona via Redirect</label>
     </li>
   </ul>
     <button class="assertion">Get an assertion</button>
@@ -223,8 +217,6 @@ $(document).ready(function() {
       experimental_forceAuthentication: $('#forceAuthentication').attr('checked') ? true : false,
       experimental_forceIssuer: $('#forceIssuer').attr('checked') ? "issuer.domain" : undefined,
       experimental_allowUnverified: $('#allowUnverified').attr('checked') ? true : false,
-      allowRedirect: $('#allowRedirect').attr('checked') ? true : false,
-      forceRedirect: $('#forceRedirect').attr('checked') ? true : false,
       oncancel: function() {
         loggit("oncancel");
         $(".specify button.assertion").removeAttr('disabled');

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -229,6 +229,17 @@ exports.setup = function(app) {
     });
   });
 
+  app.get("/unsupported_dialog_without_watch", function(req,res) {
+    renderCachableView(req, res, 'unsupported_dialog_without_watch.ejs', {
+      title: _('Unsupported Browser without Watch'),
+      layout: 'dialog_layout.ejs',
+      useJavascript: false,
+      // without the javascript bundle, there is no point in measuring the
+      // window opened time.
+      measureDomLoading: false
+    });
+  });
+
   app.get("/cookies_disabled", function(req,res) {
     renderCachableView(req, res, 'cookies_disabled.ejs', {
       title: _('Cookies Are Disabled'),

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -236,7 +236,8 @@ exports.setup = function(app) {
       useJavascript: false,
       // without the javascript bundle, there is no point in measuring the
       // window opened time.
-      measureDomLoading: false
+      measureDomLoading: false,
+      showLoading: true
     });
   });
 

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -237,7 +237,7 @@ exports.setup = function(app) {
       // without the javascript bundle, there is no point in measuring the
       // window opened time.
       measureDomLoading: false,
-      showLoading: true
+      showLoading: false
     });
   });
 

--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -527,6 +527,42 @@ BrowserID.Storage = (function() {
     }
   }
 
+  function setRpRequestInfo(info) {
+    /**
+     * sessionStorage is used instead of localStorage to enable
+     * multiple tabs to Persona to be open at once
+     */
+    if (!info.origin)
+      throw new Error("missing origin");
+
+    if (!(info.params && info.params.returnTo))
+      throw new Error("missing params.returnTo");
+
+    sessionStorage.rpRequest = JSON.stringify(info);
+  }
+
+  function getRpRequestInfo() {
+    if (sessionStorage.rpRequest) {
+      var data = JSON.parse(sessionStorage.rpRequest);
+
+      try {
+        if (!data.origin)
+          throw new Error("rpRequest missing origin");
+
+        if (!(data.params && data.params.returnTo))
+          throw new Error("rpRequest missing params.returnTo");
+      } catch(e) {
+        clearRpRequestInfo();
+        throw e;
+      }
+
+      return data;
+    }
+  }
+
+  function clearRpRequestInfo() {
+    sessionStorage.removeItem('rpRequest');
+  }
 
   return {
     /**
@@ -719,6 +755,26 @@ BrowserID.Storage = (function() {
        */
       clear: clearIdpVerificationInfo,
       INFO_LIFESPAN_MS: IDP_INFO_LIFESPAN_MS
+    },
+
+    /**
+     * Info used for environments where the RP must redirect to Persona instead
+     * of using a popup
+     */
+    rpRequest: {
+      /**
+       * Get the RP Redirection info
+       * @throws JSON.parse error if invalid JSON.
+       */
+      get: getRpRequestInfo,
+      /**
+       * Set the RP Redirection info
+       */
+      set: setRpRequestInfo,
+      /**
+       * Clear any RP Redirection info
+       */
+      clear: clearRpRequestInfo
     }
   };
 }());

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -24,6 +24,7 @@
   });
 
   var remoteOrigin;
+  localStorage.removeItem("rpRequest");
 
   function setRemoteOrigin(o) {
     if (!remoteOrigin) {
@@ -121,7 +122,11 @@
 
   chan.bind("redirect_flow", function(trans, params) {
     setRemoteOrigin(trans.origin);
-    localStorage.rpRequest = JSON.stringify({ origin: remoteOrigin, params: JSON.parse(params) });
+    localStorage.rpRequest = JSON.stringify({
+      origin: remoteOrigin,
+      params: JSON.parse(params)
+    });
+    return true;
   });
 
   chan.bind("dialog_running", function(trans, params) {

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -121,7 +121,7 @@
 
   chan.bind("redirect_flow", function(trans, params) {
     setRemoteOrigin(trans.origin);
-    sessionStorage.rpRequest = JSON.stringify({
+    storage.rpRequest.set({
       origin: remoteOrigin,
       params: JSON.parse(params)
     });

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -119,6 +119,11 @@
     }
   });
 
+  chan.bind("redirect_flow", function(trans, params) {
+    setRemoteOrigin(trans.origin);
+    localStorage.rpRequest = JSON.stringify({ origin: remoteOrigin, params: JSON.parse(params) });
+  });
+
   chan.bind("dialog_running", function(trans, params) {
     pause = true;
   });

--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -24,7 +24,6 @@
   });
 
   var remoteOrigin;
-  localStorage.removeItem("rpRequest");
 
   function setRemoteOrigin(o) {
     if (!remoteOrigin) {
@@ -122,7 +121,7 @@
 
   chan.bind("redirect_flow", function(trans, params) {
     setRemoteOrigin(trans.origin);
-    localStorage.rpRequest = JSON.stringify({
+    sessionStorage.rpRequest = JSON.stringify({
       origin: remoteOrigin,
       params: JSON.parse(params)
     });

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -96,8 +96,8 @@ BrowserID.Modules.Dialog = (function() {
       // we have a workaround. lets try it first.
       // we let WinChan try first always, to prevent the redirect flow
       // happening in an environment where popups work just fine.
-      if (localStorage.rpRequest) {
-        var rpInfo = JSON.parse(localStorage.rpRequest);
+      if (sessionStorage.rpRequest) {
+        var rpInfo = JSON.parse(sessionStorage.rpRequest);
         var done = redirectFlowComplete.curry(fixupReturnTo(rpInfo.origin, rpInfo.params.returnTo));
         self.get(rpInfo.origin, rpInfo.params, done, done);
         return;

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -38,12 +38,32 @@ BrowserID.Modules.Dialog = (function() {
     });
   }
 
-  function redirectFlowComplete(returnTo, r) {
-    console.log('returning', returnTo);
-    window.location = returnTo;
+  function startChannel() {
+    /*jshint validthis: true*/
+    var self = this,
+        established,
+        err;
+
+    try {
+      // Native goes before anything. Next, WinChan. If WinChan fails, try the
+      // workaround for environments that do not support popups.
+      established = tryNativeChannel.call(self)
+                 || tryWinChan.call(self)
+                 || tryRpRedirect.call(self);
+    }
+    catch(e) {
+      // generic error message displayed below
+      err = e;
+    }
+
+    if (!established) {
+      var errorInfo = { action: errors.relaySetup };
+      if (err) errorInfo.message = String(err);
+      self.renderError("error", errorInfo);
+    }
   }
 
-  function startChannel() {
+  function tryNativeChannel() {
     /*jshint validthis: true*/
     var self = this,
         win = self.window,
@@ -52,7 +72,7 @@ BrowserID.Modules.Dialog = (function() {
     // first, we see if there is a local channel
     if (win.navigator.id && win.navigator.id.channel) {
       win.navigator.id.channel.registerController(self);
-      return;
+      return true;
     }
 
     // returning from the primary verification flow, we were native before, we
@@ -61,7 +81,7 @@ BrowserID.Modules.Dialog = (function() {
     try {
       var info = storage.idpVerification.get();
       /*jshint sub: true */
-      if (info && info['native']) return;
+      if (info && info['native']) return true;
     } catch(e) {
       self.renderError("error", {
         action: {
@@ -69,22 +89,23 @@ BrowserID.Modules.Dialog = (function() {
           message: "could not decode localStorage: " + String(e)
         }
       });
+
+      return true;
     }
 
     // next, we see if the caller intends to call native APIs
-    if (hash === "#NATIVE" || hash === "#INTERNAL") {
-      // don't do winchan, let it be.
-      return;
-    }
+    return (hash === "#NATIVE" || hash === "#INTERNAL");
+  }
 
-
-
+  function tryWinChan() {
+    /*jshint validthis: true*/
+    var self = this;
 
     try {
       self.channel = WinChan.onOpen(function(origin, args, cb) {
         // XXX this is called whenever the primary provisioning iframe gets
         // added.  If there are no args, then do not do self.get.
-        if(args) {
+        if (args) {
           self.get(origin, args.params, function(r) {
             cb(r);
           }, function (e) {
@@ -92,23 +113,51 @@ BrowserID.Modules.Dialog = (function() {
           });
         }
       });
-    } catch (e) {
-      // we have a workaround. lets try it first.
-      // we let WinChan try first always, to prevent the redirect flow
-      // happening in an environment where popups work just fine.
-      if (sessionStorage.rpRequest) {
-        var rpInfo = JSON.parse(sessionStorage.rpRequest);
-        var done = redirectFlowComplete.curry(fixupReturnTo(rpInfo.origin, rpInfo.params.returnTo));
-        self.get(rpInfo.origin, rpInfo.params, done, done);
-        return;
-      }
+    } catch(e) {
+      // don't do anything, we'll try the redirect flow next.
+    }
 
-      self.renderError("error", {
-        action: errors.relaySetup
+    return !!self.channel;
+  }
+
+  function tryRpRedirect() {
+    /*jshint validthis: true*/
+    // If there was an error opening the WinChan, we have a potential
+    // workaround. We let WinChan try first always, to prevent the
+    // redirect flow happening in an environment where popups work just fine.
+    var self = this;
+    var rpInfo;
+    try {
+      rpInfo = storage.rpRequest.get();
+    } catch(e) {
+      this.renderError("error", {
+        action: {
+          title: "error in sessionStorage",
+          message: "could not decode sessionStorage: " + String(e)
+        }
       });
+
+      return true;
+    }
+
+    if (rpInfo) {
+      var done = function done() {
+        redirectFlowComplete(self.window, user.getReturnTo());
+      };
+      this.get(rpInfo.origin, rpInfo.params, done, done);
+      return true;
     }
   }
 
+  function redirectFlowComplete(win, returnTo) {
+    /**
+     * clear the rpRequest info to prevent users who have visited the dialog
+     * from re-starting the dialog flow by typing the dialog's URL into the
+     * address bar.
+     */
+    storage.rpRequest.clear();
+    win.location = returnTo;
+  }
 
   function onWindowUnload() {
     /*jshint validthis: true*/

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -38,6 +38,11 @@ BrowserID.Modules.Dialog = (function() {
     });
   }
 
+  function redirectFlowComplete(returnTo, r) {
+    console.log('returning', returnTo);
+    window.location = returnTo;
+  }
+
   function startChannel() {
     /*jshint validthis: true*/
     var self = this,
@@ -72,6 +77,9 @@ BrowserID.Modules.Dialog = (function() {
       return;
     }
 
+
+
+
     try {
       self.channel = WinChan.onOpen(function(origin, args, cb) {
         // XXX this is called whenever the primary provisioning iframe gets
@@ -85,6 +93,16 @@ BrowserID.Modules.Dialog = (function() {
         }
       });
     } catch (e) {
+      // we have a workaround. lets try it first.
+      // we let WinChan try first always, to prevent the redirect flow
+      // happening in an environment where popups work just fine.
+      if (localStorage.rpRequest) {
+        var rpInfo = JSON.parse(localStorage.rpRequest);
+        var done = redirectFlowComplete.curry(fixupReturnTo(rpInfo.origin, rpInfo.params.returnTo));
+        self.get(rpInfo.origin, rpInfo.params, done, done);
+        return;
+      }
+
       self.renderError("error", {
         action: errors.relaySetup
       });

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -133,6 +133,8 @@
       (isFennec ? undefined :
        "menubar=0,location=1,resizable=1,scrollbars=1,status=0,width=700,height=375");
 
+    var needsPopupFix = true;
+
     var w;
 
     // table of registered observers
@@ -369,6 +371,21 @@
       // notify the iframe that the dialog is running so we
       // don't do duplicative work
       if (commChan) commChan.notify({ method: 'dialog_running' });
+
+      if (needsPopupFix) {
+        if (commChan) {
+          commChan.notify({
+            method: 'popup_fix',
+            params: JSON.stringify(options)
+          });
+          window.location = ipServer + '/sign_in';
+          return;
+        } else {
+          //it's not ganna work on this browser without watch()!
+          //XXX: warn the console? bail as an error?
+          throw new Error("bonkers");
+        }
+      }
 
       w = WinChan.open({
         url: ipServer + '/sign_in',

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -138,7 +138,8 @@
     // Windows Phone
     //    - http://stackoverflow.com/questions/11381673/javascript-solution-to-detect-mobile-browser
     var needsPopupFix = userAgent.match(/CriOS/) ||
-                        userAgent.match(/Windows Phone/);
+                        userAgent.match(/Windows Phone/) ||
+                        userAgent.match(/BlackBerry/);
 
     var w;
 

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -135,7 +135,10 @@
 
     // Chrome for iOS
     //    - https://developers.google.com/chrome/mobile/docs/user-agent
-    var needsPopupFix = navigator.userAgent.match('CriOS');
+    // Windows Phone
+    //    - http://stackoverflow.com/questions/11381673/javascript-solution-to-detect-mobile-browser
+    var needsPopupFix = userAgent.match(/CriOS/) ||
+                        userAgent.match(/Windows Phone/);
 
     var w;
 

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -388,10 +388,9 @@
               window.location = ipServer + '/sign_in';
             }
           });
-        } else {
-          //it's not ganna work on this browser without watch()!
-          //XXX: warn the console? bail as an error?
-          throw new Error("bonkers");
+        }
+        else {
+          warn("Chrome for iOS and Windows Phone 7 only work with the .watch API");
         }
       }
 

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -138,8 +138,7 @@
     // Windows Phone
     //    - http://stackoverflow.com/questions/11381673/javascript-solution-to-detect-mobile-browser
     var needsPopupFix = userAgent.match(/CriOS/) ||
-                        userAgent.match(/Windows Phone/) ||
-                        userAgent.match(/BlackBerry/);
+                        userAgent.match(/Windows Phone/);
 
     var w;
 
@@ -396,7 +395,7 @@
         }
       }
 
-      if ((needsPopupFix && options.allowRedirect) || options.forceRedirect) {
+      if (needsPopupFix) {
         return doPopupFix();
       }
 

--- a/resources/static/test/cases/common/js/storage.js
+++ b/resources/static/test/cases/common/js/storage.js
@@ -219,7 +219,7 @@
 
     storage.idpVerification.clear();
     info = storage.idpVerification.get();
-    equal(typeof info, "undefined");
+    testHelpers.testUndefined(info);
   });
 
   test("idpVerification - clear old info", function() {
@@ -237,7 +237,23 @@
 
     storage.idpVerification.clear();
     var info = storage.idpVerification.get("expired");
-    equal(typeof info, "undefined");
+    testHelpers.testUndefined(info);
+  });
+
+  test("rpRequest functions, set, get, clear", function() {
+    storage.rpRequest.set({
+      origin: "https://testuser.com"
+      params: {
+        returnTo: "/"
+      }
+    });
+
+    var rpRequestInfo = storage.rpRequest.get();
+    equal(rpRequestInfo.origin, "testuser.com");
+
+    storage.rpRequest.clear();
+    rpRequestInfo = storage.rpRequest.get();
+    testHelpers.testUndefined(rpRequestInfo);
   });
 
 }());

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -24,12 +24,8 @@
       navMock;
 
   function WinMock() {
-    this.location.hash = "#1234";
-  }
-
-  WinMock.prototype = {
     // Oh so beautiful.
-    opener: {
+    this.opener = {
       frames: {
         1234: {
           BrowserID: {
@@ -43,13 +39,12 @@
           }
         }
       }
-    },
-
-    location: {
-    },
-
-    navigator: {}
-  };
+    };
+    this.location = {
+      hash: "#1234"
+    };
+    this.navigator = {};
+  }
 
   function createController(config) {
     // startExternalDependencies defaults to true, for most of our tests we
@@ -171,6 +166,7 @@
     winMock.location.hash = "#NATIVE";
 
     createController({
+      startExternalDependencies: true,
       ready: function() {
         testErrorNotVisible();
         start();
@@ -183,12 +179,38 @@
     winMock.location.hash = "#INTERNAL";
 
     createController({
+      startExternalDependencies: true,
       ready: function() {
         testErrorNotVisible();
         start();
       }
     });
   });
+
+  asyncTest("initialization with RP redirect flow - " +
+      "immediately calls get (which triggers an error)", function() {
+    storage.rpRequest.set({
+      origin: "testuser.com",
+      params: {
+        returnTo: "/"
+      }
+    });
+
+    var err;
+    mediator.subscribe("error_screen", function(msg, info) {
+      err = info.message;
+    });
+
+    createController({
+      startExternalDependencies: true,
+      ready: function() {
+        equal(err, "Error: module not registered for rp_info");
+        start();
+      }
+    });
+  });
+
+
 
   function testReturnFromIdP(verificationInfo, expectedParams) {
     storage.idpVerification.set(verificationInfo);

--- a/resources/views/unsupported_dialog_without_watch.ejs
+++ b/resources/views/unsupported_dialog_without_watch.ejs
@@ -1,0 +1,17 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+  <section id="error" class="cookies_disabled">
+      <div class="table">
+        <div class="vertical contents">
+          <h2 id="reason">
+            <%= gettext("Persona requires the watch() API in this browser") %>
+          </h2>
+
+          <p>
+            <%- format(gettext("If you're a developer, look at using <a %s>navigator.id.watch()</a>. If not, tell the website owner."), [" target='_blank' href='https://developer.mozilla.org/en-US/docs/Web/API/navigator.id.watch'"]) %>
+          </p>
+        </div>
+      </div>
+  </section>

--- a/resources/views/unsupported_dialog_without_watch.ejs
+++ b/resources/views/unsupported_dialog_without_watch.ejs
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-  <section id="error" class="cookies_disabled">
+  <section id="error" class="unsupported">
       <div class="table">
         <div class="vertical contents">
           <h2 id="reason">

--- a/tests/cache-header-tests.js
+++ b/tests/cache-header-tests.js
@@ -133,6 +133,8 @@ suite.addBatch({
   '/sign_in': hasProperCacheHeaders('/sign_in'),
   '/communication_iframe': hasProperCacheHeaders('/communication_iframe'),
   '/unsupported_dialog': hasProperCacheHeaders('/unsupported_dialog'),
+  '/unsupported_dialog_without_watch':
+      hasProperCacheHeaders('/unsupported_dialog_without_watch'),
   '/cookies_disabled': hasProperCacheHeaders('/cookies_disabled'),
   '/relay': hasProperCacheHeaders('/relay'),
   '/about': hasProperCacheHeaders('/about'),

--- a/tests/page-requests-test.js
+++ b/tests/page-requests-test.js
@@ -37,6 +37,8 @@ suite.addBatch({
   'GET /.well-known/browserid?domain=yahoo.com':
                                  respondsWith(200),
   'GET /unsupported_dialog':     respondsWith(200),
+  'GET /unsupported_dialog_without_watch':
+                                 respondsWith(200),
   'GET /cookies_disabled':       respondsWith(200),
   'GET /developers':             respondsWith(302),
   'GET /developers/':            respondsWith(302),


### PR DESCRIPTION
Adds a redirect flow for browsers that don't support the dialog flow. Most notably: Chrome for iOS and Windows Phone IE. The RP has no control over whether this can happen, to keep the experience consistent for all users.

This flow only works with the `watch()` API. Without it, after being redirected, the user would still not be logged in. An `unsupported_dialog_without_watch` screen will be shown on these browsers if `navigator.id.get()` is used. The wording could probably use some help.

fixes #2034 :beers: 
