### PR TITLE
always decode returnTo before redirect

### DIFF
--- a/resources/static/common/js/helpers.js
+++ b/resources/static/common/js/helpers.js
@@ -101,6 +101,10 @@
     return String(email).replace(emailRe, "");
   }
 
+  function redirect(win, returnTo) {
+    win.location = decodeURI(returnTo);
+  }
+
   _.extend(helpers, {
     isObject: function(arg) {
       return Object.prototype.toString.apply(arg) === "[object Object]";
@@ -173,7 +177,17 @@
      */
     log: log,
 
-    getDomainFromEmail: getDomainFromEmail
+    getDomainFromEmail: getDomainFromEmail,
+
+    /**
+     * Since we always encode returnTo, we need to decode it before
+     * redirecting the page. Using this helper makes sure we always
+     * decode first.
+     * @method redirect
+     * @param {window} win
+     * @param {string} returnTo
+     */
+    redirect: redirect
   });
 
 

--- a/resources/static/common/js/modules/development.js
+++ b/resources/static/common/js/modules/development.js
@@ -9,6 +9,7 @@ BrowserID.Modules.Development = (function() {
       dom = bid.DOM,
       renderer = bid.Renderer,
       storage = bid.Storage,
+      redirect = bid.Helpers.redirect,
       user = bid.User,
       clickCount = 0;
 
@@ -110,7 +111,7 @@ BrowserID.Modules.Development = (function() {
 
     if (href) {
       bid.module.stopAll();
-      document.location = href;
+      redirect(document, href);
     }
   }
 

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -10,6 +10,7 @@ BrowserID.Modules.Dialog = (function() {
       user = bid.User,
       errors = bid.Errors,
       storage = bid.Storage,
+      redirect = bid.Helpers.redirect,
       sc;
 
   function startActions(onsuccess, onerror) {
@@ -156,7 +157,7 @@ BrowserID.Modules.Dialog = (function() {
      * address bar.
      */
     storage.rpRequest.clear();
-    win.location = returnTo;
+    redirect(win, returnTo);
   }
 
   function publishKpis(rpAPI) {

--- a/resources/static/dialog/js/modules/verify_primary_user.js
+++ b/resources/static/dialog/js/modules/verify_primary_user.js
@@ -10,6 +10,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
       errors = bid.Errors,
       helpers = bid.Helpers,
       dialogHelpers = helpers.Dialog,
+      redirect = helpers.redirect,
       complete = helpers.complete,
       storage = bid.Storage,
       CANCEL_SELECTOR = ".cancel",
@@ -33,7 +34,7 @@ BrowserID.Modules.VerifyPrimaryUser = (function() {
     });
 
     var url = helpers.toURL(self.auth_url, { email: self.email });
-    self.window.document.location = url;
+    redirect(self.window.document, url);
     complete(callback);
   }
 

--- a/resources/static/pages/js/reset_password.js
+++ b/resources/static/pages/js/reset_password.js
@@ -13,6 +13,7 @@ BrowserID.resetPassword = (function() {
       pageHelpers = bid.PageHelpers,
       dom = bid.DOM,
       helpers = bid.Helpers,
+      redirect = helpers.redirect,
       complete = helpers.complete,
       validation = bid.Validation,
       tooltip = bid.Tooltip,
@@ -82,7 +83,7 @@ BrowserID.resetPassword = (function() {
                 "logged_in", self.email);
 
             countdownTimeout.call(self, function() {
-              self.doc.location = self.redirectTo;
+              redirect(self.doc, self.redirectTo);
               complete(oncomplete, verified);
             });
           });

--- a/resources/static/pages/js/verify_secondary_address.js
+++ b/resources/static/pages/js/verify_secondary_address.js
@@ -13,6 +13,7 @@ BrowserID.verifySecondaryAddress = (function() {
       pageHelpers = bid.PageHelpers,
       dom = bid.DOM,
       helpers = bid.Helpers,
+      redirect = helpers.redirect,
       complete = helpers.complete,
       validation = bid.Validation,
       tooltip = bid.Tooltip,
@@ -50,7 +51,7 @@ BrowserID.verifySecondaryAddress = (function() {
           storage.site.set(URLParse(self.redirectTo).originOnly(),
               "logged_in", self.email);
 
-          self.doc.location = self.redirectTo;
+          redirect(self.doc, self.redirectTo);
           complete(oncomplete, verified);
         }
         else {

--- a/resources/static/test/cases/common/js/helpers.js
+++ b/resources/static/test/cases/common/js/helpers.js
@@ -194,4 +194,13 @@
     equal(helpers.isArray(""), false);
     equal(helpers.isArray(arguments), false);
   });
+
+  test("redirect", function() {
+    var win = {};
+    helpers.redirect(win, "http://example.com");
+    equal(win.location, "http://example.com");
+
+    helpers.redirect(win, "http://example.com?don%2527t");
+    equal(win.location, 'http://example.com?don%27t');
+  });
 }());


### PR DESCRIPTION
It turns out there are a couple places we do show the `returnTo` address, and to be sure we aren't carrying around potentially data, we'll continue to encode it as soon as we get it. So to fix this issue though, before redirecting, we'll always _de_code it, so it's back to the original value an RP passed.

fixes #3903
