### PR TITLE
`main_site` and `stagedOnBehalfOf` localStorage fields no longer used, can be removed.

### DIFF
--- a/resources/static/common/js/storage.js
+++ b/resources/static/common/js/storage.js
@@ -78,11 +78,9 @@ BrowserID.Storage = (function() {
       emailToUserID: {},
       emails: {},
       interaction_data: {},
-      main_site: {},
       managePage: {},
       returnTo: null,
       siteInfo: {},
-      stagedOnBehalfOf: null,
       usersComputer: {}
     }, function(defaultVal, key) {
       if (!storage[key]) {


### PR DESCRIPTION
`main_site` and `stagedOnBehalfOf` localStorage fields removed from /resources/static/common/js/storage.js as they are no longer used.

Fixes issue #3855.
