### PR TITLE
Issue 3529 metrics to piggybank

### DIFF
--- a/bin/router
+++ b/bin/router
@@ -23,6 +23,7 @@ logger = require('../lib/logging.js').logger,
 forward = require('../lib/http_forward').forward,
 addP3PHeader = require('../lib/p3p.js'),
 shutdown = require('../lib/shutdown'),
+store_kpi = require('../lib/kpi'),
 toobusy = require('../lib/busy_middleware.js');
 
 var app = express.createServer();
@@ -179,10 +180,16 @@ app.use(function(req, res, next) {
       // IP address (this probably needs to be replaced with the X-forwarded-for value
       ip: ipAddress
     });
+    store_kpi({
+      type: 'signin',
+      browser: req.headers['user-agent'],
+      rp: referer,
+      // IP address (this probably needs to be replaced with the X-forwarded-for value
+      ip: ipAddress
+    });
   };
 
   // log metrics
-  // TODO also log to kpiggybank here
   if (req.url === '/sign_in') userEntry(req);
 
   forward(

--- a/bin/router
+++ b/bin/router
@@ -161,6 +161,8 @@ wsapi.routeSetup(app, {
 app.use(function(req, res, next) {
 
   // log metrics
+  // TODO also log to kpiggybank here
+  // TODO userEntry is used in exactly 1 place. so inline it here and simplify the lib/metrics file.
   if (req.url === '/sign_in') metrics.userEntry(req);
 
   forward(

--- a/bin/router
+++ b/bin/router
@@ -182,11 +182,10 @@ app.use(function(req, res, next) {
     });
     store_kpi({
       type: 'signin',
-      browser: req.headers['user-agent'],
       rp: referer,
       // IP address (this probably needs to be replaced with the X-forwarded-for value
       ip: ipAddress
-    });
+    }, req.headers['user-agent']);
   };
 
   // log metrics

--- a/bin/router
+++ b/bin/router
@@ -160,10 +160,30 @@ wsapi.routeSetup(app, {
 //catch-all
 app.use(function(req, res, next) {
 
+  // utility function to log a bunch of stuff at user entry point
+  function userEntry = function(req) {
+    var ipAddress = req.connection.remoteAddress;
+    if (req.headers['x-real-ip']) ipAddress = req.headers['x-real-ip'];
+
+    var referer = null;
+    try {
+      // don't log more than we need
+      referer = urlparse(req.headers.referer).originOnly().toString();
+    } catch(e) {
+      // ignore malformed referrers.  just log null
+    }
+
+    metrics.report('signin', {
+      browser: req.headers['user-agent'],
+      rp: referer,
+      // IP address (this probably needs to be replaced with the X-forwarded-for value
+      ip: ipAddress
+    });
+  };
+
   // log metrics
   // TODO also log to kpiggybank here
-  // TODO userEntry is used in exactly 1 place. so inline it here and simplify the lib/metrics file.
-  if (req.url === '/sign_in') metrics.userEntry(req);
+  if (req.url === '/sign_in') userEntry(req);
 
   forward(
     static_url+req.url, req, res,

--- a/bin/router
+++ b/bin/router
@@ -162,7 +162,7 @@ wsapi.routeSetup(app, {
 app.use(function(req, res, next) {
 
   // utility function to log a bunch of stuff at user entry point
-  function userEntry = function(req) {
+  function userEntry(req) {
     var ipAddress = req.connection.remoteAddress;
     if (req.headers['x-real-ip']) ipAddress = req.headers['x-real-ip'];
 

--- a/bin/verifier
+++ b/bin/verifier
@@ -104,6 +104,7 @@ function doVerification(req, resp, next) {
       if (want_ct.indexOf(ct) == -1) throw "wrong content type";
     } catch (e) {
       reason = "Content-Type expected to be one of: " + want_ct.join(", ");
+      // TODO also hit kpiggybank here
       metrics.report('verify', {
         result: 'failure',
         reason: reason,
@@ -112,6 +113,7 @@ function doVerification(req, resp, next) {
       return resp.json({ status: "failure", reason: reason}, 415);
     }
     reason = "need assertion and audience";
+    // TODO also hit kpiggybank here
     metrics.report('verify', {
       result: 'failure',
       reason: reason,
@@ -137,6 +139,7 @@ function doVerification(req, resp, next) {
     if (err) {
       statsd.increment("assertion_failure");
       resp.json({"status":"failure", reason: err});  //Could be 500 or 200 OK if invalid cert
+      // TODO also hit kpiggybank here
       metrics.report('verify', {
         result: 'failure',
         reason: err,
@@ -149,6 +152,7 @@ function doVerification(req, resp, next) {
         expires : new Date(r.success.expires).valueOf()
       }));
 
+      // TODO also hit kpiggybank here
       metrics.report('verify', {
         result: 'success',
         rp: r.success.audience

--- a/bin/verifier
+++ b/bin/verifier
@@ -21,6 +21,7 @@ config = require('../lib/configuration'),
 shutdown = require('../lib/shutdown'),
 statsd = require('../lib/statsd'),
 booleanQuery = require('../lib/boolean-query'),
+store_kpi = require('../lib/kpi'),
 toobusy = require('../lib/busy_middleware.js');
 
 logger.info("verifier server starting up");
@@ -105,6 +106,14 @@ function doVerification(req, resp, next) {
     } catch (e) {
       reason = "Content-Type expected to be one of: " + want_ct.join(", ");
       // TODO also hit kpiggybank here
+      // store_kpi inserts timestamps for you
+      // I think we just need to insert the fields we care about
+      store_kpi({
+        type: 'verify',
+        result: 'failure',
+        reason: reason,
+        rp: audience
+      });
       metrics.report('verify', {
         result: 'failure',
         reason: reason,
@@ -113,7 +122,12 @@ function doVerification(req, resp, next) {
       return resp.json({ status: "failure", reason: reason}, 415);
     }
     reason = "need assertion and audience";
-    // TODO also hit kpiggybank here
+    store_kpi({
+      type: 'verify',
+      result: 'failure',
+      reason: reason,
+      rp: audience
+    });
     metrics.report('verify', {
       result: 'failure',
       reason: reason,
@@ -137,9 +151,15 @@ function doVerification(req, resp, next) {
     else if (!r || !r.success) err = "no response returned from child process";
 
     if (err) {
+      // TODO this is ridiculous. three loggers for the same event :-\
       statsd.increment("assertion_failure");
       resp.json({"status":"failure", reason: err});  //Could be 500 or 200 OK if invalid cert
-      // TODO also hit kpiggybank here
+      store_kpi({
+        type: 'verify',
+        result: 'failure',
+        reason: err,
+        rp: audience
+      });
       metrics.report('verify', {
         result: 'failure',
         reason: err,
@@ -151,8 +171,11 @@ function doVerification(req, resp, next) {
         audience : audience, // NOTE: we return the audience formatted as the RP provided it, not normalized in any way.
         expires : new Date(r.success.expires).valueOf()
       }));
-
-      // TODO also hit kpiggybank here
+      store_kpi({
+        type: 'verify',
+        result: 'success',
+        rp: r.success.audience
+      });
       metrics.report('verify', {
         result: 'success',
         rp: r.success.audience

--- a/bin/verifier
+++ b/bin/verifier
@@ -105,15 +105,12 @@ function doVerification(req, resp, next) {
       if (want_ct.indexOf(ct) == -1) throw "wrong content type";
     } catch (e) {
       reason = "Content-Type expected to be one of: " + want_ct.join(", ");
-      // TODO also hit kpiggybank here
-      // store_kpi inserts timestamps for you
-      // I think we just need to insert the fields we care about
       store_kpi({
         type: 'verify',
         result: 'failure',
         reason: reason,
         rp: audience
-      });
+      }, req.headers['user-agent']);
       metrics.report('verify', {
         result: 'failure',
         reason: reason,
@@ -127,7 +124,7 @@ function doVerification(req, resp, next) {
       result: 'failure',
       reason: reason,
       rp: audience
-    });
+    }, req.headers['user-agent']);
     metrics.report('verify', {
       result: 'failure',
       reason: reason,
@@ -159,7 +156,7 @@ function doVerification(req, resp, next) {
         result: 'failure',
         reason: err,
         rp: audience
-      });
+      }, req.headers['user-agent']);
       metrics.report('verify', {
         result: 'failure',
         reason: err,
@@ -175,7 +172,7 @@ function doVerification(req, resp, next) {
         type: 'verify',
         result: 'success',
         rp: r.success.audience
-      });
+      }, req.headers['user-agent']);
       metrics.report('verify', {
         result: 'success',
         rp: r.success.audience

--- a/lib/kpi.js
+++ b/lib/kpi.js
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('./configuration.js'),
+      http = require('http'),
+      https = require('https'),
+      logger = require('./logging.js').logger,
+      querystring = require('querystring'),
+      und = require('underscore'),
+      urlparse = require('urlparse'),
+      TEN_MIN_IN_MS = 10 * 60 * 1000;
+  // TODO should we parse the user-agent string in here to avoid duplication?
+  // coarse = require('../coarse_user_agent_parser'),
+
+// KPI format: https://github.com/mozilla/kpiggybank#http-api
+// also https://wiki.mozilla.org/Privacy/Reviews/KPI_Backend#Example_data
+//
+// required fields:
+//   kpi_timestamp - unix (not js) timestamp rounded to 10 minutes for privacy
+//   
+exports = function store(kpi_json, cb) {
+  var options,
+      db_url,
+      kpi_req,
+      http_proxy;
+
+  // Out of concern for the user's privacy, round the server timestamp
+  // off to the nearest 10-minute mark.
+  und.each(kpi_json, function (kpi) { delete kpi.local_timestamp;
+    if (! kpi.timestamp) {
+      kpi.timestamp = new Date().getTime();
+    }
+    kpi.timestamp = kpi.timestamp - (kpi.timestamp % TEN_MIN_IN_MS);
+  });
+
+  if (!! config.get('kpi_backend_db_url')) {
+
+    var post_data = querystring.stringify({
+      'data' : JSON.stringify(kpi_json)
+    });
+
+    db_url = urlparse(config.get('kpi_backend_db_url'));
+
+    http_proxy = config.has('http_proxy') ? config.get('http_proxy') : null;
+    
+    if (http_proxy && http_proxy.port && http_proxy.host) {
+      options = {
+        host: http_proxy.host,
+        port: http_proxy.port,
+        path: db_url,
+        method: 'POST',
+        agent: false,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': post_data.length
+        }
+      };
+      kpi_req = http.request(options);
+    } else {
+      options = {
+        hostname: db_url.host,
+        path: db_url.path,
+        method: 'POST',
+        rejectUnauthorized: true,
+        agent: false,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': post_data.length
+        }
+      };
+      
+      if (db_url.port) {
+        options.port = db_url.port;
+      }
+      
+      var protocol = (db_url.scheme === 'https') ? https : http;
+      kpi_req = protocol.request(options);
+    }
+    
+    kpi_req.on('response', function(res) {
+      if (res.statusCode !== 201) {
+        logger.warn('KPI Backend (or proxy) response code is not 201: ' + res.statusCode);
+      } else {
+        logger.info('interaction data successfully posted to KPI Backend');
+      }  
+    });
+    
+    kpi_req.on('error', function (e) {
+      // TODO statsd counter
+      logger.error('KPI Backend request error: ' + e.message);
+    });
+
+    logger.debug("sending request to KPI backend: " + config.get('kpi_backend_db_url'));
+    kpi_req.write(post_data);
+    kpi_req.end();
+
+  } else {
+    cb(false);
+  }
+};

--- a/lib/kpi.js
+++ b/lib/kpi.js
@@ -19,7 +19,7 @@ const config = require('./configuration.js'),
 // required fields:
 //   kpi_timestamp - unix (not js) timestamp rounded to 10 minutes for privacy
 //   
-exports = function store(kpi_json, cb) {
+var store = function(kpi_json, cb) {
   var options,
       db_url,
       kpi_req,
@@ -99,3 +99,5 @@ exports = function store(kpi_json, cb) {
     cb(false);
   }
 };
+
+module.exports = store;

--- a/lib/kpi.js
+++ b/lib/kpi.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const config = require('./configuration.js'),
+const coarse = require('../coarse_user_agent_parser'),
+      config = require('./configuration.js'),
       http = require('http'),
       https = require('https'),
       logger = require('./logging.js').logger,
@@ -10,20 +11,31 @@ const config = require('./configuration.js'),
       und = require('underscore'),
       urlparse = require('urlparse'),
       TEN_MIN_IN_MS = 10 * 60 * 1000;
-  // TODO should we parse the user-agent string in here to avoid duplication?
-  // coarse = require('../coarse_user_agent_parser'),
 
 // KPI format: https://github.com/mozilla/kpiggybank#http-api
 // also https://wiki.mozilla.org/Privacy/Reviews/KPI_Backend#Example_data
 //
-// required fields:
-//   kpi_timestamp - unix (not js) timestamp rounded to 10 minutes for privacy
-//   
-var store = function(kpi_json, cb) {
+// input: kpi_json => kpi data object
+//        kpi_ua => request user-agent string, to be parsed here
+//        cb => fired when done
+var store = function(kpi_json, req_ua, cb) {
+  // both req_ua and cb are optional
+  if (typeof req_ua == 'function') { cb = req_ua && req_ua = null; }
   var options,
       db_url,
       kpi_req,
       http_proxy;
+
+  // Parse out the useragent coarsely for anonymity
+  if (req_ua) {
+    var ua = coarse.parse(req_ua);
+    und.each(kpi_json, function (kpi) {
+      if (! kpi.user_agent) {
+        kpi.user_agent = {};
+      }
+      und.extend(kpi.user_agent, ua);
+    });
+  }
 
   // Out of concern for the user's privacy, round the server timestamp
   // off to the nearest 10-minute mark.
@@ -96,7 +108,7 @@ var store = function(kpi_json, cb) {
     kpi_req.end();
 
   } else {
-    cb(false);
+    if (cb) cb(false);
   }
 };
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -21,8 +21,7 @@ const
 winston = require("winston"),
 configuration = require("./configuration"),
 path = require('path'),
-fs = require('fs'),
-urlparse = require('urlparse');
+fs = require('fs');
 
 // existsSync moved from path in 0.6.x to fs in 0.8.x
 if (typeof fs.existsSync === 'function') {
@@ -85,23 +84,3 @@ exports.report = function(type, entry) {
   LOGGER.info(JSON.stringify(entry));
 };
 
-// utility function to log a bunch of stuff at user entry point
-exports.userEntry = function(req) {
-  var ipAddress = req.connection.remoteAddress;
-  if (req.headers['x-real-ip']) ipAddress = req.headers['x-real-ip'];
-
-  var referer = null;
-  try {
-    // don't log more than we need
-    referer = urlparse(req.headers.referer).originOnly().toString();
-  } catch(e) {
-    // ignore malformed referrers.  just log null
-  }
-
-  exports.report('signin', {
-    browser: req.headers['user-agent'],
-    rp: referer,
-    // IP address (this probably needs to be replaced with the X-forwarded-for value
-    ip: ipAddress
-  });
-};

--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -3,15 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const coarse = require('../coarse_user_agent_parser'),
-      config = require('../configuration.js'),
-      http = require('http'),
-      https = require('https'),
       logger = require('../logging.js').logger,
-      querystring = require('querystring'),
-      und = require('underscore'),
-      urlparse = require('urlparse'),
-      wsapi = require('../wsapi.js'),
-      TEN_MIN_IN_MS = 10 * 60 * 1000;
+      store = require('../kpi.js'),
+      und = require('underscore');
 
 // Accept JSON formatted interaction data and send it to the KPI Backend
 
@@ -22,87 +16,6 @@ exports.method = 'post';
 exports.writes_db = false;
 exports.authed = false;
 exports.i18n = false;
-
-var store = function (kpi_json, cb) {
-  var options,
-      db_url,
-      kpi_req,
-      http_proxy;
-
-  // Out of concern for the user's privacy, round the server timestamp
-  // off to the nearest 10-minute mark.
-  und.each(kpi_json, function (kpi) { delete kpi.local_timestamp;
-    if (! kpi.timestamp) {
-      kpi.timestamp = new Date().getTime();
-    }
-    kpi.timestamp = kpi.timestamp - (kpi.timestamp % TEN_MIN_IN_MS);
-  });
-
-  if (!! config.get('kpi_backend_db_url')) {
-
-    var post_data = querystring.stringify({
-      'data' : JSON.stringify(kpi_json)
-    });
-
-    db_url = urlparse(config.get('kpi_backend_db_url'));
-
-    http_proxy = config.has('http_proxy') ? config.get('http_proxy') : null;
-    
-    if (http_proxy && http_proxy.port && http_proxy.host) {
-      options = {
-        host: http_proxy.host,
-        port: http_proxy.port,
-        path: db_url,
-        method: 'POST',
-        agent: false,
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Content-Length': post_data.length
-        }
-      };
-      kpi_req = http.request(options);
-    } else {
-      options = {
-        hostname: db_url.host,
-        path: db_url.path,
-        method: 'POST',
-        rejectUnauthorized: true,
-        agent: false,
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Content-Length': post_data.length
-        }
-      };
-      
-      if (db_url.port) {
-        options.port = db_url.port;
-      }
-      
-      var protocol = (db_url.scheme === 'https') ? https : http;
-      kpi_req = protocol.request(options);
-    }
-    
-    kpi_req.on('response', function(res) {
-      if (res.statusCode !== 201) {
-        logger.warn('KPI Backend (or proxy) response code is not 201: ' + res.statusCode);
-      } else {
-        logger.info('interaction data successfully posted to KPI Backend');
-      }  
-    });
-    
-    kpi_req.on('error', function (e) {
-      // TODO statsd counter
-      logger.error('KPI Backend request error: ' + e.message);
-    });
-
-    logger.debug("sending request to KPI backend: " + config.get('kpi_backend_db_url'));
-    kpi_req.write(post_data);
-    kpi_req.end();
-
-  } else {
-    cb(false);
-  }
-};
 
 exports.process = function(req, res) {
   // Always send a quick success response.  The client won't know if

--- a/lib/wsapi/interaction_data.js
+++ b/lib/wsapi/interaction_data.js
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const coarse = require('../coarse_user_agent_parser'),
-      logger = require('../logging.js').logger,
-      store = require('../kpi.js'),
-      und = require('underscore');
+const logger = require('../logging.js').logger,
+      store = require('../kpi.js');
 
 // Accept JSON formatted interaction data and send it to the KPI Backend
 
@@ -27,19 +25,9 @@ exports.process = function(req, res) {
   if (req.body.data) {
     var kpi_json = req.body.data;
 
-    if (req.headers['user-agent']) {
-      var ua = coarse.parse(req.headers['user-agent']);
-      und.each(kpi_json, function (kpi) {
-        if (! kpi.user_agent) {
-          kpi.user_agent = {};
-        }
-        und.extend(kpi.user_agent, ua);
-      });
-    }
-
     logger.debug("Simulate write to KPI Backend DB - " + JSON.stringify(kpi_json, null, 2));
     try {
-      store(kpi_json, function (store_success) {
+      store(kpi_json, req.headers['user-agent'], function (store_success) {
         if (!store_success) {
           logger.warn("failed to store interaction data");
         }


### PR DESCRIPTION
@shane-tomlinson Could I get your feedback on this? Not sure it's ready, but maybe it is (might also need to wait for privacy review before merging, I'm not sure).

This is a fix for mozilla/identity-ops#102 that sends some additional RP metrics to kpiggybank along with the existing kpi data. We do this by extracting the `wsapi/interaction_data` kpi code into a separate lib, and dropping a few additional logger calls into `bin/verifier` and `bin/router`.

There is a separate privacy bug open for collecting the RP metrics, and there's also a ton of related conversation, inside mozilla/identity-ops#102.

Open questions:
- what format should I use for the new data? what should I call the keys, how should I namespace them?
- do we need to wait until privacy review is done to merge in? 
- are there other metrics I should fold into this PR? I'm thinking particularly of #3755.
