### PR TITLE
Set the header nav radius to be a consistent 7px

### DIFF
--- a/resources/static/pages/css/style.css
+++ b/resources/static/pages/css/style.css
@@ -565,7 +565,7 @@ header .nav a {
 header .nav a:hover {
   color: #383838;
   background-color: #f4f3f0;
-  border-radius: 3px;
+  border-radius: 7px;
   text-shadow: 0 1px 0 #fff;
   text-shadow: 0 1px 0 rgba(255, 255, 255, .5);
 }


### PR DESCRIPTION
Fixes #3813.

This assumes that we want the header nav buttons to have a border-radius of 7px rather than 3px.
