### PR TITLE
make /include.orig.js available again. Fixes GH-3212.

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -143,6 +143,14 @@ exports.setup = function(app) {
 
   app.get('/include.orig.js', function(req, res, next) {
     req.url = "/build/include.js";
+
+    // scripts/browserid.spec will put this file in place for builds installed
+    // from `rpm`. But ephemerals do have use_minified_resources === true, so
+    // we don't want to key off that. GH-3212
+    if (isProductionEnvironment()) {
+      req.url = "/production/include.orig.js";
+    }
+
     next();
   });
 

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -28,6 +28,7 @@ mkdir -p resources/static/i18n/
 echo "$GIT_REVISION" > resources/static/ver.txt
 echo "locale svn r$SVN_REVISION" >> resources/static/ver.txt
 env CONFIG_FILES=$PWD/config/l10n-all.json scripts/compress
+cp resources/static/build/include.js %{_builddir}/browserid/resources/static/production/include.orig.js
 rm -r resources/static/build resources/static/test
 
 %install


### PR DESCRIPTION
I took @djc's change to browserid.spec and added the necessary adjustment in views to show this (but check my math). 

This whole area could use some overall rationalization, but for now let's just fix the 404 for /include.orig.js

I've built an rpm and installed it in a pseudo production environment and seems good to me.

@shane-tomlinson, @6a68 please consider adding this before you branch train-2013.08.14 tomorrow. 

 Fixes GH-3212.
