### PR TITLE
fixes a pathing error in win32 when there are spaces in the path

### DIFF
--- a/scripts/generate_ephemeral_keys.js
+++ b/scripts/generate_ephemeral_keys.js
@@ -11,6 +11,8 @@ var VAR = path.join(__dirname, '../var');
 var CERT = path.join(VAR, 'root.cert');
 
 function exec(file, args, next) {
+  // remove path prefix, to prevent spaces in paths causing problems on win32
+  file = file.substring(process.cwd().length + 1);
   child_process.exec([file, args].join(' '), function(err, stdout, stderr) {
     if (err) throw err;
     if (stderr) console.error(stderr);


### PR DESCRIPTION
The `exec` call in generate_ephemeral_keys.js will fail on win32 if the path prefix contains spaces (unfortunately still) so a surefire way to ensure the command won't fail is to make it a relative command by filtering out `process.cwd()`
