### PR TITLE
upgrade to node-statsd 0.0.7

### DIFF
--- a/lib/logging/transports/statsd.js
+++ b/lib/logging/transports/statsd.js
@@ -4,17 +4,11 @@
 
 const util = require('util');
 const winston = require('winston');
+const StatsD = require("node-statsd").StatsD;
 const logger = require('../logging').logger;
 const config = require('../../configuration');
 const timing_filter = require('./filters/statsd-timing');
 const increment_filter = require('./filters/statsd-increment');
-
-var StatsD = false;
-try {
-  StatsD = require("node-statsd").StatsD;
-} catch (requireError) {
-  // its ok, its an optionalDependency
-}
 
 "use strict";
 
@@ -45,11 +39,6 @@ StatsdTransport.prototype.log = function(level, msg, meta, callback) {
 function getStatsdIfEnabled() {
   var statsdConfig = config.get('statsd');
   if (statsdConfig && statsdConfig.enabled) {
-    if ( ! StatsD) {
-      return logger.error(
-                  'statsd config enabled, but node-statsd not installed.');
-    }
-
     var statsdOptions = {};
     statsdOptions.host = statsdConfig.host || "localhost";
     statsdOptions.port = statsdConfig.port || 8125;

--- a/lockdown.json
+++ b/lockdown.json
@@ -313,7 +313,7 @@
     "0.6.0": "41e64712dbd947aa9d9f466b5c0b5ee020bbcbbb"
   },
   "node-statsd": {
-    "0.0.2": "ba96c26d4ec22b4f9501bb332fdf740db5a40ee7"
+    "0.0.7": "96d4bbd21dff2d798b3374a3e9329cfecce3afa8"
   },
   "node-uuid": {
     "1.4.1": "39aef510e5889a3dca9c895b506c73aae1bac048"

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "i18n-abide": "0.0.8",
     "lockdown": "0.0.4",
     "jwcrypto": "0.4.3",
+    "mkdirp": "0.3.0",
     "mysql": "0.9.5",
     "nodemailer": "0.3.21",
-    "mkdirp": "0.3.0",
+    "node-statsd": "0.0.7",
     "optimist": "0.2.8",
     "postprocess": "0.2.4",
     "rimraf": "2.0.2",
@@ -58,9 +59,6 @@
     "connect-fonts": "0.0.9-alpha8",
     "connect-fonts-opensans": "0.0.3-beta1",
     "connect-fonts-feurasans": "0.0.2"
-  },
-  "optionalDependencies": {
-    "node-statsd": "https://github.com/downloads/lloyd/node-statsd/0509f85.tgz"
   },
   "devDependencies": {
     "vows": "git://github.com/cloudhead/vows#253ca34c",


### PR DESCRIPTION
- newer version works on windows
- removes global StatsD
- can be moved out of optionalDependencies
