### PR TITLE
[chrome] box-shadow does not show above and below the arrow

### DIFF
--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -303,7 +303,8 @@ section > .contents {
 
 #signIn .table {
     background-color: #f9f9f9;
-    box-shadow: 0px 0px 20px -11px #000;
+    border-right:1px solid #bfbfbf;
+    box-shadow: 0px 1px 5px 6px #dfdfdf;
     padding: 0 20px;
 }
 


### PR DESCRIPTION
Fixes Issue #3712.

UI Problem solved (when user resizes the window, box-shadow shows above and below the arrow).

![screenshot from 2013-10-04 01 38 51](https://f.cloud.github.com/assets/2356369/1265068/2d62c864-2c69-11e3-8753-c4d5beecacbc.png)
