### PR TITLE
3579 - Feura Sans is now Fira Sans on FirefoxOS

### DIFF
--- a/resources/static/dialog/css/m.css
+++ b/resources/static/dialog/css/m.css
@@ -21,12 +21,13 @@
 
   /* Remove background image gradients set in style.css which cause
    * horizontal lines to appear while the dialog is loading.
-   * Set the default font to Feura Sans
+   * Set the default font to Fira Sans, which used to be called
+   * Feura Sans, so support both.
    */
   body {
     height: 100%;
     background: #eff0f2 none;
-    font-family: 'Feura Sans', 'Open Sans', 'Lucida Sans', 'Lucida Grande', 'Lucida Sans Unicode', Verdana, sans-serif;
+    font-family: 'Fira Sans', 'Feura Sans', 'Open Sans', 'Lucida Sans', 'Lucida Grande', 'Lucida Sans Unicode', Verdana, sans-serif;
   }
 
   /**


### PR DESCRIPTION
Fixes issue #3579.

Tested this by pushing it to https://train0619.personatest.org/ and pointing my unagi phone to it.  No more Feura Sans warnings.

@shane-tomlinson Did I miss any other changes that should be made?

(Phone is running latest mozilla-central trunk with gaia master)
