### PR TITLE
use express mounting, kill connect-cookie-session

### DIFF
--- a/lib/wsapi.js
+++ b/lib/wsapi.js
@@ -55,7 +55,7 @@ if (config.get('public_url').indexOf('https://login.persona.org') !== 0) {
   COOKIE_KEY += "_" + hash.digest('hex').slice(0, 6);
 }
 
-const WSAPI_PREFIX = '/wsapi/';
+const WSAPI_PREFIX = '/wsapi';
 
 logger.info('session cookie name is: ' + COOKIE_KEY);
 
@@ -163,7 +163,6 @@ function checkCSRF(req, resp, next) {
 
 function checkCodeVersion(req, resp, next) {
   version(function(expectedCodeVersion) {
-    if (req.url.indexOf(WSAPI_PREFIX) === -1) return next();
     var requestedCodeVersion = req.headers['browserid-git-sha'];
 
     if (requestedCodeVersion !== expectedCodeVersion) {
@@ -219,8 +218,7 @@ function databaseDown(res, err) {
 
 function operationFromURL (path) {
   var purl = url.parse(path);
-  return purl.pathname.substr(0, WSAPI_PREFIX.length) === WSAPI_PREFIX &&
-          purl.pathname.substr(WSAPI_PREFIX.length) || null;
+  return purl.pathname.substr(1); // drop leading slash
 }
 
 var APIs;
@@ -307,36 +305,16 @@ exports.setup = function(options, app) {
   // like strict transport security and change the way cookies are set
   const overSSL = (config.get('scheme') === 'https');
 
-  var cookieParser = express.cookieParser();
-  var bodyParser = express.bodyParser();
-
   // stash our forward-to url so different wsapi handlers can use it
   exports.forwardWritesTo = options.forward_writes;
 
-  var cookieSessionMiddleware = sessions({
-    secret: COOKIE_SECRET,
-    requestKey: 'session',
-    cookieName: COOKIE_KEY,
-    duration: config.get('authentication_duration_ms'),
-    cookie: {
-      path: '/wsapi',
-      httpOnly: true,
-      maxAge: config.get('authentication_duration_ms'),
-      secure: overSSL
-    }
-  });
 
-  app.use(function(req, resp, next) {
-    var purl = url.parse(req.url);
-
-    // cookie sessions are only applied to calls to /wsapi
-    // as all other resources can be aggressively cached
-    // by layers higher up based on cache control headers.
-    // the fallout is that all code that interacts with sessions
-    // should be under /wsapi
-    if (purl.pathname.substr(0, WSAPI_PREFIX.length) !== WSAPI_PREFIX)
-      return next();
-
+  // cookie sessions are only applied to calls to /wsapi
+  // as all other resources can be aggressively cached
+  // by layers higher up based on cache control headers.
+  // the fallout is that all code that interacts with sessions
+  // should be under /wsapi
+  app.use(WSAPI_PREFIX, function(req, resp, next) {
     // explicitly disallow caching on all /wsapi calls (issue #294)
     resp.setHeader('Cache-Control', 'no-cache, max-age=0');
 
@@ -346,7 +324,7 @@ exports.setup = function(options, app) {
     if (overSSL)
       req.connection.proxySecure = true;
 
-    const operation = purl.pathname.substr(WSAPI_PREFIX.length);
+    const operation = operationFromURL(req.url);
 
     // count the number of WSAPI operation
     logger.info("wsapi." + operation);
@@ -362,17 +340,25 @@ exports.setup = function(options, app) {
         return httputils.badRequest(resp, "no such api");
     }
 
-    // perform full parsing and validation
-    return cookieParser(req, resp, function() {
-      bodyParser(req, resp, function() {
-        cookieSessionMiddleware(req, resp, function() {
-          checkExpiredSession(req, resp, function() {
-            return checkCSRF(req, resp, next);
-          });
-        });
-      });
-    });
+    next();
   });
+
+  app.use(WSAPI_PREFIX, express.cookieParser());
+  app.use(WSAPI_PREFIX, express.bodyParser());
+  app.use(WSAPI_PREFIX, sessions({
+    secret: COOKIE_SECRET,
+    requestKey: 'session',
+    cookieName: COOKIE_KEY,
+    duration: config.get('authentication_duration_ms'),
+    cookie: {
+      path: '/wsapi',
+      httpOnly: true,
+      maxAge: config.get('authentication_duration_ms'),
+      secure: overSSL
+    }
+  }));
+  app.use(WSAPI_PREFIX, checkExpiredSession);
+  app.use(WSAPI_PREFIX, checkCSRF);
 
   // load all of the APIs supported by this process
   var wsapis = { };
@@ -424,36 +410,30 @@ exports.setup = function(options, app) {
     describeOperation(api, wsapis[api]);
   });
 
-  app.use(function(req, resp, next) {
-    var purl = url.parse(req.url);
+  app.use(WSAPI_PREFIX, function wsapiMiddleware(req, resp, next) {
+    const operation = operationFromURL(req.url);
 
-    if (purl.pathname.substr(0, WSAPI_PREFIX.length) === WSAPI_PREFIX) {
-      const operation = purl.pathname.substr(WSAPI_PREFIX.length);
+    // the fake_verification wsapi is implemented elsewhere.
+    if (operation === 'fake_verification') return next();
 
-      // the fake_verification wsapi is implemented elsewhere.
-      if (operation === 'fake_verification') return next();
+    // at this point, we *know* 'operation' is valid API, give checks performed
+    // above
 
-      // at this point, we *know* 'operation' is valid API, give checks performed
-      // above
-
-      // does the request require authentication?
-      if (wsapis[operation].authed && !isAuthed(req, wsapis[operation].authed)) {
-        return httputils.badRequest(resp, "requires authentication");
-      }
-
-      // validate the arguments of the request
-      wsapis[operation].validate(req, resp, function() {
-        if (wsapis[operation].i18n) {
-          abide(req, resp, function () {
-            wsapis[operation].process(req, resp);
-          });
-        } else {
-          wsapis[operation].process(req, resp);
-        }
-      });
-    } else {
-      next();
+    // does the request require authentication?
+    if (wsapis[operation].authed && !isAuthed(req, wsapis[operation].authed)) {
+      return httputils.badRequest(resp, "requires authentication");
     }
+
+    // validate the arguments of the request
+    wsapis[operation].validate(req, resp, function() {
+      if (wsapis[operation].i18n) {
+        abide(req, resp, function () {
+          wsapis[operation].process(req, resp);
+        });
+      } else {
+        wsapis[operation].process(req, resp);
+      }
+    });
   });
 };
 
@@ -461,10 +441,11 @@ exports.setup = function(options, app) {
 exports.routeSetup = function (app, options) {
   var wsapis = allAPIs();
 
-  app.use(checkCodeVersion);
+  app.use(WSAPI_PREFIX, checkCodeVersion);
 
-  app.use(function(req, resp, next) {
+  app.use(WSAPI_PREFIX, function(req, resp, next) {
     var operation = operationFromURL(req.url);
+    
     // not a WSAPI request
     if (!operation) return next();
 
@@ -484,8 +465,9 @@ exports.routeSetup = function (app, options) {
         return httputils.notFound(resp);
     }
 
-    var destination_url = api.writes_db ? options.write_url + "/wsapi/" + operation
-                                        : options.read_url + req.url;
+    var destination_path = WSAPI_PREFIX + req.url;
+    var destination_url = (api.writes_db ? 
+        options.write_url : options.read_url) + destination_path;
 
     var cb = function() {
       forward(

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "client-sessions": "~0.3.1",
     "cookies": "0.3.6",
     "connect-cachify": "0.0.14",
-    "connect-cookie-session": "0.0.2",
     "connect-logger-statsd": "0.0.1",
     "cover": "0.2.8",
     "ejs": "0.8.3",


### PR DESCRIPTION
I was looking through wsapi, and the cascade of functions made go all like `huh?`. We can mount middleware at routes, removing the need for url checking of `/wsapi` in each middleware, and simple mount it at the correct prefix.

This makes it make more sense (imo).

For good measure, ripped out connect-cookie-session, and just used client-sessions.
