### PR TITLE
3778 - verify app://{guid} urls

### DIFF
--- a/lib/verifier/certassertion.js
+++ b/lib/verifier/certassertion.js
@@ -55,6 +55,16 @@ function compareAudiences(want, got) {
     // case 1 & 1a
     // (app:// urls are seen on FirefoxOS desktop and possibly mobile)
     if (/^(?:https?|app):\/\//.test(got)) {
+      // If want and got are equal, then success.
+      if (want === got) {
+        return undefined;
+      }
+
+      // If they are not equal, parse them and see if they are equivalent.
+      // Note that urls like app://{guid} from FirefoxOS will not parse like
+      // normal urls.  They won't have a hostname. But that shouldn't matter in
+      // the case of guids: They should have been found equal in the test
+      // above.
       var gu = normalizeParsedURL(url.parse(got));
       got_scheme = gu.protocol;
       got_domain = gu.hostname;
@@ -73,12 +83,15 @@ function compareAudiences(want, got) {
     }
     if (!got_domain) throw "domain missing";
 
-    // now parse "want" url
+    // now parse "want" url - the url that was extracted from the assertion
     want = normalizeParsedURL(url.parse(want));
 
     // compare the parts explicitly provided by the client
     if (got_scheme && got_scheme !== want.protocol) throw "scheme mismatch";
     if (got_port && got_port !== want.port) throw "port mismatch";
+
+    // We unconditionally test domain equality; testing this last is crucial
+    // for ensuring that the provided origin isn't the empty string.
     if (got_domain !== want.hostname) throw "domain mismatch";
 
     return undefined;

--- a/tests/verifier-test.js
+++ b/tests/verifier-test.js
@@ -76,7 +76,11 @@ suite.addBatch({
     'http://fakesite.com:80 and http://fakesite.com:8000': matchesAudience(false),
     'https://fakesite.com:443 and https://fakesite.com:9000': matchesAudience(false),
 
-    'app://browser.gaiamobile.org and app://browser.gaiamobile.org:80': matchesAudience(true)
+    'app://browser.gaiamobile.org and app://browser.gaiamobile.org:80': matchesAudience(true),
+    'app://marketplace.firefox.com and app://marketplace.firefox.com': matchesAudience(true),
+    'app://{5041b155-d1c0-4957-9914-c3af6aa41cf1} and app://{5041b155-d1c0-4957-9914-c3af6aa41cf1}': matchesAudience(true), 
+    'app://{5041b155-d1c0-4957-9914-c3af6aa41cf1} and app://{5041b155-d1c0-4957-9914-c3af6aa41cf2}': matchesAudience(false), 
+    'app://marketplace.firefox.com and app://{5041b155-d1c0-4957-9914-c3af6aa41cf2}': matchesAudience(false)
   }
 });
 


### PR DESCRIPTION
This patch lets us use origins of the form `app://{guid}` with the verifier.

This should address some of the problems in Issue #3778
