### PR TITLE
Test fails on tests/post-limiting-test.js (on some combinations of distro/kernel/nodejs version)

### DIFF
--- a/tests/post-limiting-test.js
+++ b/tests/post-limiting-test.js
@@ -67,7 +67,7 @@ function addTests(port, path) {
         });
       },
       "fails": function (err) {
-        assert.ok(/socket hang up/.test(err.toString()));
+	assert.ok(/Error: (socket hang up|read ECONNRESET)/.test(err.toString()));
       }
     }
   });


### PR DESCRIPTION
In ubuntu version 12.04.2/12.04.3 , I see that sometimes (but not always) ECONNRESET is returned instead of 'socket hang up' .

So 'tests/post-limiting-test.js' needs to be edited to expect either 'socket hang up' or ECONNRESET. Then only will it be able to pass all the tests. For purposes of the test, changing the test to accept either failure message is fine.

So I edited the line 70 of the 'tests/post-limiting-test.js' as:
     assert.ok(/Error: (socket hang up|read ECONNRESET)/.test(err.toString()));

This will ensure that the post-limiting-test.js is passed.
