### PR TITLE
Ensure the unsupported_dialog and cookies_disabled screens show without the loading screen.

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -205,7 +205,8 @@ exports.setup = function(app) {
       layout: 'dialog_layout.ejs',
       useJavascript: true,
       measureDomLoading: config.get('measure_dom_loading'),
-      production: config.get('use_minified_resources')
+      production: config.get('use_minified_resources'),
+      showLoading: true
     });
   });
 
@@ -223,7 +224,8 @@ exports.setup = function(app) {
       useJavascript: false,
       // without the javascript bundle, there is no point in measuring the
       // window opened time.
-      measureDomLoading: false
+      measureDomLoading: false,
+      showLoading: false
     });
   });
 
@@ -234,7 +236,8 @@ exports.setup = function(app) {
       useJavascript: false,
       // without the javascript bundle, there is no point in measuring the
       // window opened time.
-      measureDomLoading: false
+      measureDomLoading: false,
+      showLoading: false
     });
   });
 

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -619,6 +619,10 @@
     padding: 10px;
   }
 
+  #error .lighter {
+    color: #fff;
+  }
+
   a.emphasize {
     font-size: 14px;
     padding: 5px;
@@ -653,8 +657,14 @@
    * or else their content is not displayed on mobile devices. See issue #1998
    */
   #error.unsupported, #error.cookies_disabled {
-    position: static;
-    height: 250px;
+    display: block;
+    position: absolute;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 10px;
   }
 
   /**

--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -659,7 +659,6 @@
   #error.unsupported, #error.cookies_disabled {
     display: block;
     position: absolute;
-    position: fixed;
     top: 0;
     left: 0;
     right: 0;

--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -287,11 +287,8 @@ section > .contents {
   _height: 100%;
 }
 
-#error.unsupported h2 {
-  margin: 0 0 20px;
-}
-
 #error img {
+    margin-top: 20px;
     border: none;
 }
 

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -36,7 +36,7 @@
      */ %>
   <title><%= format(gettext("Mozilla Persona: %s"), [gettext(title)]) %></title>
 </head>
-  <body class="loading">
+  <body <% if (showLoading) { %>class="loading"i<% } %>>
       <% if (useJavascript !== false && enable_development_menu) { %>
         <a href="#" id="showDevelopment">&nbsp;</a>
       <% } %>
@@ -44,6 +44,8 @@
       <div id="content">
         <%- body %>
       </div>
+
+      <% if (showLoading) { %>
 
       <!-- the loading screen should take up the entire
            screen and not just within the borders of the content
@@ -58,6 +60,8 @@
             </div>
         </div>
       </section>
+
+      <% } %>
 
 
       <footer>

--- a/resources/views/unsupported_dialog.ejs
+++ b/resources/views/unsupported_dialog.ejs
@@ -2,22 +2,26 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-  <section id="error" style="display: block" class="unsupported">
-      <h2>
-        <%- gettext('We are sorry, but currently your browser is not supported.') %>
-      </h2>
+  <section id="error" class="unsupported">
+    <div class="table">
+      <div class="vertical contents">
+        <h2>
+          <%- gettext('We are sorry, but currently your browser is not supported.') %>
+        </h2>
 
 
-      <a href="http://getfirefox.com" target="_blank">
-        <img src="<%- cachify('/dialog/i/firefox_logo.png') %>" width="250" height="88" alt="<%- gettext('Firefox logo') %>" />
-      </a>
+        <a class="isDesktop" href="http://getfirefox.com" target="_blank">
+          <img src="<%- cachify('/dialog/i/firefox_logo.png') %>" width="250" height="88" alt="<%- gettext('Firefox logo') %>" />
+        </a>
 
-      <p>
-        <%- format(gettext('Persona works with <a %(getFirefoxLink)s>Firefox</a>'), { getFirefoxLink: 'href="http://getfirefox.com" target="_blank" title="Get Firefox"' }) %>
-      </p>
+        <p>
+          <%- format(gettext('Persona works with <a %(getFirefoxLink)s>Firefox</a>'), { getFirefoxLink: 'href="http://getfirefox.com" target="_blank" title="Get Firefox"' }) %>
+          <span class="lighter">
+           <%- format(gettext('and other <a %(otherBrowserLink)s>modern browsers.</a>'), { otherBrowserLink: 'href="http://whatbrowser.org" target="_blank"' }) %>
+          </span>
+        </p>
 
-      <p class="lighter">
-       <%- format(gettext('and other <a %(otherBrowserLink)s>modern browsers.</a>'), { otherBrowserLink: 'href="http://whatbrowser.org" target="_blank"' }) %>
-      </p>
+      </div>
+    </div>
 
   </section>


### PR DESCRIPTION
@seanmonstar - could you review this? An ephemeral instance, unsupported-styles.personatest.org is set up.

Ensure the styling of the unsupported_dialog and cookies_disabled screens match other parts of the site. (vertically centered error messages)

fixes #3783
fixes #3784
