### PR TITLE
Allow scripts in inline ToS/PP pages (issue #3987)

### DIFF
--- a/resources/static/dialog/views/inline_tospp.ejs
+++ b/resources/static/dialog/views/inline_tospp.ejs
@@ -17,7 +17,7 @@
   <% if (typeof no_iframe !== "undefined" && no_iframe === true) { %>
     <div class="contents" id="tosppframe" name="tosppframe"></div>
   <% } else { %>
-    <iframe class="contents" id="tosppframe" name="tosppframe" sandbox security="restricted"></iframe>
+    <iframe class="contents" id="tosppframe" name="tosppframe" sandbox="allow-scripts" security="restricted"></iframe>
   <% } %>
   <p class="submit cf buttonrow isMobile">
     <button href="#"><%= gettext("OK") %></button>


### PR DESCRIPTION
This allows scripts to run in inlined ToS/PP pages, but not to access local assets. Even if an attacker specified a page on the persona origin, it would run in a unique origin that would not have access to the local storage.
