### PR TITLE
update ./scripts/lockdown to version from npm-lockdown@0.0.5. Fixes #3303

### DIFF
--- a/scripts/lockdown
+++ b/scripts/lockdown
@@ -92,6 +92,13 @@ function rewritePackageMD(json) {
   return JSON.stringify(json);
 }
 
+function copy(from, to) {
+  for (var k in from) {
+    to[k] = from[k];
+  }
+  return to;
+}
+
 var server = http.createServer(function (req, res) {
   if (req.method !== 'GET') {
     return res.end('non GET requests not supported', 501);
@@ -163,15 +170,14 @@ var server = http.createServer(function (req, res) {
 
 server.listen(process.env['LOCKDOWN_PORT'] || 0, '127.0.0.1', function() {
   boundPort = server.address().port;
+  var env = copy(process.env, {
+    NPM_CONFIG_REGISTRY: 'http://127.0.0.1:' + boundPort,
+    NPM_LOCKDOWN_RUNNING: "true"
+  });
 
   var child = exec('npm install', {
-    env: {
-      NPM_CONFIG_REGISTRY: 'http://127.0.0.1:' + boundPort,
-      NPM_LOCKDOWN_RUNNING: "true",
-      PATH: process.env['PATH'],
-      HOME: process.env['HOME']
-    },
-    cwd: process.cwd()
+    cwd: process.cwd(),
+    env: env
   }, function(e) {
     if (warn.length) {
       console.log();


### PR DESCRIPTION
update ./scripts/lockdown to @0.0.5 to pass the full environment down. fixes #3303

For reasons described in https://github.com/mozilla/browserid/issues/3303#issuecomment-16911322 it would be beneficial to pass down more of the environment to child processes while npm-lockdown runs.

The full environment is already what is passed down in npm-lockdown@0.0.5 (https://github.com/mozilla/npm-lockdown/commit/c908e38bbba5ec5a332f6736b54746e8632aedce), but the checked-in version of ./scripts/lockdown in mozilla/browserid comes from @0.0.4. 

(I could also update browserid:package.json to use that version, but I'd still need to update the checked-in version of ./scripts/lockdown (because we never want to circularly depend on the npm installed version of lockdown to make the right assurances)).

I've failed at unwinding the trail of various issues reported, so this PR is a bit of a strawman to invite comments about what's best/most-secure. I want this change so I can use Jenkins more reliably to fix #3745 for regular running of frontend qunit tests.
