### PR TITLE
Ensure the window.close event is always sent along with the KPI event stream it belongs to.

### DIFF
--- a/resources/static/communication_iframe/start.js
+++ b/resources/static/communication_iframe/start.js
@@ -133,10 +133,24 @@
   });
 
   chan.bind("dialog_complete", function(trans, checkAuthStatus) {
+    // dialog_complete is called whenever either an error occurred, the dialog
+    // was closed, or if an assertion was generated. It is called before
+    // dialog_close. Processing can occur in the dialog after the
+    // dialog_complete message is called.
     pause = false;
-    // The dialog has closed, so that we get results from users who only open
-    // the dialog a single time, send the KPIs immediately. Note, this does not
-    // take care of native contexts. Native contexts are taken care of in in
+    if (checkAuthStatus) {
+      // the dialog running can change authentication status,
+      // lets manually purge our network cache
+      user.clearContext();
+      checkAndEmit();
+    }
+  });
+
+  chan.bind("dialog_close", function(trans) {
+    // The dialog has closed & no more processing will occur.
+    // So that we get results from users who only open the dialog a single
+    // time, send the KPIs immediately. Note, this does not take care of
+    // native contexts. Native contexts are taken care of in in
     // dialog/js/misc/internal_api.js. Errors sending the KPI data should not
     // affect anything else.
     try {
@@ -154,11 +168,6 @@
       }
     } catch(e) {}
 
-    if (checkAuthStatus) {
-      // the dialog running can change authentication status,
-      // lets manually purge our network cache
-      user.clearContext();
-      checkAndEmit();
-    }
   });
+
 }());

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -281,7 +281,9 @@ BrowserID.Modules.Dialog = (function() {
 
 
       // XXX Perhaps put this into the state machine.
-      self.bind(self.window, "unload", onWindowUnload);
+      // use the beforeunload instead of unload or else IE8 does not have time
+      // to write the final KPIs to localStorage
+      self.bind(self.window, "beforeunload", onWindowUnload);
 
       self.publish("channel_established");
 

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -375,7 +375,7 @@
           return REQUIRES_WATCH;
         }
       }
-      
+
       if (!isSupported()) {
         var reason = noSupportReason();
         var url = "unsupported_dialog";
@@ -468,6 +468,9 @@
           if (options && options.oncancel) options.oncancel();
           delete options.oncancel;
         }
+      }, function() {
+        // Called on window close.
+        commChan.notify({ method: 'dialog_close' });
       });
     };
 


### PR DESCRIPTION
@kparlante, @6a68 and @seanmonstar - I could use some review here! Scary update to WinChan, I have yet to put a PR against that repo. Do you think this can be done another way using the existing callbacks, or does a new callback make more sense?

We incorrectly made the assumption that if a message was received by WinChan from the dialog, that all dialog processing was complete. This had the effect that if an assertion was generated in the dialog, a message with the assertion was sent to WinChan, _include.js took this as meaning all processing was complete in the dialog, and told the communication_iframe to submit the KPIs. The KPI event stream was cleared, and then the dialog would close, causing window.unload to be added to the recently cleared event stream.

To fix this, I added a new optional callback, close_cb, as input to WinChan.open. This callback is triggered due to a new 'close' message that is postMessage'd from the dialog's unload event handler. close_cb is then hooked up to send a message to the communication_iframe that the dialog is closed and that is _now_ safe to send the KPIs.

In addition, IE8 was unable to write the window.unload event to the event stream from the window.unload event handler. Instead, writing this final event must be done in window.beforeunload.

fixes #3794
