### PR TITLE
groups simultaneous requests to the same resource

### DIFF
--- a/resources/static/common/js/modules/xhr.js
+++ b/resources/static/common/js/modules/xhr.js
@@ -275,7 +275,7 @@ BrowserID.Modules.XHR = (function() {
 
   function triggerHandlers(handlers, resp, xhrObj, textResponse) {
     for (var i = 0; i < handlers.length; i++) {
-      complete(handlers[i], resp, xhrObj, textResponse);
+      complete(handlers[i], _.extend({}, resp), xhrObj, textResponse);
     }
   }
 

--- a/resources/static/common/js/modules/xhr.js
+++ b/resources/static/common/js/modules/xhr.js
@@ -273,9 +273,11 @@ BrowserID.Modules.XHR = (function() {
     return errorInfo;
   }
 
-  function triggerHandlers(handlers, resp, xhrObj, textResponse) {
+  function triggerHandlers(handlers, response, xhrObj, textResponse) {
     for (var i = 0; i < handlers.length; i++) {
-      complete(handlers[i], _.extend({}, resp), xhrObj, textResponse);
+      var resp = response;
+      if (typeof resp === 'object') resp = _.extend({}, resp);
+      complete(handlers[i], resp, xhrObj, textResponse);
     }
   }
 

--- a/resources/static/common/js/modules/xhr.js
+++ b/resources/static/common/js/modules/xhr.js
@@ -86,16 +86,8 @@ BrowserID.Modules.XHR = (function() {
      *
      * @method getExistingRequest
      */
-    getExistingRequest: getExistingRequest,
+    getExistingRequest: getExistingRequest
 
-    /**
-     * If an existing request was not found, then we store the created
-     * one so that it can be found again. Don't worry, we'll be sure to
-     * cleanup after ourselves in all cases.
-     *
-     * @method setExistingRequest
-     */
-    setExistingRequest: setExistingRequest
   });
 
   sc = XHR.sc;
@@ -110,7 +102,6 @@ BrowserID.Modules.XHR = (function() {
 
     self.outstandingRequests = {};
     self.outstandingTimers = [];
-    self.existingRequests = {};
     self.transport = config.transport || XHRTransport;
     self.time_until_delay = config.time_until_delay;
 
@@ -164,8 +155,6 @@ BrowserID.Modules.XHR = (function() {
 
     var request = getRequestInfo(options);
 
-    self.setExistingRequest(request);
-
     // The request obj must be added to list of outstanding requests in
     // case request is synchronous. This makes sure all housekeeping is kept in
     // order.
@@ -201,17 +190,13 @@ BrowserID.Modules.XHR = (function() {
 
   function getExistingRequest(options) {
     /*jshint validthis: true*/
-  
     if (options.type === "GET") {
-      return this.existingRequests[options.url];
-    }
-  }
-
-  function setExistingRequest(request) {
-    /*jshint validthis: true*/
-
-    if (request.type === "GET") {
-      this.existingRequests[request.url] = request;
+      for (var key in this.outstandingRequests) {
+        var request = this.outstandingRequests[key];
+        if (request.type === "GET" && request.url === options.url) {
+          return request;
+        }
+      }
     }
   }
 
@@ -254,10 +239,6 @@ BrowserID.Modules.XHR = (function() {
       outstandingRequests[eventTime].xhr.abort();
       outstandingRequests[eventTime] = null;
       delete outstandingRequests[eventTime];
-    }
-
-    for (var existingRequest in self.existingRequests) {
-      delete self.existingRequests[existingRequest];
     }
 
     // abort any outstanding response timers
@@ -361,10 +342,6 @@ BrowserID.Modules.XHR = (function() {
     var outstandingRequests = this.outstandingRequests;
     outstandingRequests[request.eventTime] = null;
     delete outstandingRequests[request.eventTime];
-
-    if (request.type === "GET" && this.existingRequests[request.url]) {
-      delete this.existingRequests[request.url];
-    }
 
     var timer = request.slowRequestTimeout;
     if (timer) {

--- a/resources/static/test/cases/common/js/modules/xhr.js
+++ b/resources/static/test/cases/common/js/modules/xhr.js
@@ -13,6 +13,7 @@
       mediator = bid.Mediator,
       testHelpers = bid.TestHelpers;
 
+
   module("common/js/modules/xhr", {
     setup: function() {
       transport.setDelay(0);
@@ -298,5 +299,48 @@
 
   });
 
+  asyncTest("multiple GETs to the same resource use 1 request", function() {
+    var first;
+    xhr.get({
+      url: "/slow_request",
+      error: testHelpers.unexpectedXHRFailure,
+      success: function(info) {
+        first = info.time;
+      }
+    });
+
+    setTimeout(function() {
+      xhr.get({
+        url: "/slow_request",
+        error: testHelpers.unexpectedXHRFailure,
+        success: function(info) {
+          equal(info.time, first, "used same request");
+          start();
+        }
+      });
+    }, 100);
+  });
+
+  asyncTest("multiple GETs to the different resources DONT use same request", function() {
+    var first;
+    xhr.get({
+      url: "/slow_request?foo",
+      error: testHelpers.unexpectedXHRFailure,
+      success: function(info) {
+        first = info.time;
+      }
+    });
+
+    setTimeout(function() {
+      xhr.get({
+        url: "/slow_request?bar",
+        error: testHelpers.unexpectedXHRFailure,
+        success: function(info) {
+          notEqual(info.time, first, "used separate requests");
+          start();
+        }
+      });
+    }, 100);
+  });
 
 }());

--- a/resources/static/test/mocks/xhr.js
+++ b/resources/static/test/mocks/xhr.js
@@ -21,6 +21,14 @@ BrowserID.Mocks.xhr = (function() {
   // this cert is meaningless, but it has the right format
   var random_cert = "eyJhbGciOiJSUzEyOCJ9.eyJpc3MiOiJpc3N1ZXIuY29tIiwiZXhwIjoxMzE2Njk1MzY3NzA3LCJwdWJsaWMta2V5Ijp7ImFsZ29yaXRobSI6IlJTIiwibiI6IjU2MDYzMDI4MDcwNDMyOTgyMzIyMDg3NDE4MTc2ODc2NzQ4MDcyMDM1NDgyODk4MzM0ODExMzY4NDA4NTI1NTk2MTk4MjUyNTE5MjY3MTA4MTMyNjA0MTk4MDA0NzkyODQ5MDc3ODY4OTUxOTA2MTcwODEyNTQwNzEzOTgyOTU0NjUzODEwNTM5OTQ5Mzg0NzEyNzczMzkwMjAwNzkxOTQ5NTY1OTAzNDM5NTIxNDI0OTA5NTc2ODMyNDE4ODkwODE5MjA0MzU0NzI5MjE3MjA3MzYwMTA1OTA2MDM5MDIzMjk5NTYxMzc0MDk4OTQyNzg5OTk2NzgwMTAyMDczMDcxNzYwODUyODQxMDY4OTg5ODYwNDAzNDMxNzM3NDgwMTgyNzI1ODUzODk5NzMzNzA2MDY5IiwiZSI6IjY1NTM3In0sInByaW5jaXBhbCI6eyJlbWFpbCI6InRlc3R1c2VyQHRlc3R1c2VyLmNvbSJ9fQ.aVIO470S_DkcaddQgFUXciGwq2F_MTdYOJtVnEYShni7I6mqBwK3fkdWShPEgLFWUSlVUtcy61FkDnq2G-6ikSx1fUZY7iBeSCOKYlh6Kj9v43JX-uhctRSB2pI17g09EUtvmb845EHUJuoowdBLmLa4DSTdZE-h4xUQ9MsY7Ik";
 
+  var slowResponse = function(xhrObj) {
+    xhrObj._delayTimeout = setTimeout(function() {
+      if (xhrObj._request.success) {
+        xhrObj._request.success({ success: true, time: + new Date() });
+      }
+    }, 1000);
+  };
+
   /**
    * This is the responses table, the keys are the request type, url, and
    * a "selector" for testing.  The right is the expected return value, already
@@ -257,13 +265,10 @@ BrowserID.Mocks.xhr = (function() {
       "post /wsapi/interaction_data throttle": 413,
       "post /wsapi/interaction_data ajaxError": undefined,
       // request used to test the abortAll functionality of xhr.js
-      "get /slow_request valid": function(xhrObj) {
-        xhrObj._delayTimeout = setTimeout(function() {
-          if (xhrObj._request.success) {
-            xhrObj._request.success({ success: true });
-          }
-        }, 1000);
-      }
+      "get /slow_request valid": slowResponse,
+      // used to be sure different params dont share same request
+      "get /slow_request?foo valid": slowResponse,
+      "get /slow_request?bar valid": slowResponse
     },
 
     setContextInfo: function(field, value) {


### PR DESCRIPTION
If we ever make more than 1 GET request to the same resource (including GET params), this will group them together into a single request. While the request is mid-flight, additional requests to the same resource will not start a new one, but add their listeners to the existing request.

This may not happen often, but when it does, we most likely never want the requests to be separate.

This likely fixes #3872, since right now, the dialog can sometimes call `/wsapi/session_context` twice at the start, one for `interaction_data`, and one for `cookie_check`. This is the likely cause of a race condition where both pass their empty session cookie, both requests generate a CSRF token, and then after one returns, we start a new request using the first token, but by then the second request finished and changed our cookie. Gross!
