### PR TITLE
[load_gen] improve details on failures to show original request and response code and body

### DIFF
--- a/bin/load_gen
+++ b/bin/load_gen
@@ -218,8 +218,8 @@ function poll() {
             completed[act][2]++;
           } else {
             completed[act][1]++;
-            winston.error('('+act+') ' + err.toString());
           }
+          winston.error('('+act+') ' + err.toString());
         } else {
           completed[act][0]++;
         }

--- a/lib/load_gen/activities/add_email.js
+++ b/lib/load_gen/activities/add_email.js
@@ -76,7 +76,8 @@ exports.startFunc = function(cfg, cb) {
           if (err) return cb(err);
 
           if (r.body.success !== true) {
-            return cb(common.error('failed to complete email addition for: ' + email, null, token));
+            r.token = token; // for logging
+            return cb(common.error('failed to complete email addition for: ' + email, null, r));
           }
 
           // and now we should call registration status to complete the
@@ -87,7 +88,7 @@ exports.startFunc = function(cfg, cb) {
             err = common.checkResponse(err, r);
             if (err) return cb(err);
             if (r.body.status !== 'complete') {
-              return cb(common.error("registration_status failed during signup"));
+              return cb(common.error("registration_status failed during signup", null, r));
             }
 
             // now generate a key

--- a/lib/load_gen/activities/change_pass.js
+++ b/lib/load_gen/activities/change_pass.js
@@ -45,7 +45,7 @@ exports.startFunc = function(cfg, cb) {
     }, function (err, r) {
       err = common.checkResponse(err, r);
       if (err) return cb(err);
-      if (!r.body.success) return cb(common.error("password update failed"));
+      if (!r.body.success) return cb(common.error("password update failed", null, r));
       cb(null);
     });
   });

--- a/lib/load_gen/activities/interaction_data.js
+++ b/lib/load_gen/activities/interaction_data.js
@@ -6,7 +6,9 @@
  * this file is the "interaction_data" activity, which simulates 
  * the load of the client passing on interaction data for kpi metrics */
 
-var client = require('../../wsapi_client.js');
+const
+client = require('../../wsapi_client.js'),
+common = require('../common');
 
 var blob = { data: 
   { "event_stream":[["window.dom_loading",972],
@@ -43,17 +45,12 @@ var blob = { data:
 };
 
 exports.startFunc = function(cfg, cb) {
-
   client.post(cfg, '/wsapi/interaction_data', {}, blob, function(err, r) {
-    if (err) {
-      cb(err);
-    } else if (!r || r.code !== 200) {
-      cb("for interaction_data post response code is not 200: " + (r ? r.code : "no response"));
-    } else if (r.body !== '{"success":true}' ){
-      cb("interaction_data post not successful");
-    } else {
-      cb();
+    err = common.checkResponse(err, r);
+    if (err) return cb(err);
+    if (r.body.success !== true) {
+      return cb(common.error("interaction_data post not successful", null, r));
     }
+    cb();
   });
-  
 };

--- a/lib/load_gen/activities/reset_pass.js
+++ b/lib/load_gen/activities/reset_pass.js
@@ -82,7 +82,7 @@ exports.startFunc = function(cfg, cb) {
         err = common.checkResponse(err, r);
         if (err) return cb(err);
         if (r.body.success !== true) {
-          return cb(common.error("failed to complete user creation"));
+          return cb(common.error("failed to complete user creation", null, r));
         }
         // and now let's log in with this email address
         common.authAndKey(cfg, user, context, email, function(err) {

--- a/lib/load_gen/activities/signup.js
+++ b/lib/load_gen/activities/signup.js
@@ -82,7 +82,7 @@ exports.startFunc = function(cfg, cb) {
         if (err) return cb(err);
 
         if (r.body.success !== true) {
-          return cb(common.error("failed to complete user creation"));
+          return cb(common.error("failed to complete user creation", null, r));
         }
 
         // and now let's log in with this email address

--- a/lib/load_gen/common.js
+++ b/lib/load_gen/common.js
@@ -20,11 +20,7 @@ exports.auth = function(cfg, user, ctx, email, cb) {
         err = exports.checkResponse(err, r);
         if (err) return cb(err);
         if (r.body.success !== true) {
-          var detail = '';
-          if (typeof r.body === 'object') {
-            detail = " - " + JSON.stringify(r.body);
-          }
-          return cb(new LoadGenError("non-success response " + r.code + detail));
+          return cb(new LoadGenError("failed to auth user: " + email, null, r));
         }
         ctx.session.authenticated = true;
         cb();
@@ -87,7 +83,9 @@ exports.genAssertionAndVerify = function(cfg, user, ctx, email, audience, cb) {
       }, function (err, r) {
         err = exports.checkResponse(err, r);
         if (err) return cb(err);
-        if (r.body.status !== 'okay') return cb(new LoadGenError("verification failed with: " + r.body.reason));
+        if (r.body.status !== 'okay') {
+          return cb(new LoadGenError("verification failed", null, r));
+        }
         cb(null);
       });
     });
@@ -100,24 +98,36 @@ function LoadGenError(message, code, details) {
   this.code = code || "unknown";
   if (details) this.details = details;
 }
+
 LoadGenError.prototype = new Error();
-LoadGenError.prototype.toString = function() {
-  return this.code + ": " + this.message + (this.details ? "\n> " + this.details : "");
-};
 LoadGenError.prototype.constructor = LoadGenError;
-exports.error = function(m, c, d) {
-  return new LoadGenError(m, c, d);
+
+LoadGenError.prototype.toString = function() {
+  var str = this.code + ": " + this.message;
+  if (this.details) {
+    var clone = JSON.parse(JSON.stringify(this.details));
+    delete clone.headers; // TMI, usually
+    str += " >>> " + JSON.stringify(clone);
+  }
+  return str;
+};
+
+exports.error = function(message, code, details) {
+  return new LoadGenError(message, code, details);
 };
 
 // check an error parameter and http response for an error
 exports.checkResponse = function(err, resp) {
+  if (err) return new LoadGenError(err);
+  if (!resp) return new LoadGenError("null http response object");
+
   var e;
-  if (err) e = new LoadGenError(err);
-  else if (!resp) e = new LoadGenError("null http response object");
-  else if (!resp.body) e = new LoadGenError("null response body");
-  else if (resp.code === 503) e = new LoadGenError("too busy", "serverTooBusy");
-  else if (resp.code !== 200) {
-    e = new LoadGenError("non 200 response code: " + resp.code, "responseNotOk");
+  if (resp.code === 503) {
+    e = new LoadGenError("too busy", "serverTooBusy", resp);
+  } else if (resp.code !== 200) {
+    e = new LoadGenError("non 200 response code", "responseNotOk", resp);
+  } else if (!resp.body) {
+    e = new LoadGenError("null response body", null, resp);
   }
 
   // no error so far?  let's parse the response body
@@ -125,7 +135,7 @@ exports.checkResponse = function(err, resp) {
     try {
       resp.body = JSON.parse(resp.body);
     } catch(exc) {
-      e = new LoadGenError("non-json response body", "nonJSON", resp.body);
+      e = new LoadGenError("non-json response body", "nonJSON", resp);
     }
   }
 

--- a/lib/wsapi_client.js
+++ b/lib/wsapi_client.js
@@ -27,6 +27,23 @@ function startRequest() {
 }
 exports.recentLatency = function() { return recentLatency; };
 
+function summarizeRequestFromResponse(res) {
+  var req = {};
+
+  if (res && res.client && res.client._httpMessage) {
+    var message = res.client._httpMessage;
+    req.method = message.method;
+    if (message._headers) {
+      req.host = message._headers.host;
+    }
+    req.path = message.path;
+
+    return JSON.parse(JSON.stringify(req));
+  }
+
+  return req;
+}
+
 function completeRequest(startTime) {
   numberOfRequests++;
   var num = numberOfRequests < LATENCY_DECAY ? numberOfRequests : LATENCY_DECAY;
@@ -116,7 +133,8 @@ exports.get = function(cfg, path, context, getArgs, cb) {
       res.on('data', function(chunk) { body += chunk; })
       .on('end', function() {
         completeRequest(timingHandle);
-        cb(null, {code: res.statusCode, headers: res.headers, body: body});
+        var req = summarizeRequestFromResponse(res);
+        cb(null, {code: res.statusCode, headers: res.headers, body: body, req: req});
         cb = null;
       });
     }).on('error', function (e) {
@@ -197,7 +215,8 @@ exports.post = function(cfg, path, context, postArgs, cb) {
         res.on('data', function(chunk) { body += chunk; })
         .on('end', function() {
           completeRequest(timingHandle);
-          cb(null, {code: res.statusCode, headers: res.headers, body: body});
+          var req = summarizeRequestFromResponse(res);
+          cb(null, {code: res.statusCode, headers: res.headers, body: body, req: req});
           cb = null;
         });
       }).on('error', function (e) {


### PR DESCRIPTION
When running load_gen, there are occasionally errors reported, which I'm pretty sure are database replication races. I don't believe that these actually happen in production (for the most part). The load_gen tool inherently does sequences of wsapi calls that a real user would never perform at the same speed. 

However, the errors are reported with so little detail that it's not possible to trace them. So this PR increases the errors to always show the response code and body, and the request method, host and URI.

Before:

```
error: (signup) responseNotOk: non 200 response code: 400
error: (signup) unknown: null response body
```

After:

```
error: (signup) responseNotOk: non 200 response code >>> {"code":400,"body":"Bad Request: that email does not belong to you","req":{"method":"POST","host":"login.anosrep.org","path":"/wsapi/cert_key"}}
error: (signup) responseNotOk: non 200 response code >>> {"code":400,"body":"","req":{"method":"GET","host":"login.anosrep.org","path":"/wsapi/fake_verification?email=foo%40loadtest.domain"}}
```
