### PR TITLE
a stateless "goldilocks" api

### DIFF
--- a/example/rp/get.html
+++ b/example/rp/get.html
@@ -56,7 +56,7 @@ pre {
 
 <div class="intro">
   This is a RP for testing, it allows you to drive the <tt>navigator.id.get()</tt> call manually
-  to locally test Persona. Looking to test <a href="/">navigator.id.watch</a>?
+  to locally test Persona. Looking to test <a href="/index.html">stateless "goldilocks"</a> or <a href="/">navigator.id.watch</a>?
 </div>
 
 <div class="specify">

--- a/example/rp/watch.html
+++ b/example/rp/watch.html
@@ -51,12 +51,12 @@ pre {
 <body>
 <div class="title">
   <h1>Persona Test Relying Party</h1>
-  <h2>Stateless "Goldilocks"</h2>
+  <h2>navigator.id.watch</h2>
 </div>
 
 <div class="intro">
   This is a RP for testing, it allows you to drive the
-  <tt>Stateless "Goldilocks"</tt> calls manually to locally test Persona.  Looking to test <a href="/watch.html">navigator.id.watch</a> or <a href="/get.html">navigator.id.get</a>?
+  <tt>navigator.id.watch() &amp; navigator.id.request()</tt> calls manually to locally test Persona.  Looking to test <a href="/index.html">stateless "goldilocks"</a> or <a href="/get.html">navigator.id.get</a>?
 </div>
 
 <div class="specify">
@@ -98,6 +98,7 @@ pre {
     </li>
   </ul>
     <button class="assertion">Get an assertion</button>
+    <button class="logout">logout</button>
 </div>
 
 <div class="session">
@@ -112,6 +113,21 @@ pre {
 
 <div class="loginEvents">
   <h2>logins</h2>
+  <pre> ... </pre>
+</div>
+
+<div class="logoutEvents">
+  <h2>logouts</h2>
+  <pre> ... </pre>
+</div>
+
+<div class="matchEvents">
+  <h2>matches</h2>
+  <pre> ... </pre>
+</div>
+
+<div class="readiness">
+  <h2>readiness</h2>
   <pre> ... </pre>
 </div>
 
@@ -162,6 +178,12 @@ function checkAssertion(assertion) {
 };
 
 navigator.id.watch({
+  loggedInUser: (storage.loggedInUser === 'null') ? null : storage.loggedInUser,
+  onready: function () {
+    loggit("onready");
+    var txt = serial++ + ' navigator.id ready at ' + (new Date).toString();
+    $(".readiness > pre").text(txt);
+  },
   onlogin: function (assertion) {
     loggit("onlogin");
     var txt = serial++ + ' got assertion at ' + (new Date).toString();
@@ -170,6 +192,16 @@ navigator.id.watch({
     checkAssertion(assertion);
 
     $(".specify button.assertion").removeAttr('disabled');
+  },
+  onlogout: function () {
+    loggit("onlogout");
+    var txt = serial++ + ' logout callback invoked at ' + (new Date).toString();
+    $(".logoutEvents > pre").text(txt);
+  },
+  onmatch: function() {
+    loggit("onmatch")
+    var txt = serial++ + ' match callback invoked at ' + (new Date).toString();
+    $(".matchEvents > pre").text(txt);
   }
 });
 
@@ -196,6 +228,14 @@ $(document).ready(function() {
       }
     });
   });
+
+  $(".specify button.logout").click(function() { navigator.id.logout() });
+
+  $(".session button.update_session").click(function() {
+    storage.loggedInUser = $.trim($('#loggedInUser').val());
+    $(".session input").fadeOut(100).fadeIn(350);
+  });
+  $('#loggedInUser').val(storage.loggedInUser ? storage.loggedInUser : "");
 });
 
 </script>

--- a/resources/static/common/js/models/rp_info.js
+++ b/resources/static/common/js/models/rp_info.js
@@ -33,6 +33,7 @@ BrowserID.Models.RpInfo = (function() {
     issuer: 'default',
     emailHint: und,
     userAssertedClaims: und,
+    rpAPI: und,
 
     init: function(options) {
       var self = this;
@@ -48,6 +49,7 @@ BrowserID.Models.RpInfo = (function() {
         'termsOfService',
         'allowUnverified',
         'returnTo',
+        'rpAPI',
         'emailHint',
         'userAssertedClaims'
         );
@@ -106,6 +108,10 @@ BrowserID.Models.RpInfo = (function() {
 
     isDefaultIssuer: function() {
       return this.issuer === "default";
+    },
+
+    getRpAPI: function() {
+      return this.rpAPI;
     },
 
     getEmailHint: function() {

--- a/resources/static/dialog/js/modules/dialog.js
+++ b/resources/static/dialog/js/modules/dialog.js
@@ -108,6 +108,9 @@ BrowserID.Modules.Dialog = (function() {
         // added.  If there are no args, then do not do self.get.
         if (args) {
           self.get(origin, args.params, function(r) {
+            // assertion being passed through WinChan, so we have
+            // fulfilled the `one_time` assertion promise.
+            storage.site.remove(origin, "one_time");
             cb(r);
           }, function (e) {
             cb(null);

--- a/resources/static/dialog/js/modules/generate_assertion.js
+++ b/resources/static/dialog/js/modules/generate_assertion.js
@@ -26,13 +26,19 @@ BrowserID.Modules.GenerateAssertion = (function() {
       self.checkRequired(options, "email", "rpInfo");
 
       var email = options.email,
-          origin = options.rpInfo.getOrigin();
+          origin = options.rpInfo.getOrigin(),
+          isOneTime = options.rpInfo.getRpAPI() === "stateless";
 
       user.getAssertion(email, origin, function(assertion) {
         assertion = assertion || null;
 
         if (assertion) {
-          storage.site.set(origin, "logged_in", email);
+          if (isOneTime) {
+            storage.site.set(origin, "one_time", email);
+            storage.site.remove(origin, "logged_in");
+          } else {
+            storage.site.set(origin, "logged_in", email);
+          }
         }
 
         self.publish("assertion_generated", {

--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -291,6 +291,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
     var VALID_RP_API_VALUES = [
       "watch_without_onready",
       "watch_with_onready",
+      "stateless",
       "get",
       "getVerifiedEmail",
       "internal"

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -299,7 +299,8 @@
       }
 
       if (!options.onlogin) throw new Error("'onlogin' is a required argument to navigator.id.watch()");
-      if (!options.onlogout) throw new Error("'onlogout' is a required argument to navigator.id.watch()");
+      if (!options.onlogout && (options.onmatch || options.onready || ('loggedInUser' in options)))
+        throw new Error('stateless api only allows onlogin option');
 
       observers.login = options.onlogin || null;
       observers.logout = options.onlogout || null;
@@ -338,7 +339,8 @@
       var rp_api = api_called;
       if (rp_api === "request") {
         if (observers.ready) rp_api = "watch_with_onready";
-        else rp_api = "watch_without_onready";
+        else if (observers.onlogout) rp_api = "watch_without_onready";
+        else rp_api = "stateless";
       }
 
       return rp_api;
@@ -358,7 +360,7 @@
       }
 
       options.rp_api = getRPAPI();
-      var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request');
+      var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request' || api_called === 'auth');
 
       // reset the api_called in case the site implementor changes which api
       // method called the next time around.

--- a/resources/static/test/cases/common/js/user.js
+++ b/resources/static/test/cases/common/js/user.js
@@ -1196,6 +1196,19 @@
     }, testHelpers.unexpectedXHRFailure);
   });
 
+  asyncTest("getSilentAssertion with one_time API", function() {
+    var LOGGED_IN_EMAIL = TEST_EMAIL;
+
+    lib.syncEmailKeypair(LOGGED_IN_EMAIL, function() {
+      storage.site.set(lib.rpInfo.getOrigin(), "one_time", LOGGED_IN_EMAIL);
+      lib.getSilentAssertion(null, function(email, assertion) {
+        equal(email, LOGGED_IN_EMAIL, "correct email");
+        equal(storage.site.get(lib.rpInfo.getOrigin(), "one_time"), undefined, "one_time flag removed");
+        testAssertion(assertion, start);
+      }, testHelpers.unexpectedXHRFailure);
+    }, testHelpers.unexpectedXHRFailure);
+  });
+
   asyncTest("logoutUser", function(onSuccess) {
     lib.authenticate(TEST_EMAIL, "testuser", function(authenticated) {
       lib.syncEmails(function() {

--- a/resources/static/test/cases/include.js
+++ b/resources/static/test/cases/include.js
@@ -58,10 +58,19 @@
     testWatchIsSad(1);
   });
 
+
+  test("stateless arguments options", function() {
+    ok(watch({ onlogin: noOp }), "no logout means stateless");
+
+    ok(!watch({ onlogin: noOp, loggedInUser: 'asdf' }), 'stateless cant use loggedInUser');
+    ok(!watch({ onlogin: noOp, onmatch: noOp }), 'stateless cant use onmatch');
+    ok(!watch({ onlogin: noOp, onready: noOp }), 'stateless cant use onready');
+  });
+
   function testWatchIsHappy(loggedInUser) {
     var err;
     try {
-      callWatch(undefined);
+      callWatch(loggedInUser);
     } catch(e) {
       err = e;
     }
@@ -76,6 +85,15 @@
       err = e;
     }
     ok(err);
+  }
+
+  function watch(obj) {
+    try {
+      navigator.id.watch(obj);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   function callWatch(loggedInUser) {


### PR DESCRIPTION
keeps current watch() api, but makes it "stateless" if RP doesn't want
session management. to indicate this, simply don't pass an `onlogout`
handler to watch().

navigator.id.watch({ onlogin: function(assertion) {} });
navigator.id.request(optionsAsNormal);

Two notes:
1. Since there's really only 1 option to pass to watch() for this, I'd think it would be nice to allow passing a function instead of an object with an onlogin parameter.
2. There's some confusion over whether we're keeping the same function names, or introducing configure and prompt. Changing it in this PR is really easy, the only changes would be in include.js.
