### PR TITLE
RP branded emails.

### DIFF
--- a/bin/router
+++ b/bin/router
@@ -76,9 +76,10 @@ app.use(express.logger({
   }
 }));
 
-// limit all content bodies to 10kb, at which point we'll forcefully
-// close down the connection.
-app.use(express.limit("10kb"));
+// limit all content bodies to 128kb, at which point we'll forcefully
+// close down the connection. The large limit is to accommodate data URIs
+// for the siteLogo
+app.use(express.limit("128kb"));
 
 var statsd_config = config.get('statsd');
 if (statsd_config && statsd_config.enabled) {

--- a/bin/router
+++ b/bin/router
@@ -76,10 +76,9 @@ app.use(express.logger({
   }
 }));
 
-// limit all content bodies to 128kb, at which point we'll forcefully
-// close down the connection. The large limit is to accommodate data URIs
-// for the siteLogo
-app.use(express.limit("128kb"));
+// limit all content bodies to 10kb, at which point we'll forcefully
+// close down the connection. 
+app.use(express.limit("10kb"));
 
 var statsd_config = config.get('statsd');
 if (statsd_config && statsd_config.enabled) {

--- a/lib/email.js
+++ b/lib/email.js
@@ -39,34 +39,45 @@ const templates = {
   "new": {
     landing: 'verify_email_address',
     subject: _("%(site)s: Complete sign-in"),
-    template: fs.readFileSync(path.join(TEMPLATE_PATH, 'new.ejs')),
-    templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'new.html.ejs'))
+    template: 'new.ejs',
+    templateHTML: 'new.html.ejs'
   },
   "reset": {
     landing: 'reset_password',
     subject: _("%(site)s: Complete password reset"),
-    template: fs.readFileSync(path.join(TEMPLATE_PATH, 'reset.ejs')),
-    templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'reset.html.ejs'))
+    template: 'reset.ejs',
+    templateHTML: 'reset.html.ejs'
   },
   "confirm": {
     landing: 'confirm',
     subject: _("%(site)s: Complete sign-in"),
-    template: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.ejs')),
-    templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'confirm.html.ejs'))
+    template: 'confirm.ejs',
+    templateHTML: 'confirm.html.ejs'
   },
   "transition": {
     landing: 'complete_transition',
     subject: _("%(site)s: Complete sign-in"),
-    template: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.ejs')),
-    templateHTML: fs.readFileSync(path.join(TEMPLATE_PATH, 'transition.html.ejs'))
+    template: 'transition.ejs',
+    templateHTML: 'transition.html.ejs'
   },
 };
 
-// now turn file contents into compiled templates
+// turn template file contents into compiled templates
 Object.keys(templates).forEach(function(type) {
-  templates[type].template = ejs.compile(templates[type].template.toString());
+  var templatePath = path.join(TEMPLATE_PATH, templates[type].template);
+  var template = fs.readFileSync(templatePath);
+
+  templates[type].template = ejs.compile(template.toString(), {
+    filename: templatePath
+  });
+
   if (templates[type].templateHTML) {
-    templates[type].templateHTML = ejs.compile(templates[type].templateHTML.toString());
+    var templateHTMLPath = path.join(TEMPLATE_PATH, templates[type].templateHTML);
+    var templateHTML = fs.readFileSync(templateHTMLPath);
+
+    templates[type].templateHTML = ejs.compile(templateHTML.toString(), {
+      filename: templateHTMLPath
+    });
   }
 });
 
@@ -88,8 +99,17 @@ exports.setInterceptor = function(callback) {
   interceptor = callback;
 };
 
+function getBackgroundColor(backgroundColor) {
+  backgroundColor = backgroundColor || "45505b";
+  if (! /^#/.test(backgroundColor)) {
+    backgroundColor = "#" + backgroundColor;
+  }
+  return backgroundColor;
+}
+
+
 //TODO send in localeContext
-function doSend(email_type, email, site, secret, langContext) {
+function doSend(email_type, email, site, secret, langContext, backgroundColor, siteLogo) {
   if (!templates[email_type]) throw "unknown email type: " + email_type;
 
   // remove scheme from site to make it more human
@@ -107,12 +127,15 @@ function doSend(email_type, email, site, secret, langContext) {
     // log verification email to console separated by whitespace.
     console.log("\nVERIFICATION URL:\n" + public_url + "\n");
   } else {
+
     var templateArgs = {
       link: public_url,
       site: site,
       gettext: GETTEXT,
       format: format,
-      cachify: cachify
+      cachify: cachify,
+      backgroundColor: getBackgroundColor(backgroundColor),
+      siteLogo: siteLogo || ''
     };
 
     var mailOpts = {
@@ -133,7 +156,6 @@ function doSend(email_type, email, site, secret, langContext) {
     if (email_params.templateHTML) {
       mailOpts.html = email_params.templateHTML(templateArgs);
     }
-
     emailer.send_mail(mailOpts, function(err, success) {
       if (!success) {
         logger.error("error sending email to: " + email + " - " + err);
@@ -142,18 +164,18 @@ function doSend(email_type, email, site, secret, langContext) {
   }
 }
 
-exports.sendNewUserEmail = function(email, site, secret, langContext) {
-  doSend('new', email, site, secret, langContext);
+exports.sendNewUserEmail = function(email, site, secret, langContext, backgroundColor, siteLogo) {
+  doSend('new', email, site, secret, langContext, backgroundColor, siteLogo);
 };
 
-exports.sendConfirmationEmail = function(email, site, secret, langContext) {
-  doSend('confirm', email, site, secret, langContext);
+exports.sendConfirmationEmail = function(email, site, secret, langContext, backgroundColor, siteLogo) {
+  doSend('confirm', email, site, secret, langContext, backgroundColor, siteLogo);
 };
 
-exports.sendForgotPasswordEmail = function(email, site, secret, langContext) {
-  doSend('reset', email, site, secret, langContext);
+exports.sendForgotPasswordEmail = function(email, site, secret, langContext, backgroundColor, siteLogo) {
+  doSend('reset', email, site, secret, langContext, backgroundColor, siteLogo);
 };
 
-exports.sendTransitionEmail = function(email, site, secret, langContext) {
-  doSend('transition', email, site, secret, langContext);
+exports.sendTransitionEmail = function(email, site, secret, langContext, backgroundColor, siteLogo) {
+  doSend('transition', email, site, secret, langContext, backgroundColor, siteLogo);
 };

--- a/lib/email.js
+++ b/lib/email.js
@@ -12,6 +12,8 @@ logger = require('./logging.js').logger,
 url = require('url'),
 cachify = require('connect-cachify').cachify;
 
+const DEFAULT_BACKGROUND_COLOR = "45505b";
+
 /* if smtp parameters are configured, use them */
 try { var smtp_params = config.get('smtp'); } catch(e) {}
 if (smtp_params && smtp_params.host) {
@@ -100,7 +102,7 @@ exports.setInterceptor = function(callback) {
 };
 
 function getBackgroundColor(backgroundColor) {
-  backgroundColor = backgroundColor || "45505b";
+  backgroundColor = backgroundColor || DEFAULT_BACKGROUND_COLOR;
   if (! /^#/.test(backgroundColor)) {
     backgroundColor = "#" + backgroundColor;
   }
@@ -108,8 +110,8 @@ function getBackgroundColor(backgroundColor) {
 }
 
 
-//TODO send in localeContext
-function doSend(email_type, email, site, secret, langContext, backgroundColor, siteLogo) {
+function doSend(email_type, email, site, secret, langContext,
+    backgroundColor, siteLogo) {
   if (!templates[email_type]) throw "unknown email type: " + email_type;
 
   // remove scheme from site to make it more human

--- a/lib/static_resources.js
+++ b/lib/static_resources.js
@@ -91,6 +91,8 @@ var dialog_js = und.flatten([
 
     '/common/js/models/models.js',
     '/common/js/models/interaction_data.js',
+    '/common/js/models/rp_info.js',
+
 
     '/common/js/modules/interaction_data.js',
 
@@ -98,6 +100,7 @@ var dialog_js = und.flatten([
     '/dialog/js/misc/helpers.js',
     '/dialog/js/misc/state.js',
     '/dialog/js/misc/screen_size_hacks.js',
+
 
     '/dialog/js/modules/actions.js',
     '/dialog/js/modules/dialog.js',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -15,7 +15,8 @@
 const
 logger = require('./logging.js').logger,
 httputils = require('./httputils.js'),
-check = require('validator').check;
+check = require('validator').check,
+url = require('url');
 
 var hostnameRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
@@ -67,6 +68,43 @@ var types = {
     var regex = /^(?:https?|app):\/\/(?=.{1,254}(?::|$))(?:(?!-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;
     if (typeof x !== 'string' || !x.match(regex)) {
       throw new Error("not a valid origin");
+    }
+  },
+  color: function(value) {
+    if (value.substr(0, 1) === '#') {
+      value = value.substr(1);
+    }
+
+    // Check if this is valid hex color
+    if (!value.match(/^[0-9a-fA-F]{3}$|^[0-9a-fA-F]{6}$/)) {
+      throw new Error('not a valid color: ' + value);
+    }
+  },
+  image: function(inputLogoUri) {
+    var dataMatches = null; // is this a valid data URI?
+    // Ideally we'd be loading this from a canonical constants library.
+    var imageMimeTypes = ['png', 'gif', 'jpg', 'jpeg', 'svg'];
+    // This regex converts valid input of the form:
+    //   'data:image/png;base64,iV...'
+    // into an array that looks like:
+    //   ['data:image/png;base64,iV...', 'image', 'png', ...]
+    // which means that mimetype proper is represented as-> [1]/[2]
+    var dataUriRegex = /^data:(.+)\/(.+);base64,(.*)$/;
+
+    dataMatches = inputLogoUri.match(dataUriRegex);
+    if (dataMatches) {
+      if ((dataMatches[1].toLowerCase() === 'image')
+           &&
+          (imageMimeTypes.indexOf(dataMatches[2].toLowerCase()) > -1)) {
+        return;
+      }
+      throw new Error("Bad data URI for siteLogo: " + inputLogoUri.slice(0, 15) + " ...");
+    }
+
+    // Regularize URL; throws error if input is relative.
+    /*jshint newcap:false*/
+    if (url.parse(inputLogoUri).protocol !== 'https:') {
+      throw new Error("siteLogos can only be served from https and data schemes.");
     }
   }
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -71,16 +71,13 @@ var types = {
     }
   },
   color: function(value) {
-    if (value.substr(0, 1) === '#') {
-      value = value.substr(1);
-    }
-
-    // Check if this is valid hex color
-    if (!value.match(/^[0-9a-fA-F]{3}$|^[0-9a-fA-F]{6}$/)) {
-      throw new Error('not a valid color: ' + value);
-    }
+    check(value).isHexColor();
   },
   image: function(inputLogoUri) {
+    if (typeof inputLogoUri !== "string") {
+      throw new Error("not a valid image");
+    }
+
     if (url.parse(inputLogoUri).protocol !== 'https:') {
       throw new Error("images must be served over https.");
     }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -81,30 +81,8 @@ var types = {
     }
   },
   image: function(inputLogoUri) {
-    var dataMatches = null; // is this a valid data URI?
-    // Ideally we'd be loading this from a canonical constants library.
-    var imageMimeTypes = ['png', 'gif', 'jpg', 'jpeg', 'svg'];
-    // This regex converts valid input of the form:
-    //   'data:image/png;base64,iV...'
-    // into an array that looks like:
-    //   ['data:image/png;base64,iV...', 'image', 'png', ...]
-    // which means that mimetype proper is represented as-> [1]/[2]
-    var dataUriRegex = /^data:(.+)\/(.+);base64,(.*)$/;
-
-    dataMatches = inputLogoUri.match(dataUriRegex);
-    if (dataMatches) {
-      if ((dataMatches[1].toLowerCase() === 'image')
-           &&
-          (imageMimeTypes.indexOf(dataMatches[2].toLowerCase()) > -1)) {
-        return;
-      }
-      throw new Error("Bad data URI for siteLogo: " + inputLogoUri.slice(0, 15) + " ...");
-    }
-
-    // Regularize URL; throws error if input is relative.
-    /*jshint newcap:false*/
     if (url.parse(inputLogoUri).protocol !== 'https:') {
-      throw new Error("siteLogos can only be served from https and data schemes.");
+      throw new Error("images must be served over https.");
     }
   }
 };

--- a/lib/wsapi/stage_email.js
+++ b/lib/wsapi/stage_email.js
@@ -21,6 +21,14 @@ exports.args = {
   pass: {
     type: 'password',
     required: false
+  },
+  'backgroundColor': {
+    type: 'color',
+    required: false
+  },
+  'siteLogo': {
+    type: 'image',
+    required: false
   }
 };
 exports.i18n = true;
@@ -83,7 +91,8 @@ exports.process = function(req, res) {
 
             res.json({ success: true });
             // let's now kick out a verification email!
-            email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext);
+            email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext,
+                req.params.backgroundColor, req.params.siteLogo);
           });
         } catch(e) {
           // we should differentiate tween' 400 and 500 here.

--- a/lib/wsapi/stage_reset.js
+++ b/lib/wsapi/stage_reset.js
@@ -21,7 +21,15 @@ exports.writes_db = true;
 exports.authed = false;
 exports.args = {
   email: 'email',
-  site:  'origin'
+  site:  'origin',
+  'backgroundColor': {
+    type: 'color',
+    required: false
+  },
+  'siteLogo': {
+    type: 'image',
+    required: false
+  }
 };
 exports.i18n = true;
 
@@ -64,7 +72,8 @@ exports.process = function(req, res) {
           res.json({ success: true });
 
           // let's now kick out a verification email!
-          email.sendForgotPasswordEmail(req.params.email, req.params.site, secret, langContext);
+          email.sendForgotPasswordEmail(req.params.email, req.params.site, secret, langContext,
+              req.params.backgroundColor, req.params.siteLogo);
         });
       } catch (e) {
         // we should differentiate tween' 400 and 500 here.

--- a/lib/wsapi/stage_reverify.js
+++ b/lib/wsapi/stage_reverify.js
@@ -18,7 +18,15 @@ exports.writes_db = true;
 exports.authed = 'assertion';
 exports.args = {
   email: 'email',
-  site: 'origin'
+  site: 'origin',
+  'backgroundColor': {
+    type: 'color',
+    required: false
+  },
+  'siteLogo': {
+    type: 'image',
+    required: false
+  }
 };
 exports.i18n = true;
 
@@ -33,7 +41,7 @@ exports.process = function(req, res) {
     if (err) return res.json({ success: false, reason: err });
     if (!owned) return res.json({ success: false, reason: 'you don\'t control that email address' });
 
-    db.emailIsVerified(req.params.email, function(err, verified) { 
+    db.emailIsVerified(req.params.email, function(err, verified) {
       if (err) return res.json({ success: false, reason: err });
       if (verified) return res.json({ success: false, reason: 'email is already verified' });
 
@@ -43,13 +51,14 @@ exports.process = function(req, res) {
           if (err) return wsapi.databaseDown(res, err);
 
           var langContext = wsapi.langContext(req);
-          
+
           // store the email being reverified
           req.session.pendingReverification = secret;
-          
+
           res.json({ success: true });
           // let's now kick out a verification email!
-          email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext);
+          email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext,
+              req.params.backgroundColor, req.params.siteLogo);
         });
       } catch(e) {
         // we should differentiate tween' 400 and 500 here.

--- a/lib/wsapi/stage_transition.js
+++ b/lib/wsapi/stage_transition.js
@@ -20,7 +20,15 @@ exports.authed = false;
 exports.args = {
   email: 'email',
   site:  'origin',
-  pass:  'password'
+  pass:  'password',
+  'backgroundColor': {
+    type: 'color',
+    required: false
+  },
+  'siteLogo': {
+    type: 'image',
+    required: false
+  }
 };
 exports.i18n = true;
 
@@ -70,11 +78,12 @@ exports.process = function(req, res) {
 
             // store the email being added in session data
             req.session.pendingReset = secret;
-            
+
             res.json({ success: true });
 
             // let's now kick out a verification email!
-            email.sendTransitionEmail(req.params.email, req.params.site, secret, langContext);
+            email.sendTransitionEmail(req.params.email, req.params.site, secret, langContext,
+                req.params.backgroundColor, req.params.siteLogo);
           });
         } catch(e) {
           // we should differentiate tween' 400 and 500 here.

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -27,7 +27,15 @@ exports.args = {
     type: 'boolean',
     required: false
   },
-  'site': 'origin'
+  'site': 'origin',
+  'backgroundColor': {
+    type: 'color',
+    required: false
+  },
+  'siteLogo': {
+    type: 'image',
+    required: false
+  }
 };
 exports.i18n = true;
 
@@ -78,7 +86,8 @@ exports.process = function(req, res) {
 
             res.json({ success: true, unverified: true });
 
-            email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext);
+            email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext,
+                req.params.backgroundColor);
           });
         } else {
           // the typical flow
@@ -102,7 +111,8 @@ exports.process = function(req, res) {
             res.json({ success: true });
 
             // let's now kick out a verification email!
-            email.sendNewUserEmail(req.params.email, req.params.site, secret, langContext);
+            email.sendNewUserEmail(req.params.email, req.params.site, secret, langContext,
+                req.params.backgroundColor, req.params.siteLogo);
           });
         }
       } catch(e) {

--- a/lib/wsapi/stage_user.js
+++ b/lib/wsapi/stage_user.js
@@ -87,7 +87,7 @@ exports.process = function(req, res) {
             res.json({ success: true, unverified: true });
 
             email.sendConfirmationEmail(req.params.email, req.params.site, secret, langContext,
-                req.params.backgroundColor);
+                req.params.backgroundColor, req.params.siteLogo);
           });
         } else {
           // the typical flow

--- a/lockdown.json
+++ b/lockdown.json
@@ -40,7 +40,6 @@
     "0.3.3": "74a521e3c5c702fe1dc240e6250a2583f885227f"
   },
   "character-parser": {
-    "1.0.0": "11301d24b12b00b32185dbaf18ee19ecd23f3e8b",
     "1.0.2": "55384d6afcf8c6b9dd483e8347646a790e4545e7"
   },
   "cjson": {
@@ -138,7 +137,6 @@
     "0.1.6": "fec66b6d1c6b8cc554aa78c05ece35bef11a913f"
   },
   "escodegen": {
-    "0.0.22": "4c9ba6e9f353aaba3eccdb045e93f9543cbb739d",
     "0.0.23": "9acf978164368e42276571f18839c823b3a844df"
   },
   "esprima": {
@@ -165,7 +163,6 @@
     "1.1.1": "1f89623453123ef9623956e264c60bf4c3cf5ccf"
   },
   "glob": {
-    "3.2.1": "57af70ec73ba2323bfe3f29a067765db64c5d758",
     "3.2.3": "e313eeb249c7affaa5c475286b0e115b59839467"
   },
   "gobbledygook": {
@@ -173,7 +170,6 @@
   },
   "graceful-fs": {
     "1.1.14": "07078db5f6377f6321fceaaedf497de124dc9465",
-    "1.2.1": "b35cc6e623576fc2a278cba12c00dda6a1758d2d",
     "1.2.3": "15a4806a57547cb2d2dbf27f42e89a8c3451b364",
     "2.0.0": "c9a206f6f5f4b94e1046dfaaccfe9e12d0ab8cef"
   },
@@ -193,7 +189,6 @@
     "0.2.7": "45be2390d27af4b7613aac4ee4d957e3f4cbdb54"
   },
   "inherits": {
-    "1.0.0": "38e1975285bf1f7ba9c84da102bb12771322ac48",
     "2.0.0": "76c81b3b1c10ddee3a60bf2c247162bc369f8ba8"
   },
   "irc": {
@@ -209,7 +204,6 @@
     "0.9.1": "ff32ec7f09f84001f7498eeafd63c9e4fbb2dc0e"
   },
   "jsxgettext": {
-    "0.0.4": "7dc442c1102ba73edfaa7fd60703ab1d03234194",
     "0.1.3": "db9dd0bedd531606cdd5fd978dd75d383fd99327"
   },
   "jwcrypto": {
@@ -249,7 +243,6 @@
     "0.3.5": "de3e5f8961c88c787ee1368df849ac4413eca8d7"
   },
   "monocle": {
-    "0.1.46": "32ff9137fd3ee31d2d69a29db2f8a69389cd9860",
     "0.1.50": "9a7cbd0ccc10de95fd78a04b9beb2482ae4940b7"
   },
   "mysql": {
@@ -353,7 +346,6 @@
     "1.1.4": "2b23f1949b369ed61d22bd6570ff0320302fc8df"
   },
   "source-map": {
-    "0.1.22": "425906162f81bf110552ccc9931dba079e9f1341",
     "0.1.25": "5851545c1f4a40243829065c20e6f40b023fba1a"
   },
   "stack-trace": {
@@ -398,7 +390,7 @@
     "2.0.7": "a44c07d157a15e13d73d4af4ece6aab70f298224"
   },
   "validator": {
-    "0.4.9": "0f2421e35abe4321054383ed5cc154264a984a94"
+    "1.5.1": "7ab356cbbcbbb000ab85c43b8cda12621b1344c0"
   },
   "vm-browserify": {
     "0.0.1": "51d25979366ab219dfe35a3fc65ecd6af3631d54"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "underscore": "1.3.1",
     "urlparse": "0.0.1",
     "useragent": "2.0.7",
-    "validator": "0.4.9",
+    "validator": "1.5.1",
     "winston": "0.6.2",
     "connect-fonts": "0.0.9-alpha8",
     "connect-fonts-opensans": "0.0.3-beta1",

--- a/resources/email_templates/_footer.html.ejs
+++ b/resources/email_templates/_footer.html.ejs
@@ -1,0 +1,36 @@
+                    <tr class="spacer">
+                      <td height="20px"> </td>
+                    </tr>
+                </table><!-- /white area-->
+              </td>
+            </tr>
+
+            <tr class="spacer">
+              <td height="2px"></td>
+            </tr>
+
+            <tr>
+              <td align="center" valign="top" bgcolor="#fff" style="border-collapse: collapse; color: #3d3d3f; background-color:rgba(255,255,255,0.6);">
+                <table border="0" cellpadding="10" cellspacing="0"><!-- footer area -->
+                  <tr>
+                    <td>
+                      <%- format(gettext('<a %s><strong>Mozilla Persona.</strong></a> Simple sign-in from the non-profit behind Firefox.'), ["href='https://login.persona.org/about' target='_blank' style='color:#3d3d3f; text-decoration: none;'"]) %>
+                    </td>
+                  </tr>
+                </table><!-- /footer area -->
+              </td>
+            </tr>
+
+            <tr class="spacer">
+              <td height="60px"></td>
+            </tr>
+
+          </table><!-- /bg color area -->
+
+        </td>
+      </tr>
+    </table><!-- /body area -->
+    </center>
+  </body>
+</html>
+

--- a/resources/email_templates/_footer.html.ejs
+++ b/resources/email_templates/_footer.html.ejs
@@ -10,7 +10,7 @@
             </tr>
 
             <tr>
-              <td align="center" valign="top" bgcolor="#fff" style="border-collapse: collapse; color: #3d3d3f; background-color:rgba(255,255,255,0.6);">
+              <td align="center" valign="top" bgcolor="#fff" style="border-collapse: collapse; color: #3d3d3f; background-color: #fff; background-color:rgba(255,255,255,0.6);">
                 <table border="0" cellpadding="10" cellspacing="0"><!-- footer area -->
                   <tr>
                     <td>

--- a/resources/email_templates/_header.html.ejs
+++ b/resources/email_templates/_header.html.ejs
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Persona</title>
+        <style type="text/css">
+            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
+            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
+            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
+
+            body {
+              background: <%= backgroundColor %>;
+              margin:0;
+              padding:0;
+              width:100% !important;
+              -webkit-text-size-adjust:none;
+              font-family: Helvetica, Arial, sans-serif;
+              font-size: 14px;
+              color: #3d3f3f;
+            }
+
+            img {
+              display: block;
+              border:0;
+              height:auto;
+              line-height:100%;
+              outline:none;
+              text-decoration:none;
+            }
+
+            a {
+              color: #3d3f3f;
+              text-decoration: none;
+            }
+
+            a:hover {
+              text-decoration: underline;
+            }
+
+            p {
+              margin: 0;
+              line-height: 1.5;
+            }
+
+            table td {
+              border-collapse:collapse;
+            }
+        </style>
+  </head>
+  <body style="-webkit-text-size-adjust: none;padding:0;margin:0;">
+    <center>
+    <table border="0" cellpadding="20" cellspacing="0" height="100%" width="100%"><!-- body area -->
+      <tr style="margin: 0;
+        padding: 0;
+        height: 100% !important;
+        width: 100% !important;
+        background: <%= backgroundColor %>
+        -webkit-text-size-adjust:none;
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color: #3d3f3f;">
+        <td align="center" valign="top" style="border-collapse: collapse;" bgcolor="<%= backgroundColor %>">
+          <table border="0" cellpadding="0" cellspacing="0"><!-- bg color area -->
+            <tr class="spacer">
+              <td height="40px"></td>
+            </tr>
+
+            <tr>
+              <td width="600" align="center" valign="top" style="border-collapse: collapse;">
+                <img style="max-width: 200px; max-height: 200px;" src="<%= siteLogo || cachify('/pages/i/persona-logo-wordmark.png') %>" alt="<%= site %>" />
+              </td>
+            </tr>
+
+            <tr class="spacer">
+              <td height="10px"> </td>
+            </tr>
+
+            <tr>
+              <td width="600" align="center" valign="top" class="email-content"
+              bgcolor="#fff" style="text-align: center; border-collapse:
+              collapse; padding: 0 10px;">
+                <table border="0" cellpadding="0" cellspacing="0"><!-- white area -->
+
+                  <tr class="spacer">
+                    <td height="30px" width="600"> </td>
+                  </tr>
+
+

--- a/resources/email_templates/_header.html.ejs
+++ b/resources/email_templates/_header.html.ejs
@@ -54,7 +54,7 @@
         padding: 0;
         height: 100% !important;
         width: 100% !important;
-        background: <%= backgroundColor %>
+        background: <%= backgroundColor %>;
         -webkit-text-size-adjust:none;
         font-family: Helvetica, Arial, sans-serif;
         font-size: 14px;

--- a/resources/email_templates/_header.html.ejs
+++ b/resources/email_templates/_header.html.ejs
@@ -59,7 +59,7 @@
         font-family: Helvetica, Arial, sans-serif;
         font-size: 14px;
         color: #3d3f3f;">
-        <td align="center" valign="top" style="border-collapse: collapse;" bgcolor="<%= backgroundColor %>">
+        <td align="center" valign="top" style="border-collapse: collapse; background-color: <%= backgroundColor %>;" bgcolor="<%= backgroundColor %>">
           <table border="0" cellpadding="0" cellspacing="0"><!-- bg color area -->
             <tr class="spacer">
               <td height="40px"></td>
@@ -76,9 +76,7 @@
             </tr>
 
             <tr>
-              <td width="600" align="center" valign="top" class="email-content"
-              bgcolor="#fff" style="text-align: center; border-collapse:
-              collapse; padding: 0 10px;">
+              <td width="600" align="center" valign="top" class="email-content" bgcolor="#fff" style="text-align: center; border-collapse: collapse; padding: 0 10px; background-color: #fff;">
                 <table border="0" cellpadding="0" cellspacing="0"><!-- white area -->
 
                   <tr class="spacer">

--- a/resources/email_templates/confirm.ejs
+++ b/resources/email_templates/confirm.ejs
@@ -1,7 +1,7 @@
-<%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
 <%= link %>
 
-<%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
+<%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
 
 :::<%= gettext('Mozilla Persona') %>
 :::<%= gettext('Simple sign-in from the non-profit behind Firefox') %>

--- a/resources/email_templates/confirm.html.ejs
+++ b/resources/email_templates/confirm.html.ejs
@@ -1,113 +1,35 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Persona</title>
-        <style type="text/css">
-            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
-            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
-            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
+<% include _header.html.ejs %>
 
-            body{
-              background: #45505b;
-              margin:0;
-              padding:0;
-              width:100% !important;
-              -webkit-text-size-adjust:none;
-              font-family: Helvetica, Arial, sans-serif;
-              font-size: 14px;
-              color: #424f5a;
-            }
-            img{
-              border:0;
-              height:auto;
-              line-height:100%;
-              outline:none;
-              text-decoration:none;
-            }
-            a{
-              color: #3b9bda;
-              text-decoration: none;
-            }
-            a:hover{
-              text-decoration: underline;
-            }
-            p{
-              margin: 0 0 15px;
-              line-height: 1.5;
-            }
+  <tr>
+    <td align="center">
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+    </td>
+  </tr>
 
-            h2{
-              font-size: 18px;
-              margin: 20px 0 15px;
-            }
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-            p:last-child{
-              margin-bottom: 0;
-            }
-            table td{
-              border-collapse:collapse;
-            }
-        </style>
-  </head>
-  <body style="-webkit-text-size-adjust: none;margin: 0;padding: 0;background-color: #45505b;width: 100% !important;">
-    <center>
-    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-      <tr style="margin: 0;
-        padding: 0;
-        height: 100% !important;
-        width: 100% !important;
-        background: #45505b;
-        -webkit-text-size-adjust:none;
-        font-family: Helvetica, Arial, sans-serif;
-        font-size: 14px;
-        color: #424f5a;">
-        <td align="center" valign="top" style="border-collapse: collapse;">
+  <tr>
+    <td align="center">
+      <a href="<%= link %>" style="padding: 0 26px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px; text-decoration:none; display: inline-block; line-height: 41px;">
+        <span style="color:#fff" >
+          <%= gettext('Confirm your address now') %>
+        </span>
+      </a>
+    </td>
+  </tr>
+
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
+
+  <tr>
+    <td align="center">
+      <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
+    </td>
+  </tr>
 
 
-                <table border="0" cellpadding="0" cellspacing="0" width="90%">
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse;">
-                      <img src="<%= cachify('/pages/i/persona-logo-wordmark.png') %>" alt="Mozilla Persona" />
-                    </td>
-                  </tr>
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                </table><!-- #header -->
-                <table id="content" border="0" cellpadding="0" cellspacing="0" width="600" style="background-color: #fff; border-radius: 3px; margin-bottom: 30px;">
-                  <tr>
-                    <td align="left" valign="top" class="email-content" style="border-collapse: collapse; padding: 30px;">
-                      <p>
-                        <%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
-                      </p>
+<% include _footer.html.ejs %>
 
-                      <p>
-                        <a href="<%= link %>" style="padding: 7px 10px 6px 10px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px;"> <%= gettext('Confirm your address now') %></a>
-                      </p>
-
-                      <p>
-                        <%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
-                      </p>
-
-                    </td>
-                  </tr>
-                </table><!-- #content -->
-
-                <table border="0" cellpadding="0" cellspacing="0" width="600" style="margin-bottom: 60px;">
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse; color: #d4d4d4; padding: 0">
-                      <%- format(gettext('<strong>Mozilla Persona.</strong> Simple sign-in from the non-profit behind Firefox. <a %s>Learn more&rarr;</a>'), ["href='https://login.persona.org/about' target='_blank' style='color:#ffa274'"]) %>
-                    </td>
-                  </tr>
-                </table><!-- #footer-->
-        </td>
-      </tr>
-    </table><!-- #container table -->
-    </center>
-
-  </body>
-</html>

--- a/resources/email_templates/new.ejs
+++ b/resources/email_templates/new.ejs
@@ -1,7 +1,7 @@
-<%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
 <%= link %>
 
-<%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
+<%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
 
 :::<%= gettext('Mozilla Persona') %>
 :::<%= gettext('Simple sign-in from the non-profit behind Firefox') %>

--- a/resources/email_templates/new.html.ejs
+++ b/resources/email_templates/new.html.ejs
@@ -1,116 +1,37 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Persona</title>
-        <style type="text/css">
-            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
-            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
-            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
-
-            body{
-              background: #45505b;
-              margin:0;
-              padding:0;
-              width:100% !important;
-              -webkit-text-size-adjust:none;
-              font-family: Helvetica, Arial, sans-serif;
-              font-size: 14px;
-              color: #424f5a;
-            }
-            img{
-              border:0;
-              height:auto;
-              line-height:100%;
-              outline:none;
-              text-decoration:none;
-            }
-            a{
-              color: #3b9bda;
-              text-decoration: none;
-            }
-            a:hover{
-              text-decoration: underline;
-            }
-            p{
-              margin: 0 0 15px;
-              line-height: 1.5;
-            }
-
-            h2{
-              font-size: 18px;
-              margin: 20px 0 15px;
-            }
-
-            p:last-child{
-              margin-bottom: 0;
-            }
-            table td{
-              border-collapse:collapse;
-            }
-        </style>
-  </head>
-  <body style="-webkit-text-size-adjust: none;margin: 0;padding: 0;background-color: #45505b;width: 100% !important;">
-    <center>
-    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-      <tr style="margin: 0;
-        padding: 0;
-        height: 100% !important;
-        width: 100% !important;
-        background: #45505b;
-        -webkit-text-size-adjust:none;
-        font-family: Helvetica, Arial, sans-serif;
-        font-size: 14px;
-        color: #424f5a;">
-        <td align="center" valign="top" style="border-collapse: collapse;">
+<% include _header.html.ejs %>
 
 
-                <table border="0" cellpadding="0" cellspacing="0" width="90%">
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse;">
-                      <img src="<%= cachify('/pages/i/persona-logo-wordmark.png') %>" alt="Mozilla Persona" />
-                    </td>
-                  </tr>
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                </table><!-- #header -->
-                <table border="0" cellpadding="0" cellspacing="0" width="600" style="background-color: #fff; border-radius: 3px; margin-bottom: 30px;">
-                  <tr>
-                    <td align="left" valign="top" class="email-content" style="border-collapse: collapse;  padding: 30px;">
-                      <p>
-                        <%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
-                      </p>
+  <tr>
+    <td align="center">
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+    </td>
+  </tr>
 
-                      <p>
-                        <a href="<%= link %>" style="padding: 7px 10px 6px 10px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px;"> <%= gettext('Confirm your account now') %>
-                        </a>
-                      </p>
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-                      <p>
-                        <%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
-                      </p>
+  <tr>
+    <td align="center">
+      <a href="<%= link %>" style="padding: 0 26px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px; text-decoration:none; display: inline-block; line-height: 41px;">
+        <span style="color:#fff" >
+          <%= gettext('Confirm your account now') %>
+        </span>
+      </a>
+    </td>
+  </tr>
 
-                    </td>
-                  </tr>
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-                </table><!-- #content -->
+  <tr>
+    <td align="center">
+      <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
+    </td>
+  </tr>
 
-                <table border="0" cellpadding="0" cellspacing="0" width="600" style="margin-bottom: 60px;">
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse; color: #d4d4d4; padding: 0">
-                      <%- format(gettext('<strong>Mozilla Persona.</strong> Simple sign-in from the non-profit behind Firefox. <a %s>Learn more&rarr;</a>'), ["href='https://login.persona.org/about' target='_blank' style='color:#ffa274'"]) %>
-                    </td>
-                  </tr>
-                </table><!-- #footer-->
 
-        </td>
-      </tr>
-    </table><!-- #container table -->
-    </center>
 
-  </body>
-</html>
+<% include _footer.html.ejs %>
+

--- a/resources/email_templates/reset.ejs
+++ b/resources/email_templates/reset.ejs
@@ -3,7 +3,7 @@
 <%= gettext('Click to reset your password:') %>
 <%= link %>
 
-<%= gettext('Note: If you did NOT ask to reset your password, please ignore this email.') %>
+<%= gettext('If you were NOT attempting to reset your password, please ignore this email.') %>
 
 :::<%= gettext('Mozilla Persona') %>
 :::<%= gettext('Simple sign-in from the non-profit behind Firefox') %>

--- a/resources/email_templates/reset.html.ejs
+++ b/resources/email_templates/reset.html.ejs
@@ -1,112 +1,34 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Persona</title>
-        <style type="text/css">
-            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
-            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
-            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
+<% include _header.html.ejs %>
 
-            body{
-              background: #45505b;
-              margin:0;
-              padding:0;
-              width:100% !important;
-              -webkit-text-size-adjust:none;
-              font-family: Helvetica, Arial, sans-serif;
-              font-size: 14px;
-              color: #424f5a;
-            }
-            img{
-              border:0;
-              height:auto;
-              line-height:100%;
-              outline:none;
-              text-decoration:none;
-            }
-            a{
-              color: #3b9bda;
-              text-decoration: none;
-            }
-            a:hover{
-              text-decoration: underline;
-            }
-            p{
-              margin: 0 0 15px;
-              line-height: 1.5;
-            }
+  <tr>
+    <td align="center">
+      <%= gettext('Forgot your password for Persona? It happens to the best of us.') %>
+    </td>
+  </tr>
 
-            h2{
-              font-size: 18px;
-              margin: 20px 0 15px;
-            }
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-            p:last-child{
-              margin-bottom: 0;
-            }
-            table td{
-              border-collapse:collapse;
-            }
-        </style>
-  </head>
-  <body style="-webkit-text-size-adjust: none;margin: 0;padding: 0;background-color: #45505b;width: 100% !important;">
-    <center>
-    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-      <tr style="margin: 0;
-        padding: 0;
-        height: 100% !important;
-        width: 100% !important;
-        background: #45505b;
-        -webkit-text-size-adjust:none;
-        font-family: Helvetica, Arial, sans-serif;
-        font-size: 14px;
-        color: #424f5a;">
-        <td align="center" valign="top" style="border-collapse: collapse;">
+  <tr>
+    <td align="center">
+      <a href="<%= link %>" style="padding: 0 26px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px; text-decoration:none; display: inline-block; line-height: 41px;">
+        <span style="color:#fff" >
+          <%= gettext('Reset your password now') %>
+        </span>
+      </a>
+    </td>
+  </tr>
+
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
+
+  <tr>
+    <td align="center">
+      <%= gettext('If you were NOT attempting to reset your password, please ignore this email.') %>
+    </td>
+  </tr>
 
 
-                <table border="0" cellpadding="0" cellspacing="0" width="90%">
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse;">
-                      <img src="<%= cachify('/pages/i/persona-logo-wordmark.png') %>" alt="Mozilla Persona" />
-                    </td>
-                  </tr>
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                </table><!-- #header -->
-                <table id="content" border="0" cellpadding="0" cellspacing="0" width="600" style="background-color: #fff; border-radius: 3px; margin-bottom: 30px;">
-                  <tr>
-                    <td align="left" valign="top" class="email-content" style="border-collapse: collapse; padding: 30px;">
-                      <p><%= gettext('Forgot your password for Persona? It happens to the best of us.') %></p>
-
-                      <p>
-                        <a href="<%= link %>" style="padding: 7px 10px 6px 10px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px;"> <%= gettext('Reset your password now') %></a>
-                      </p>
-
-                      <p>
-                        <%= gettext('If you did NOT attempt to reset your password, please ignore this email.') %>
-                      </p>
-
-                    </td>
-                  </tr>
-                </table><!-- #content -->
-
-                <table border="0" cellpadding="0" cellspacing="0" width="600" style="margin-bottom: 60px;">
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse; color: #d4d4d4; padding: 0">
-                      <%- format(gettext('<strong>Mozilla Persona.</strong> Simple sign-in from the non-profit behind Firefox. <a %s>Learn more&rarr;</a>'), ["href='https://login.persona.org/about' target='_blank' style='color:#ffa274'"]) %>
-                    </td>
-                  </tr>
-                </table><!-- #footer-->
-
-        </td>
-      </tr>
-    </table><!-- #container table -->
-    </center>
-
-  </body>
-</html>
+<% include _footer.html.ejs %>

--- a/resources/email_templates/transition.ejs
+++ b/resources/email_templates/transition.ejs
@@ -1,9 +1,9 @@
 <%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
 
-<%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
 <%= link %>
 
-<%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
+<%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
 
 :::<%= gettext('Mozilla Persona') %>
 :::<%= gettext('Simple sign-in from the non-profit behind Firefox') %>

--- a/resources/email_templates/transition.html.ejs
+++ b/resources/email_templates/transition.html.ejs
@@ -1,116 +1,37 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>Persona</title>
-        <style type="text/css">
-            #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" button. */
-            body{width:100% !important;} .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
-            body{-webkit-text-size-adjust:none;} /* Prevent Webkit platforms from changing default text sizes. */
+<% include _header.html.ejs %>
 
-            body{
-              background: #45505b;
-              margin:0;
-              padding:0;
-              width:100% !important;
-              -webkit-text-size-adjust:none;
-              font-family: Helvetica, Arial, sans-serif;
-              font-size: 14px;
-              color: #424f5a;
-            }
-            img{
-              border:0;
-              height:auto;
-              line-height:100%;
-              outline:none;
-              text-decoration:none;
-            }
-            a{
-              color: #3b9bda;
-              text-decoration: none;
-            }
-            a:hover{
-              text-decoration: underline;
-            }
-            p{
-              margin: 0 0 15px;
-              line-height: 1.5;
-            }
+  <tr>
+    <td align="center">
+      <%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
+    </td>
+    <td align="center">
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+    </td>
+  </tr>
 
-            h2{
-              font-size: 18px;
-              margin: 20px 0 15px;
-            }
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-            p:last-child{
-              margin-bottom: 0;
-            }
-            table td{
-              border-collapse:collapse;
-            }
-        </style>
-  </head>
-  <body style="-webkit-text-size-adjust: none;margin: 0;padding: 0;background-color: #45505b;width: 100% !important;">
-    <center>
-    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-      <tr style="margin: 0;
-        padding: 0;
-        height: 100% !important;
-        width: 100% !important;
-        background: #45505b;
-        -webkit-text-size-adjust:none;
-        font-family: Helvetica, Arial, sans-serif;
-        font-size: 14px;
-        color: #424f5a;">
-        <td align="center" valign="top" style="border-collapse: collapse;">
+  <tr>
+    <td align="center">
+      <a href="<%= link %>" style="padding: 0 26px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px; text-decoration:none; display: inline-block; line-height: 41px;">
+        <span style="color:#fff" >
+          <%= gettext('Confirm your address now') %>
+        </span>
+      </a>
+    </td>
+  </tr>
 
+  <tr class="spacer">
+    <td height="20px"> </td>
+  </tr>
 
-                <table border="0" cellpadding="0" cellspacing="0" width="90%">
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse;">
-                      <img src="<%= cachify('/pages/i/persona-logo-wordmark.png') %>" alt="Mozilla Persona" />
-                    </td>
-                  </tr>
-                  <tr class="spacer">
-                    <td height="30px"></td>
-                  </tr>
-                </table><!-- #header -->
-                <table id="content" border="0" cellpadding="0" cellspacing="0" width="90%" style="background-color: #fff; border-radius: 3px; margin-bottom: 60px;">
-                  <tr>
-                    <td align="left" valign="top" class="email-content" style="border-collapse: collapse; padding: 30px;">
-                      <p>
-                        <%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
-                      </p>
-                      <p>
-                        <%= format(gettext('Click this confirmation link to sign in to %(site)s:'), { site: site })%>
+  <tr>
+    <td align="center">
+      <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>
+    </td>
+  </tr>
 
-                      <p>
-                        <a href="<%= link %>" style="padding: 7px 10px 6px 10px; background-color: #4eb5e5; color: #fff; font-weight: bold; border-radius: 3px;"> <%= gettext('Confirm your address now') %></a>
-                      </p>
+<% include _footer.html.ejs %>
 
-                      <p>
-                        <%= format(gettext('If you did NOT attempt to sign in to %(site)s, please ignore this email.'), { site: site }) %>
-                      </p>
-
-                    </td>
-                  </tr>
-                </table><!-- #content -->
-
-                <table border="0" cellpadding="0" cellspacing="0" width="600" style="margin-bottom: 60px;">
-                  <tr>
-                    <td align="left" valign="top" style="border-collapse: collapse; color: #d4d4d4; padding: 0">
-                      <%- format(gettext('<strong>Mozilla Persona.</strong> Simple sign-in from the non-profit behind Firefox. <a %s>Learn more&rarr;</a>'), ["href='https://login.persona.org/about' target='_blank' style='color:#ffa274'"]) %>
-                    </td>
-                  </tr>
-                </table><!-- #footer-->
-
-        </td>
-      </tr>
-    </table><!-- #container table -->
-    </center>
-
-  </body>
-</html>

--- a/resources/static/common/js/browserid.js
+++ b/resources/static/common/js/browserid.js
@@ -25,7 +25,11 @@
     PATH_MAX_LENGTH: 2048,
 
     // XHR requests are considered delayed after 10 seconds.
-    XHR_DELAY_MS: 10 * 1000
+    XHR_DELAY_MS: 10 * 1000,
+
+    // limit siteLogo's to 126kb. The backend allows up to 128kb, this leaves
+    // 2kb for the rest of the request body.
+    MAX_SITE_LOGO_SIZE: 126 * 1024
   };
 
   for (var key in constants) {

--- a/resources/static/common/js/browserid.js
+++ b/resources/static/common/js/browserid.js
@@ -27,9 +27,9 @@
     // XHR requests are considered delayed after 10 seconds.
     XHR_DELAY_MS: 10 * 1000,
 
-    // limit siteLogo's to 126kb. The backend allows up to 128kb, this leaves
-    // 2kb for the rest of the request body.
-    MAX_SITE_LOGO_SIZE: 126 * 1024
+    // limit siteLogo's to 128kb. The backend does not accept data-URI
+    // siteLogos, so this is only used for the front end.
+    MAX_SITE_LOGO_SIZE: 128 * 1024
   };
 
   for (var key in constants) {

--- a/resources/static/common/js/models/rp_info.js
+++ b/resources/static/common/js/models/rp_info.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+BrowserID.Models.RpInfo = (function() {
+  "use strict";
+
+  /**
+   * This model represents RP specific info. This is created on startup, only
+   * origin and hostname are required.
+   */
+
+  var bid = BrowserID,
+      und,
+      sc;
+
+  var Module = bid.Modules.Module.extend({
+    origin: und,
+    hostname: und,
+    backgroundColor: und,
+    siteName: und,
+    siteLogo: und,
+    privacyPolicy: und,
+    termsOfService: und,
+    allowUnverified: und,
+
+    init: function(options) {
+      var self = this;
+
+      self.importFrom(options,
+        'origin',
+        'hostname',
+        'backgroundColor',
+        'siteName',
+        'siteLogo',
+        'privacyPolicy',
+        'termsOfService',
+        'allowUnverified'
+        );
+
+      sc.init.call(self, options);
+    },
+
+    getOrigin: function() {
+      return this.origin;
+    },
+
+    getHostname: function() {
+      return this.hostname;
+    },
+
+    getBackgroundColor: function() {
+      return this.backgroundColor;
+    },
+
+    getSiteName: function() {
+      return this.siteName;
+    },
+
+    getSiteLogo: function() {
+      return this.siteLogo;
+    },
+
+    getTermsOfService: function() {
+      return this.termsOfService;
+    },
+
+    getAllowUnverified: function() {
+      return this.allowUnverified;
+    }
+  });
+
+  sc = Module.sc;
+
+  return Module;
+}());
+

--- a/resources/static/common/js/models/rp_info.js
+++ b/resources/static/common/js/models/rp_info.js
@@ -60,6 +60,13 @@ BrowserID.Models.RpInfo = (function() {
       return this.siteLogo;
     },
 
+    getEmailableSiteLogo: function() {
+      // data URI siteLogos are not universally mailable.
+      if (/^https:/.test(this.siteLogo)) {
+        return this.siteLogo;
+      }
+    },
+
     getTermsOfService: function() {
       return this.termsOfService;
     },

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -222,18 +222,21 @@ BrowserID.Network = (function() {
      * @param {string} email
      * @param {string} password
      * @param {string} origin - site user is trying to sign in to.
+     * @param {string} backgroundColor - backgroundColor to set in the email
      * @param {boolean} allowUnverified
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    createUser: function(email, password, origin, allowUnverified,
-        onComplete, onFailure) {
+    createUser: function(email, password, rpInfo, onComplete, onFailure) {
       var postData = {
         email: email,
         pass: password,
-        site : origin,
-        allowUnverified: allowUnverified
+        site : rpInfo.getOrigin(),
+        allowUnverified: rpInfo.getAllowUnverified(),
+        backgroundColor: rpInfo.getBackgroundColor(),
+        siteLogo: rpInfo.getSiteLogo()
       };
+
       stageAddressForVerification(postData, "/wsapi/stage_user", onComplete, onFailure);
     },
 
@@ -303,10 +306,12 @@ BrowserID.Network = (function() {
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    requestPasswordReset: function(email, origin, onComplete, onFailure) {
+    requestPasswordReset: function(email, rpInfo, onComplete, onFailure) {
       var postData = {
         email: email,
-        site : origin
+        site : rpInfo.getOrigin(),
+        backgroundColor: rpInfo.getBackgroundColor(),
+        siteLogo: rpInfo.getSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_reset", onComplete, onFailure);
     },
@@ -343,10 +348,12 @@ BrowserID.Network = (function() {
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    requestEmailReverify: function(email, origin, onComplete, onFailure) {
+    requestEmailReverify: function(email, rpInfo, onComplete, onFailure) {
       var postData = {
         email: email,
-        site : origin
+        site : rpInfo.getOrigin(),
+        backgroundColor: rpInfo.getBackgroundColor(),
+        siteLogo: rpInfo.getSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_reverify", onComplete, onFailure);
     },
@@ -457,11 +464,13 @@ BrowserID.Network = (function() {
      * @param {function} [onComplete] - called when complete.
      * @param {function} [onFailure] - called on xhr failure.
      */
-    addSecondaryEmail: function(email, password, origin, onComplete, onFailure) {
+    addSecondaryEmail: function(email, password, rpInfo, onComplete, onFailure) {
       var postData = {
         email: email,
         pass: password,
-        site : origin
+        site : rpInfo.getOrigin(),
+        backgroundColor: rpInfo.getBackgroundColor(),
+        siteLogo: rpInfo.getSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_email", onComplete, onFailure);
     },
@@ -707,11 +716,13 @@ BrowserID.Network = (function() {
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
-    requestTransitionToSecondary: function(email, password, origin, onComplete, onFailure) {
+    requestTransitionToSecondary: function(email, password, rpInfo, onComplete, onFailure) {
       var postData = {
         email: email,
         pass: password,
-        site : origin
+        site : rpInfo.getOrigin(),
+        backgroundColor: rpInfo.getBackgroundColor(),
+        siteLogo: rpInfo.getSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_transition", onComplete, onFailure);
     },

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -234,7 +234,7 @@ BrowserID.Network = (function() {
         site : rpInfo.getOrigin(),
         allowUnverified: rpInfo.getAllowUnverified(),
         backgroundColor: rpInfo.getBackgroundColor(),
-        siteLogo: rpInfo.getSiteLogo()
+        siteLogo: rpInfo.getEmailableSiteLogo()
       };
 
       stageAddressForVerification(postData, "/wsapi/stage_user", onComplete, onFailure);
@@ -311,7 +311,7 @@ BrowserID.Network = (function() {
         email: email,
         site : rpInfo.getOrigin(),
         backgroundColor: rpInfo.getBackgroundColor(),
-        siteLogo: rpInfo.getSiteLogo()
+        siteLogo: rpInfo.getEmailableSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_reset", onComplete, onFailure);
     },
@@ -353,7 +353,7 @@ BrowserID.Network = (function() {
         email: email,
         site : rpInfo.getOrigin(),
         backgroundColor: rpInfo.getBackgroundColor(),
-        siteLogo: rpInfo.getSiteLogo()
+        siteLogo: rpInfo.getEmailableSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_reverify", onComplete, onFailure);
     },
@@ -470,7 +470,7 @@ BrowserID.Network = (function() {
         pass: password,
         site : rpInfo.getOrigin(),
         backgroundColor: rpInfo.getBackgroundColor(),
-        siteLogo: rpInfo.getSiteLogo()
+        siteLogo: rpInfo.getEmailableSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_email", onComplete, onFailure);
     },
@@ -722,7 +722,7 @@ BrowserID.Network = (function() {
         pass: password,
         site : rpInfo.getOrigin(),
         backgroundColor: rpInfo.getBackgroundColor(),
-        siteLogo: rpInfo.getSiteLogo()
+        siteLogo: rpInfo.getEmailableSiteLogo()
       };
       stageAddressForVerification(postData, "/wsapi/stage_transition", onComplete, onFailure);
     },

--- a/resources/static/common/js/network.js
+++ b/resources/static/common/js/network.js
@@ -221,9 +221,7 @@ BrowserID.Network = (function() {
      * @method createUser
      * @param {string} email
      * @param {string} password
-     * @param {string} origin - site user is trying to sign in to.
-     * @param {string} backgroundColor - backgroundColor to set in the email
-     * @param {boolean} allowUnverified
+     * @param {object} rpInfo - info about the RP user is signing in to
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
@@ -302,7 +300,7 @@ BrowserID.Network = (function() {
      * Request a password reset for the given email address.
      * @method requestPasswordReset
      * @param {string} email
-     * @param {string} origin
+     * @param {object} rpInfo - info about the RP user is signing in to
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
@@ -344,7 +342,7 @@ BrowserID.Network = (function() {
      * Stage an email reverification.
      * @method requestEmailReverify
      * @param {string} email
-     * @param {string} origin - site user is trying to sign in to.
+     * @param {object} rpInfo - info about the RP user is signing in to
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */
@@ -460,7 +458,7 @@ BrowserID.Network = (function() {
      * @method addSecondaryEmail
      * @param {string} email
      * @param {string} password
-     * @param {string} origin
+     * @param {object} rpInfo - info about the RP user is signing in to
      * @param {function} [onComplete] - called when complete.
      * @param {function} [onFailure] - called on xhr failure.
      */
@@ -712,7 +710,7 @@ BrowserID.Network = (function() {
      * @method requestTransitionToSecondary
      * @param {string} email
      * @param {string} password
-     * @param {string} origin - site user is trying to sign in to.
+     * @param {object} rpInfo - info about the RP user is signing in to
      * @param {function} [onComplete] - Callback to call when complete.
      * @param {function} [onFailure] - Called on XHR failure.
      */

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -433,6 +433,14 @@ BrowserID.User = (function() {
     },
 
     /**
+     * Set the RP info
+     * @method setRpInfo
+     */
+    setRpInfo: function(rpInfo) {
+      this.rpInfo = rpInfo;
+    },
+
+    /**
      * Set the interface to use for networking.  Used for unit testing.
      * @method setNetwork
      * @param {BrowserID.Network} networkInterface - BrowserID.Network
@@ -531,8 +539,7 @@ BrowserID.User = (function() {
      */
     createSecondaryUser: function(email, password, onComplete, onFailure) {
       stageAddressVerification(email, password,
-        network.createUser.bind(network, email, password,
-            origin, allowUnverified), function(status) {
+        network.createUser.bind(network, email, password, this.rpInfo), function(status) {
               // If creating an unverified account, the user will not go
               // through the verification flow while the dialog is open and the
               // cache will not be updated accordingly. Update the cache now.
@@ -796,6 +803,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     requestPasswordReset: function(email, onComplete, onFailure) {
+      var rpInfo = this.rpInfo;
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a password reset.
         if (info.state === "unknown") {
@@ -807,7 +815,7 @@ BrowserID.User = (function() {
         }
         else {
           stageAddressVerification(email, null,
-            network.requestPasswordReset.bind(network, email, origin),
+            network.requestPasswordReset.bind(network, email, rpInfo),
             onComplete, onFailure);
         }
       }, onFailure);
@@ -855,7 +863,7 @@ BrowserID.User = (function() {
       else {
         // try to reverify this address.
         stageAddressVerification(email, null,
-          network.requestEmailReverify.bind(network, email, origin),
+          network.requestEmailReverify.bind(network, email, this.rpInfo),
           onComplete, onFailure);
       }
     },
@@ -892,6 +900,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     requestTransitionToSecondary: function(email, password, onComplete, onFailure) {
+      var rpInfo = this.rpInfo;
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a transition to secondary.
         if (info.state === "unknown") {
@@ -903,7 +912,7 @@ BrowserID.User = (function() {
         }
         else {
           stageAddressVerification(email, password,
-            network.requestTransitionToSecondary.bind(network, email, password, origin),
+            network.requestTransitionToSecondary.bind(network, email, password, rpInfo),
             onComplete, onFailure);
         }
       }, onFailure);
@@ -1250,7 +1259,8 @@ BrowserID.User = (function() {
      */
     addEmail: function(email, password, onComplete, onFailure) {
       stageAddressVerification(email, password,
-        network.addSecondaryEmail.bind(network, email, password, origin), onComplete, onFailure);
+        network.addSecondaryEmail.bind(network, email, password, this.rpInfo),
+          onComplete, onFailure);
     },
 
     /**

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -437,7 +437,7 @@ BrowserID.User = (function() {
      * @method setRpInfo
      */
     setRpInfo: function(rpInfo) {
-      this.rpInfo = rpInfo;
+      User.rpInfo = rpInfo;
     },
 
     /**
@@ -539,7 +539,7 @@ BrowserID.User = (function() {
      */
     createSecondaryUser: function(email, password, onComplete, onFailure) {
       stageAddressVerification(email, password,
-        network.createUser.bind(network, email, password, this.rpInfo), function(status) {
+        network.createUser.bind(network, email, password, User.rpInfo), function(status) {
               // If creating an unverified account, the user will not go
               // through the verification flow while the dialog is open and the
               // cache will not be updated accordingly. Update the cache now.
@@ -803,7 +803,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     requestPasswordReset: function(email, onComplete, onFailure) {
-      var rpInfo = this.rpInfo;
+      var rpInfo = User.rpInfo;
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a password reset.
         if (info.state === "unknown") {
@@ -863,7 +863,7 @@ BrowserID.User = (function() {
       else {
         // try to reverify this address.
         stageAddressVerification(email, null,
-          network.requestEmailReverify.bind(network, email, this.rpInfo),
+          network.requestEmailReverify.bind(network, email, User.rpInfo),
           onComplete, onFailure);
       }
     },
@@ -900,7 +900,7 @@ BrowserID.User = (function() {
      * @param {function} [onFailure] - Called on XHR failure.
      */
     requestTransitionToSecondary: function(email, password, onComplete, onFailure) {
-      var rpInfo = this.rpInfo;
+      var rpInfo = User.rpInfo;
       User.addressInfo(email, function(info) {
         // user is not known.  Can't request a transition to secondary.
         if (info.state === "unknown") {
@@ -1259,7 +1259,7 @@ BrowserID.User = (function() {
      */
     addEmail: function(email, password, onComplete, onFailure) {
       stageAddressVerification(email, password,
-        network.addSecondaryEmail.bind(network, email, password, this.rpInfo),
+        network.addSecondaryEmail.bind(network, email, password, User.rpInfo),
           onComplete, onFailure);
     },
 

--- a/resources/static/dialog/js/misc/state.js
+++ b/resources/static/dialog/js/misc/state.js
@@ -254,7 +254,8 @@ BrowserID.State = (function() {
        */
       info = _.extend({ email: self.newUserEmail || self.addEmailEmail ||
                                self.resetPasswordEmail || self.transitionNoPassword ||
-                               self.newFxAccountEmail}, info);
+                               self.newFxAccountEmail
+                      }, info);
       if(self.newUserEmail) {
         startAction(false, "doStageUser", info);
       }

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -288,6 +288,10 @@ BrowserID.Modules.Dialog = (function() {
       // no matter what, we clear the primary flow state for this window
       storage.idpVerification.clear();
 
+      params.origin = user.getOrigin();
+      var rpInfo = bid.Models.RpInfo.create(params);
+      user.setRpInfo(rpInfo);
+
       function start() {
         self.publish("start", params);
       }

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -249,6 +249,11 @@ BrowserID.Modules.ValidateRpParams = (function() {
 
     dataMatches = inputLogoUri.match(dataUriRegex);
     if (dataMatches) {
+      if (inputLogoUri.length > (bid.MAX_SITE_LOGO_SIZE)) {
+        throw new Error("data URI for siteLogo is too large, " +
+                        "max size is: " + bid.MAX_SITE_LOGO_SIZE);
+      }
+
       if ((dataMatches[1].toLowerCase() === 'image')
            &&
           (_.indexOf(imageMimeTypes, dataMatches[2].toLowerCase()) > -1)) {
@@ -256,6 +261,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
       }
       throw new Error("Bad data URI for siteLogo: " + inputLogoUri.slice(0, 15) + " ...");
     }
+
 
     // Regularize URL; throws error if input is relative.
     outputLogoUri = fixupURL(originURL, inputLogoUri);

--- a/resources/static/test/cases/common/js/models/rp_info.js
+++ b/resources/static/test/cases/common/js/models/rp_info.js
@@ -1,0 +1,36 @@
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function() {
+  var bid = BrowserID,
+      Model = bid.Models.RpInfo,
+      testHelpers = bid.TestHelpers;
+
+  module("common/js/models/rp_info", {
+    setup: function() {
+      testHelpers.setup();
+    },
+
+    teardown: function() {
+      testHelpers.teardown();
+    }
+  });
+
+  test("getEmailableSiteLogo with dataURI siteLogo - siteLogo not emailable, no logo returned", function() {
+    var model = Model.create({
+      siteLogo: "data:image/png;base64,FAKEDATA"
+    });
+
+    testHelpers.testUndefined(model.getEmailableSiteLogo());
+  });
+
+  test("getEmailableSiteLogo with https siteLogo - logo returned", function() {
+    model = Model.create({
+      siteLogo: "https://testuser.com/site_logo.png"
+    });
+
+    equal(model.getEmailableSiteLogo(), "https://testuser.com/site_logo.png");
+  });
+
+}());

--- a/resources/static/test/cases/common/js/network.js
+++ b/resources/static/test/cases/common/js/network.js
@@ -10,6 +10,7 @@
       user = bid.User,
       network = bid.Network,
       testHelpers = bid.TestHelpers,
+      RpInfo = bid.Models.RpInfo,
       TEST_EMAIL = "testuser@testuser.com",
       TEST_PASSWORD = "password",
       failureCheck = testHelpers.failureCheck,
@@ -57,11 +58,12 @@
       args.push("password");
     }
 
-    args.push("origin");
+    var rpInfo = RpInfo.create({
+      origin: "testuser.com",
+      allowUnverified: !!config.unverified
+    });
 
-    if (config.unverified) {
-      args.push(false);
-    }
+    args.push(rpInfo);
 
     args.push(onComplete, onFailure || testHelpers.unexpectedFailure);
     return args;

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -149,7 +149,7 @@
 
     asyncTest(stageFuncName + " with XHR failure", function() {
       storage.addEmail(TEST_EMAIL);
-      var args = [lib[stageFuncName], TEST_EMAIL];
+      var args = [lib[stageFuncName].bind(lib), TEST_EMAIL];
       if (config.password) args.push(config.password);
 
       failureCheck.apply(null, args);

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -149,7 +149,7 @@
 
     asyncTest(stageFuncName + " with XHR failure", function() {
       storage.addEmail(TEST_EMAIL);
-      var args = [lib[stageFuncName].bind(lib), TEST_EMAIL];
+      var args = [lib[stageFuncName], TEST_EMAIL];
       if (config.password) args.push(config.password);
 
       failureCheck.apply(null, args);

--- a/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
@@ -68,14 +68,18 @@
     _.extend(options, {
       ready: function() {
         options.originURL = domain || HTTPS_TEST_DOMAIN;
+        var receivedError;
         try {
           controller.validate(options);
           ok(false);
         } catch(error) {
-          if (expectedErrorMessage)
-            equal(error.message, expectedErrorMessage, "expected error: " + expectedErrorMessage);
-
+          receivedError = error;
         }
+
+        ok(receivedError);
+
+        if (expectedErrorMessage)
+          equal(receivedError.message, expectedErrorMessage, "expected error: " + expectedErrorMessage);
 
         // If a parameter is not properly escaped, scriptRun will be true.
         equal(typeof window.scriptRun, "undefined", "script was not run");
@@ -252,6 +256,15 @@
 
   asyncTest("get with data:<not image>... siteLogo - not allowed", function() {
     var URL = "data:text/html;base64,FAKEDATA";
+    testExpectValidationFailure({siteLogo: URL});
+  });
+
+  asyncTest("get with too large of a data:image... siteLogo - not allowed",
+      function() {
+    var URL = "data:image/png;base64,";
+    for(var i = 0; i < bid.MAX_SITE_LOGO_SIZE; i++) {
+      URL += (i % 10);
+    }
     testExpectValidationFailure({siteLogo: URL});
   });
 

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -19,6 +19,7 @@ BrowserID.TestHelpers = (function() {
       provisioning = bid.Mocks.Provisioning,
       screens = bid.Screens,
       tooltip = bid.Tooltip,
+      RpInfo = bid.Models.RpInfo,
       registrations = [],
       calls = {},
       testOrigin = "https://login.persona.org";
@@ -102,6 +103,11 @@ BrowserID.TestHelpers = (function() {
         provisioning: provisioning
       });
       user.setOrigin(testOrigin);
+      var rpInfo = RpInfo.create({
+        origin: testOrigin,
+        allowUnverified: false
+      });
+      user.setRpInfo(rpInfo);
       moduleManager.stopAll();
       moduleManager.reset();
     },

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -156,6 +156,8 @@
     <script src="/common/js/state_machine.js"></script>
     <script src="/common/js/models/models.js"></script>
     <script src="/common/js/models/interaction_data.js"></script>
+    <script src="/common/js/models/rp_info.js"></script>
+
 
     <script src="/common/js/modules/dom_module.js"></script>
     <script src="/common/js/modules/page_module.js"></script>

--- a/resources/views/test.ejs
+++ b/resources/views/test.ejs
@@ -219,6 +219,7 @@
     <script src="cases/common/js/state_machine.js"></script>
 
     <script src="cases/common/js/models/interaction_data.js"></script>
+    <script src="cases/common/js/models/rp_info.js"></script>
 
     <script src="cases/common/js/modules/module.js"></script>
     <script src="cases/common/js/modules/dom_module.js"></script>

--- a/tests/lib/secondary.js
+++ b/tests/lib/secondary.js
@@ -12,7 +12,9 @@ exports.create = function(opts, cb) {
   wcli.post(wsapi.configuration, '/wsapi/stage_user', wsapi.context, {
     email: opts.email,
     pass:  opts.password,
-    site:  opts.site
+    site:  opts.site,
+    backgroundColor: opts.backgroundColor,
+    siteLogo: opts.siteLogo
   }, function(err, r) {
     if (err) return cb("cannot stage: " + err);
     if (r.code !== 200) return cb("cannot stage: " + r.body);

--- a/tests/post-limiting-test.js
+++ b/tests/post-limiting-test.js
@@ -21,6 +21,9 @@ var suite = vows.describe('post-limiting');
 // disable vows (often flakey?) async error behavior
 suite.options.error = false;
 
+// Set a max post size of 128kb to accommodate data URIs when staging users.
+const MAX_POST_SIZE = 1024 * 128;
+
 start_stop.addStartupBatches(suite);
 
 var code_version;
@@ -41,9 +44,9 @@ function request(opts, done) {
 }
 
 function addTests(port, path) {
-  // test posting more than 10kb
+  // test posting more than allowed
   suite.addBatch({
-    "posting more than 10kb": {
+    "posting more than allowed": {
       topic: function()  {
         var cb = this.callback;
         getVersion(function() {
@@ -60,7 +63,7 @@ function addTests(port, path) {
           }).on('error', function (e) {
             cb(e);
           });
-          req.write(secrets.weakGenerate(1024 * 10 + 1));
+          req.write(secrets.weakGenerate(MAX_POST_SIZE + 1));
           req.end();
         });
       },
@@ -70,9 +73,9 @@ function addTests(port, path) {
     }
   });
 
-  // test posting more than 10kb with content-length header
+  // test posting more than allowed with content-length header
   suite.addBatch({
-    "posting more than 10kb with content-length": {
+    "posting more than allowed with content-length": {
       topic: function()  {
         var cb = this.callback;
         getVersion(function() {
@@ -82,7 +85,7 @@ function addTests(port, path) {
             path: path,
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded',
-              'Content-Length': 1024 * 10 + 1
+              'Content-Length': MAX_POST_SIZE + 1
             },
             method: "POST"
           }, function (res) {
@@ -90,7 +93,7 @@ function addTests(port, path) {
           }).on('error', function (e) {
             cb(e);
           });
-          req.write(secrets.weakGenerate(1024 * 10 + 1));
+          req.write(secrets.weakGenerate(MAX_POST_SIZE + 1));
           req.end();
         });
       },

--- a/tests/post-limiting-test.js
+++ b/tests/post-limiting-test.js
@@ -21,8 +21,7 @@ var suite = vows.describe('post-limiting');
 // disable vows (often flakey?) async error behavior
 suite.options.error = false;
 
-// Set a max post size of 128kb to accommodate data URIs when staging users.
-const MAX_POST_SIZE = 1024 * 128;
+const MAX_POST_SIZE = 1024 * 10;
 
 start_stop.addStartupBatches(suite);
 

--- a/tests/rp-branded-emails-test.js
+++ b/tests/rp-branded-emails-test.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+require('./lib/test_env.js');
+
+const assert        = require('assert'),
+      vows          = require('vows'),
+      start_stop    = require('./lib/start-stop.js'),
+      secondary     = require('./lib/secondary.js'),
+      wsapi         = require('./lib/wsapi.js'),
+      secrets       = require('../lib/secrets.js'),
+      email         = require('../lib/email.js');
+
+const FIRST_EMAIL   = secrets.weakGenerate(12) + '@somedomain.com',
+      SECOND_EMAIL  = secrets.weakGenerate(12) + '@otherdomain.com',
+      TEST_PASS     = 'thisismypassword',
+      TEST_SITE     = 'https://fakesite.com';
+
+var generatedEmails;
+function interceptor(email, site, secret, emails) {
+  assert.ok(false);
+  generatedEmails = emails;
+}
+
+var suite = vows.describe('rp-branded-emails');
+
+start_stop.addStartupBatches(suite);
+
+suite.addBatch({
+  "/wsapi/stage_user with invalid backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_user', {
+      email: FIRST_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: 'g',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_user with invalid siteLogo": {
+    topic: wsapi.post('/wsapi/stage_user', {
+      email: FIRST_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: "http://invalid.protocol/site_logo.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_user with valid backgroundColor and siteLogo": {
+    topic: function() {
+      secondary.create({
+        email: FIRST_EMAIL,
+        pass: TEST_PASS,
+        site: TEST_SITE,
+        backgroundColor: '#fedcba',
+        siteLogo: TEST_SITE + "/rp_background.png"
+      }, this.callback);
+    },
+    "succeeds": function(err, r) {
+      assert.equal(r.code, 200);
+    }
+  }
+});
+
+
+suite.addBatch({
+  "/wsapi/stage_email with invalid backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_email', {
+      email: SECOND_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: 'g',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_email with invalid siteLogo": {
+    topic: wsapi.post('/wsapi/stage_email', {
+      email: SECOND_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: "http://invalid.protocol/site_logo.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_email with valid siteLogo and backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_email', {
+      email: SECOND_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "succeeds": function(err, r) {
+      assert.equal(r.code, 200);
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_reset with invalid backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_reset', {
+      email: SECOND_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: 'g',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_reset with invalid siteLogo": {
+    topic: wsapi.post('/wsapi/stage_reset', {
+      email: SECOND_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: "http://invalid.protocol/site_logo.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_reset with valid backgroundColor and siteLogo": {
+    topic: wsapi.post('/wsapi/stage_reset', {
+      email: SECOND_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "succeeds": function(err, r) {
+      assert.equal(r.code, 200);
+    }
+  }
+});
+
+
+suite.addBatch({
+  "/wsapi/stage_reverify with invalid backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_reverify', {
+      email: FIRST_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: 'g',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_reverify with invalid siteLogo": {
+    topic: wsapi.post('/wsapi/stage_reverify', {
+      email: FIRST_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: "http://invalid.protocol/site_logo.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_reverify with valid backgroundColor and siteLogo": {
+    topic: wsapi.post('/wsapi/stage_reverify', {
+      email: FIRST_EMAIL,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "succeeds": function(err, r) {
+      assert.equal(r.code, 200);
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_transition with invalid backgroundColor": {
+    topic: wsapi.post('/wsapi/stage_transition', {
+      email: SECOND_EMAIL,
+      site: TEST_SITE,
+      pass: TEST_PASS,
+      backgroundColor: 'g',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_transition with invalid siteLogo": {
+    topic: wsapi.post('/wsapi/stage_transition', {
+      email: SECOND_EMAIL,
+      pass: TEST_PASS,
+      site: TEST_SITE,
+      backgroundColor: '#fedcba',
+      siteLogo: "http://invalid.protocol/site_logo.png"
+    }),
+    "fails": function(err, r) {
+      assert.equal(r.code, 400);
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+    }
+  }
+});
+
+suite.addBatch({
+  "/wsapi/stage_transition with valid backgroundColor and siteLogo": {
+    topic: wsapi.post('/wsapi/stage_transition', {
+      email: SECOND_EMAIL,
+      site: TEST_SITE,
+      pass: TEST_PASS,
+      backgroundColor: '#fedcba',
+      siteLogo: TEST_SITE + "/rp_background.png"
+    }),
+    "succeeds": function(err, r) {
+      assert.equal(r.code, 200);
+    }
+  }
+});
+
+
+start_stop.addShutdownBatches(suite);
+
+// run or export the suite.
+if (process.argv[1] === __filename) suite.run();
+else suite.export(module);
+

--- a/tests/rp-branded-emails-test.js
+++ b/tests/rp-branded-emails-test.js
@@ -19,12 +19,6 @@ const FIRST_EMAIL   = secrets.weakGenerate(12) + '@somedomain.com',
       TEST_PASS     = 'thisismypassword',
       TEST_SITE     = 'https://fakesite.com';
 
-var generatedEmails;
-function interceptor(email, site, secret, emails) {
-  assert.ok(false);
-  generatedEmails = emails;
-}
-
 var suite = vows.describe('rp-branded-emails');
 
 start_stop.addStartupBatches(suite);
@@ -56,7 +50,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: images must be served over https.");
     }
   }
 });
@@ -106,7 +100,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: images must be served over https.");
     }
   }
 });
@@ -151,7 +145,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: images must be served over https.");
     }
   }
 });
@@ -196,7 +190,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: images must be served over https.");
     }
   }
 });
@@ -242,7 +236,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: siteLogos can only be served from https and data schemes.");
+      assert.equal(JSON.parse(r.body).reason, "siteLogo: Error: images must be served over https.");
     }
   }
 });

--- a/tests/rp-branded-emails-test.js
+++ b/tests/rp-branded-emails-test.js
@@ -34,7 +34,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: ValidatorError: Invalid hexcolor");
     }
   }
 });
@@ -84,7 +84,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: ValidatorError: Invalid hexcolor");
     }
   }
 });
@@ -130,7 +130,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: ValidatorError: Invalid hexcolor");
     }
   }
 });
@@ -175,7 +175,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: ValidatorError: Invalid hexcolor");
     }
   }
 });
@@ -220,7 +220,7 @@ suite.addBatch({
     }),
     "fails": function(err, r) {
       assert.equal(r.code, 400);
-      assert.equal(JSON.parse(r.body).reason, "backgroundColor: Error: not a valid color: g");
+      assert.equal(JSON.parse(r.body).reason, "backgroundColor: ValidatorError: Invalid hexcolor");
     }
   }
 });


### PR DESCRIPTION
- Create a new model on the front end, rp_info.js, to keep things sane.
- Add new backend validation types: color and image
- Add backend tests to check backgroundColor and siteLogo
- Update the copy in HTML and text emails as per @ryanfeeley's suggestions.
- Loads of email styling updates to work across webmail and mobile.
- Use a common _header.html.ejs and _footer.html.ejs shared across all emails so updates are simpler
- Simplify the email template configuration - only specify the template filename, not the full path.
