### PR TITLE
internal.setPersistent sets `remember` field instead of `logged_in` field to indicate user wants a silent assertion.

### DIFF
--- a/resources/static/dialog/js/misc/internal_api.js
+++ b/resources/static/dialog/js/misc/internal_api.js
@@ -61,7 +61,7 @@
 
     user.checkAuthentication(function(authenticated) {
       if (authenticated) {
-        storage.site.set(origin, "remember", true);
+        storage.site.set(origin, "logged_in", true);
       }
 
       complete(!!authenticated || null);

--- a/resources/static/test/cases/dialog/js/misc/internal_api.js
+++ b/resources/static/test/cases/dialog/js/misc/internal_api.js
@@ -55,7 +55,7 @@
     internal.setPersistent(ORIGIN, function(status) {
       strictEqual(status, null, "user is not authenticated should not succeed in setting persistent");
 
-      testUndefined(storage.site.get(ORIGIN, "remember"), "remember status not set");
+      testUndefined(storage.site.get(ORIGIN, "logged_in"), "logged_in status not set");
       testUndefined(storage.site.get(ORIGIN, "email"), "email not set");
       start();
     });
@@ -66,7 +66,7 @@
       internal.setPersistent(ORIGIN, function(status) {
         equal(status, true, "setPersistent status reported as true");
 
-        equal(storage.site.get(ORIGIN, "remember"), true, "remember status set to true");
+        equal(storage.site.get(ORIGIN, "logged_in"), true, "logged_in status set to true");
         start();
       });
     });


### PR DESCRIPTION
In  `resources/static/test/cases/dialog/js/misc/internal_api.js` and `resources/static/dialog/js/misc/internal_api.js` , internal.setPersistent sets `remember` field instead of `logged_in` field to indicate user wants a silent assertion.

This means users signing in using internal API are not getting the full goodness of silent assertions.

So we should replace 'remember' field with 'logged_in' field.

internal.setPersistent function is defined in `resources/static/dialog/js/misc/internal_api.js`.

Fixes Issue #3856.
