### PR TITLE
evaluate nothing in include.js when native support is available

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -116,13 +116,6 @@
 
   if (!navigator.id) {
     navigator.id = {};
-    // Is there a native implementation on this platform?
-    // If so, hook navigator.id onto it.
-    if (navigator.mozId) {
-      navigator.id = navigator.mozId;
-    } else {
-      navigator.id = {};
-    }
   }
 
   if (!navigator.id.request || navigator.id._shimmed) {

--- a/scripts/create_include.js
+++ b/scripts/create_include.js
@@ -31,10 +31,16 @@ module.exports = function(done) {
     output += '\n(function() {\n';
     // define undefined in case the RP has accidentally redefined undefined.
     output += '\tvar undefined;\n';
+    // if native support exists, use it and abort all further evaluation.
+    output += '\tif (navigator.mozId) { navigator.id = navigator.mozId; }\n';
+    output += '\telse { (function() {\n';
+    output += '\tvar undefined;\n';
     output += fs.readFileSync(path.join(dir, '_jschannel.js'));
     output += fs.readFileSync(path.join(winchan_dir, 'winchan.js'));
     output += fs.readFileSync(path.join(dir, '_include.js'));
-    output += '}());\n';
+    output += '\t}());\n'; // end inner function
+    output += '\t}\n'; // end else
+    output += '}());\n'; // end outer function
 
     fs.writeFileSync(target, output);
   } catch(e) {


### PR DESCRIPTION
There's no reason to evaluate a bunch of code when we have native support.  let's abort earlier.

Also, there's no reason to test for .request when .mozId is defined - this affords greater flexibility in native implementations.
