### PR TITLE
If the user has not yet clicked on "Yes, this is my computer", remove the cert after generating an assertion.

### DIFF
--- a/automation-tests/tests/remove-email.js
+++ b/automation-tests/tests/remove-email.js
@@ -152,6 +152,10 @@ runner.run(module, {
       .wwin(CSS['dialog'].windowName)
       .wclick(CSS['dialog'].emailPrefix + getEmailIndex(secondPrimaryEmail))
       .wclick(CSS['dialog'].signInButton)
+      // The user has not yet clicked "yes" to "is this your computer?" and
+      // the cert used when secondPrimaryEmail was added has been deleted.
+      // The user must re-auth with the IdP.
+      .wclick(CSS['testidp.org'].loginButton)
       .wclickIfExists(CSS['dialog'].notMyComputerButton)
       .wwin()
       .wtext(CSS['123done.org'].currentlyLoggedInEmail, function(err, text) {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1383,6 +1383,13 @@ BrowserID.User = (function() {
                   // issuer is used for B2G to get silent assertions to get
                   // assertions backed by certs from a special issuer.
                   storage.site.set(audience, "issuer", issuer);
+
+                  /**
+                   * If a user who signs with a primary address is not authenticated to Persona,
+                   * an assertion is first generated with the audience login.persona.org to sign the user
+                   * into Persona, another assertion is generated to sign the user into the RP. The cert should
+                   * be removed after generating the assertion for the RP.
+                   */
                   if (audience !== PERSONA_ORG_AUDIENCE && !storage.usersComputer.confirmed(email)) {
                     // If the user has not confirmed that this is their
                     // computer, immediately invalidate the cert so that nobody

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -26,7 +26,8 @@ BrowserID.User = (function() {
       userid,
       auth_status,
       issuer = "default",
-      allowUnverified = false;
+      allowUnverified = false,
+      PERSONA_ORG_AUDIENCE = "https://login.persona.org";
 
   var TRANSITION_STATES = [
     "transition_to_secondary",
@@ -603,7 +604,7 @@ BrowserID.User = (function() {
           persistEmailKeypair(email, authInfo.keypair, authInfo.cert,
             function() {
               // We are getting an assertion for persona.org.
-              User.getAssertion(email, "https://login.persona.org", function(assertion) {
+              User.getAssertion(email, PERSONA_ORG_AUDIENCE, function(assertion) {
                 if (assertion) {
                   onComplete("primary.verified", {
                     assertion: assertion
@@ -1382,6 +1383,12 @@ BrowserID.User = (function() {
                   // issuer is used for B2G to get silent assertions to get
                   // assertions backed by certs from a special issuer.
                   storage.site.set(audience, "issuer", issuer);
+                  if (audience !== PERSONA_ORG_AUDIENCE && !storage.usersComputer.confirmed(email)) {
+                    // If the user has not confirmed that this is their
+                    // computer, immediately invalidate the cert so that nobody
+                    // else can sign in using this address.
+                    storage.invalidateEmail(email);
+                  }
                   complete(onComplete, assertion);
                 });
             }, 0);


### PR DESCRIPTION
@fmarier - This goes along with what we talked about on the front end. The odd thing is that when re-loading a page that uses .watch, if the user is authenticated to the IdP, a new cert is generated automatically. Is that the desired behavior?
