### PR TITLE
Remove the window.unload event in the KPI event stream.

### DIFF
--- a/resources/static/common/js/modules/interaction_data.js
+++ b/resources/static/common/js/modules/interaction_data.js
@@ -81,7 +81,6 @@ BrowserID.Modules.InteractionData = (function() {
    *   may be a couple of exceptions).
    * window.redirect_to_primary - the user has to authenticate with their
    *   IdP so they are being redirected away.
-   * window.unload - the last thing in every event stream.
    * generate_assertion - the order was given to generate an assertion.
    * assertion_generated - the assertion generation is complete -
    *   these two together are useful to measure how long crypto is taking
@@ -103,7 +102,6 @@ BrowserID.Modules.InteractionData = (function() {
     cancel_state: "screen.cancel",
     primary_user_authenticating: "window.redirect_to_primary",
     dom_loading: "window.dom_loading",
-    window_unload: "window.unload",
     channel_established: "window.channel_established",
     user_can_interact: "user.can_interact",
     generate_assertion: null,

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -159,11 +159,6 @@ BrowserID.Modules.Dialog = (function() {
     win.location = returnTo;
   }
 
-  function onWindowUnload() {
-    /*jshint validthis: true*/
-    this.publish("window_unload");
-  }
-
   function publishKpis(rpAPI) {
     /*jshint validthis: true*/
 
@@ -280,9 +275,6 @@ BrowserID.Modules.Dialog = (function() {
         user.setReturnTo(params.returnTo);
 
 
-      // XXX Perhaps put this into the state machine.
-      self.bind(self.window, "unload", onWindowUnload);
-
       self.publish("channel_established");
 
       // no matter what, we clear the primary flow state for this window
@@ -308,12 +300,6 @@ BrowserID.Modules.Dialog = (function() {
         start();
       }
     }
-
-    // BEGIN TESTING API
-    ,
-    onWindowUnload: onWindowUnload
-    // END TESTING API
-
   });
 
   sc = Dialog.sc;

--- a/resources/static/test/cases/dialog/js/modules/dialog.js
+++ b/resources/static/test/cases/dialog/js/modules/dialog.js
@@ -329,25 +329,6 @@
     });
   });
 
-  asyncTest("onWindowUnload", function() {
-    createController({
-      ready: function() {
-        var error;
-
-        try {
-          controller.onWindowUnload();
-        }
-        catch(e) {
-          error = e;
-        }
-
-        equal(typeof error, "undefined", "unexpected error thrown when unloading window (" + error + ")");
-        start();
-      }
-    });
-  });
-
-
   asyncTest("get with invalid RP parameter (termsOfService) - print error screen", function() {
     testRelativeURLNotAllowed({
       termsOfService: "relative.html",


### PR DESCRIPTION
@kparlante - this is a PR with the alternate proposal to remove the window.close event.

If we do not need the event for KPI processing, this allows us to avoid making changes to WinChan - see issue #3861

issue #3794
