### PR TITLE
replace crossword with webmaker; fixes #3716 (for now)

### DIFF
--- a/resources/views/about.ejs
+++ b/resources/views/about.ejs
@@ -9,10 +9,10 @@
             <article class="blurb">
                 <div class="info first">
                     <h1><%- gettext('Persona replaces multiple passwords') %></h1>
-                    <p><%- format(gettext('Sites such as <a %(timesLink)s>%(timesName)s</a>, <a %(openphotoLink)s>%(openphotoName)s</a> and <a %(voostLink)s>%(voostName)s</a> use Persona instead of usernames to sign you in.'),
+                    <p><%- format(gettext('Sites such as <a %(webmakerLink)s>%(webmakerName)s</a>, <a %(openphotoLink)s>%(openphotoName)s</a> and <a %(voostLink)s>%(voostName)s</a> use Persona instead of usernames to sign you in.'),
                                   {
-                                    timesLink: 'href="http://crossword.thetimes.co.uk/" target="_blank"',
-                                    timesName: 'The Times Crossword',
+                                    webmakerLink: 'href="https://webmaker.org/" target="_blank"',
+                                    webmakerName: 'Mozilla Webmaker',
                                     openphotoLink: 'href="https://current.trovebox.com/" target="_blank"',
                                     openphotoName: 'Trovebox',
                                     voostLink: 'href="https://www.voo.st/" target="_blank"',


### PR DESCRIPTION
So for now s/crossword/webmaker/; Fixes #3716 (for now).

A review of that whole page is overdue, but for now, let's not have a dead link. Leading with webmaker is not optimal.
