### PR TITLE
update to awsbox 0.5.4 - mitigates #3899

### DIFF
--- a/lockdown.json
+++ b/lockdown.json
@@ -22,7 +22,7 @@
     "0.2.0": "c55013856c8194ec854a0cbec90aab5a04ce3ac5"
   },
   "awsbox": {
-    "0.5.3": "0145a4eda4d6d9d70fcca363d6e89892c4af4dec"
+    "0.5.4": "ac88be60ddb0bdfe923cd8b02697c92d81eb692f"
   },
   "awssum": {
     "1.1.0": "e010144aa516af78eca01352aab9203b816611bb"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "vows": "0.5.13",
-    "awsbox": "0.5.3",
+    "awsbox": "0.5.4",
     "irc": "0.3.3",
     "jshint": "0.9.1",
     "which": "1.0.5",


### PR DESCRIPTION
as stated, unblocks automated testing against ephemeral/dev instances.  Also, lots of regression fixes that will improve usability: https://github.com/mozilla/awsbox/blob/v0.5.4/ChangeLog#L1-L8

/cc @jrgm @shane-tomlinson @chilts 
