### PR TITLE
a stateless "goldilocks" api

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,9 +4,9 @@ Ben Adida <ben@adida.net>
 Brian J Brennan <brianloveswords@gmail.com>
 Brian Warner <warner-github@lothar.com>
 Bryan Clark <clarkbw@gmail.com>
-Dan Callahan <dan.callahan@gmail.com>
 Christian Kakesa <christian.kakesa@gmail.com>
 Crystal Beasley <crystal@mozilla.com>
+Dan Callahan <dan.callahan@gmail.com>
 Dan Mills <thunder@mozilla.com>
 David Burns <dburns@mozilla.com>
 Dirkjan Ochtman <dirkjan@ochtman.nl>
@@ -27,6 +27,7 @@ Mariusz Cieśla <mariusz@dotmariusz.net>
 Matjaž Horvat <matjaz.horvat@gmail.com>
 Michael Hanson <mhanson@gmail.com>
 Milos Dinic <milos@mozilla.com>
+Mohit Agarwal <mohit.agarwal019@gmail.com>
 Pete Fritchman <petef@databits.net>
 Peter deHaan <pdehaan@mozilla.com>
 Richard Soderberg <rsoderberg@gmail.com>

--- a/resources/static/common/js/models/rp_info.js
+++ b/resources/static/common/js/models/rp_info.js
@@ -32,6 +32,7 @@ BrowserID.Models.RpInfo = (function() {
     returnTo: und,
     issuer: 'default',
     emailHint: und,
+    rpAPI: und,
 
     init: function(options) {
       var self = this;
@@ -47,6 +48,7 @@ BrowserID.Models.RpInfo = (function() {
         'termsOfService',
         'allowUnverified',
         'returnTo',
+        'rpAPI',
         'emailHint'
         );
 
@@ -104,6 +106,10 @@ BrowserID.Models.RpInfo = (function() {
 
     isDefaultIssuer: function() {
       return this.issuer === "default";
+    },
+
+    getRpAPI: function() {
+      return this.rpAPI;
     },
 
     getEmailHint: function() {

--- a/resources/static/common/js/user.js
+++ b/resources/static/common/js/user.js
@@ -1471,7 +1471,11 @@ BrowserID.User = (function() {
        */
       var rpInfo = User.rpInfo;
       User.checkAuthenticationAndSync(function(authenticated) {
-        var loggedInEmail = storage.site.get(rpInfo.getOrigin(), "logged_in");
+        var origin = rpInfo.getOrigin();
+        var loggedInEmail = storage.site.get(origin, "logged_in");
+        if (!loggedInEmail) {
+          loggedInEmail = storage.site.get(origin, "one_time");
+        }
         // User is not signed in to Persona or not signed into the site.
         if (!(authenticated && loggedInEmail))
           return complete(onComplete, null, null);
@@ -1495,8 +1499,10 @@ BrowserID.User = (function() {
           // generated.
           // If there has been an issuer change, this will check with the new
           // issuer to make sure the user is authenticated there.
-          User.getAssertion(loggedInEmail, rpInfo.getOrigin(),
-              function(assertion) {
+          User.getAssertion(loggedInEmail, origin, function(assertion) {
+            if (assertion) {
+              storage.site.remove(origin, "one_time");
+            }
             complete(onComplete, assertion ? loggedInEmail : null, assertion);
           }, onFailure);
         });

--- a/resources/static/dialog/css/style.css
+++ b/resources/static/dialog/css/style.css
@@ -303,7 +303,8 @@ section > .contents {
 
 #signIn .table {
     background-color: #f9f9f9;
-    box-shadow: 0px 0px 20px -11px #000;
+    border-right:1px solid #bfbfbf;
+    box-shadow: 0px 1px 5px 6px #dfdfdf;
     padding: 0 20px;
 }
 

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -108,6 +108,9 @@ BrowserID.Modules.Dialog = (function() {
         // added.  If there are no args, then do not do self.get.
         if (args) {
           self.get(origin, args.params, function(r) {
+            // assertion being passed through WinChan, so we have
+            // fulfilled the `one_time` assertion promise.
+            storage.site.remove(origin, "one_time");
             cb(r);
           }, function (e) {
             cb(null);

--- a/resources/static/dialog/js/modules/generate_assertion.js
+++ b/resources/static/dialog/js/modules/generate_assertion.js
@@ -26,13 +26,18 @@ BrowserID.Modules.GenerateAssertion = (function() {
       self.checkRequired(options, "email", "rpInfo");
 
       var email = options.email,
-          origin = options.rpInfo.getOrigin();
+          origin = options.rpInfo.getOrigin(),
+          isOneTime = options.rpInfo.getRpAPI() === "stateless";
 
       user.getAssertion(email, origin, function(assertion) {
         assertion = assertion || null;
 
         if (assertion) {
-          storage.site.set(origin, "logged_in", email);
+          if (isOneTime) {
+            storage.site.set(origin, "one_time", email);
+          } else {
+            storage.site.set(origin, "logged_in", email);
+          }
         }
 
         self.publish("assertion_generated", {

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -276,6 +276,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
     var VALID_RP_API_VALUES = [
       "watch_without_onready",
       "watch_with_onready",
+      "stateless",
       "get",
       "getVerifiedEmail",
       "internal"

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -299,7 +299,6 @@
       }
 
       if (!options.onlogin) throw new Error("'onlogin' is a required argument to navigator.id.watch()");
-      if (!options.onlogout) throw new Error("'onlogout' is a required argument to navigator.id.watch()");
 
       observers.login = options.onlogin || null;
       observers.logout = options.onlogout || null;
@@ -319,7 +318,8 @@
       var rp_api = api_called;
       if (rp_api === "request") {
         if (observers.ready) rp_api = "watch_with_onready";
-        else rp_api = "watch_without_onready";
+        else if (observers.onlogout) rp_api = "watch_without_onready";
+        else rp_api = "stateless";
       }
 
       return rp_api;
@@ -339,7 +339,7 @@
       }
 
       options.rp_api = getRPAPI();
-      var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request');
+      var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request' || api_called === 'auth');
 
       // reset the api_called in case the site implementor changes which api
       // method called the next time around.

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -116,13 +116,6 @@
 
   if (!navigator.id) {
     navigator.id = {};
-    // Is there a native implementation on this platform?
-    // If so, hook navigator.id onto it.
-    if (navigator.mozId) {
-      navigator.id = navigator.mozId;
-    } else {
-      navigator.id = {};
-    }
   }
 
   if (!navigator.id.request || navigator.id._shimmed) {

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -1196,6 +1196,19 @@
     }, testHelpers.unexpectedXHRFailure);
   });
 
+  asyncTest("getSilentAssertion with one_time API", function() {
+    var LOGGED_IN_EMAIL = TEST_EMAIL;
+
+    lib.syncEmailKeypair(LOGGED_IN_EMAIL, function() {
+      storage.site.set(lib.rpInfo.getOrigin(), "one_time", LOGGED_IN_EMAIL);
+      lib.getSilentAssertion(null, function(email, assertion) {
+        equal(email, LOGGED_IN_EMAIL, "correct email");
+        equal(storage.site.get(lib.rpInfo.getOrigin(), "one_time"), undefined, "one_time flag removed");
+        testAssertion(assertion, start);
+      }, testHelpers.unexpectedXHRFailure);
+    }, testHelpers.unexpectedXHRFailure);
+  });
+
   asyncTest("logoutUser", function(onSuccess) {
     lib.authenticate(TEST_EMAIL, "testuser", function(authenticated) {
       lib.syncEmails(function() {

--- a/resources/static/test/cases/dialog/js/modules/generate_assertion.js
+++ b/resources/static/test/cases/dialog/js/modules/generate_assertion.js
@@ -12,9 +12,11 @@
       xhr = bid.Mocks.xhr,
       user = bid.User;
 
+  var ORIGIN = "http://testuser.com";
+
   function createController(config) {
     config = _.extend({
-      origin: "http://testuser.com"
+      origin: ORIGIN
     }, config);
 
     var rpInfo = bid.Models.RpInfo.create(config);
@@ -48,6 +50,46 @@
         email: "testuser@testuser.com",
         ready: function() {
           ok(assertion, "assertion generated");
+          start();
+        }
+      });
+    });
+  });
+
+  asyncTest("generated assertion should set logged_in on site", function() {
+    var EMAIL = "testuser@testuser.com";
+    user.syncEmailKeypair(EMAIL, function() {
+      var assertion;
+      mediator.subscribe("assertion_generated", function(msg, info) {
+        assertion = info.assertion;
+      });
+
+      createController({
+        email: EMAIL,
+        ready: function() {
+          ok(assertion, "assertion generated");
+          equal(storage.site.get(ORIGIN, "logged_in"), EMAIL);
+          start();
+        }
+      });
+    });
+  });
+
+  asyncTest("generated assertion when rpAPI is 'stateless' should set one_time on site", function() {
+    var EMAIL = "testuser@testuser.com";
+    user.syncEmailKeypair(EMAIL, function() {
+      var assertion;
+      mediator.subscribe("assertion_generated", function(msg, info) {
+        assertion = info.assertion;
+      });
+
+      createController({
+        email: EMAIL,
+        rpAPI: "stateless",
+        ready: function() {
+          ok(assertion, "assertion generated");
+          equal(storage.site.get(ORIGIN, "one_time"), EMAIL, "one_time bit set");
+          equal(storage.site.get(ORIGIN, "logged_in"), undefined, "logged in not set");
           start();
         }
       });

--- a/scripts/create_include.js
+++ b/scripts/create_include.js
@@ -31,10 +31,16 @@ module.exports = function(done) {
     output += '\n(function() {\n';
     // define undefined in case the RP has accidentally redefined undefined.
     output += '\tvar undefined;\n';
+    // if native support exists, use it and abort all further evaluation.
+    output += '\tif (navigator.mozId) { navigator.id = navigator.mozId; }\n';
+    output += '\telse { (function() {\n';
+    output += '\tvar undefined;\n';
     output += fs.readFileSync(path.join(dir, '_jschannel.js'));
     output += fs.readFileSync(path.join(winchan_dir, 'winchan.js'));
     output += fs.readFileSync(path.join(dir, '_include.js'));
-    output += '}());\n';
+    output += '\t}());\n'; // end inner function
+    output += '\t}\n'; // end else
+    output += '}());\n'; // end outer function
 
     fs.writeFileSync(target, output);
   } catch(e) {


### PR DESCRIPTION
keeps current watch() api, but makes it "stateless" if RP doesn't want
session management. to indicate this, simply don't pass an `onlogout`
handler to watch().

navigator.id.watch({ onlogin: function(assertion) {} });
navigator.id.request(optionsAsNormal);
