### PR TITLE
Fix how rpInfo is created in native Desktop authentication flow

### DIFF
--- a/lib/wsapi/discovery.js
+++ b/lib/wsapi/discovery.js
@@ -47,7 +47,7 @@ exports.process = function(req, res) {
       }
       wellKnown = {
         "public-key": fallbackPubKey.toSimpleObject(),
-        authentication: config.get('public_url') + '/auth#NATIVE',
+        authentication: config.get('public_url') + '/auth',
         provisioning: config.get('public_url') + '/provision'
       };
     }

--- a/resources/static/authentication_api.js
+++ b/resources/static/authentication_api.js
@@ -8,7 +8,9 @@
 (function() {
   "use strict";
 
-  if (!navigator.id) {
+  if (navigator.mozId) {
+    navigator.id = navigator.mozId;
+  } else if (!navigator.id) {
     navigator.id = {};
   }
 

--- a/resources/static/dialog/js/modules/idp_authentication.js
+++ b/resources/static/dialog/js/modules/idp_authentication.js
@@ -38,6 +38,12 @@ BrowserID.Modules.IdPAuthentication= (function() {
     return function(msg, info) {
       dialogHelpers.createUser.call(self, email, info.password, function(info) {
         if (info.success) {
+          info.rpInfo = user.rpInfo;
+          info.siteName = user.rpInfo.siteName;
+          info.email = email;
+          info.verifier = "waitForUserValidation";
+          info.verificationMessage = "user_confirmed";
+
           var checkRegistration = moduleManager.start("check_registration", info);
           mediator.subscribe('user_confirmed', function(msg, confirmationInfo) {
             if (confirmationInfo.mustAuth) {
@@ -64,6 +70,32 @@ BrowserID.Modules.IdPAuthentication= (function() {
     };
   }
 
+  function parseRPInfo() {
+    var offset = '?'.length;
+    var whitelist = [
+      'backgroundColor',
+      'origin',
+      'privacyPolicy',
+      'returnTo',
+      'siteLogo',
+      'siteName',
+      'termsOfService'
+    ];
+    var rawRPInfo = window.location.search.slice(offset);
+    if (! rawRPInfo) {
+      throw new Error('Missing RPInfo in URL');
+    }
+    var aRPInfo = {};
+    var parts = rawRPInfo.split('&');
+    for (var i=0; i < parts.length; i++) {
+      var pieces = parts[i].split('=');
+      if (whitelist.indexOf(pieces[0]) !== -1) {
+	aRPInfo[decodeURIComponent(pieces[0])] = decodeURIComponent(pieces[1]);
+      }
+    }
+    return aRPInfo;
+  }
+
   var Module = bid.Modules.PageModule.extend({
     start: function(options) {
       options = options || {};
@@ -72,17 +104,18 @@ BrowserID.Modules.IdPAuthentication= (function() {
       ensureSize(700, 440);
 
       navigator.id.beginAuthentication(function(email) {
-        mediator.subscribe("authentication_success", function(msg, info) {
-          // TODO: Are we sure that we authed as email?
-          navigator.id.completeAuthentication();
+        mediator.subscribe("authenticated", function(msg, info) {
+          if (email === info.email) {
+            navigator.id.completeAuthentication();
+          } else {
+            // Should never happen
+            navigator.id.raiseProvisioningFailure(
+              'user is not authenticated as target user');
+          }
         });
 
         mediator.subscribe("new_user", newUserComplete(self));
-
-        var rpInfo = bid.Models.RpInfo.create({
-          origin: info.origin,
-          siteName: info.siteName
-        });
+        var rpInfo = bid.Models.RpInfo.create(parseRPInfo());
         user.setRpInfo(rpInfo);
 
         moduleManager.start("authenticate", {

--- a/resources/static/provisioning_api.js
+++ b/resources/static/provisioning_api.js
@@ -627,7 +627,9 @@
     };
   })();
 
-  if (!navigator.id) {
+  if (navigator.mozId) {
+    navigator.id = navigator.mozId;
+  } else if (!navigator.id) {
     navigator.id = {};
   }
 

--- a/resources/views/authenticate_layout.ejs
+++ b/resources/views/authenticate_layout.ejs
@@ -101,6 +101,7 @@
 
 
       <% if (useJavascript !== false) { %>
+        <%- cachify_js(util.format('/authentication_api.js')) %>
         <%- cachify_js(util.format('/production/%s/idp_authenticate.js', locale)) %>
       <% } %>
 	</body>

--- a/resources/views/provision.ejs
+++ b/resources/views/provision.ejs
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Persona Provisioning</title>
 <script src="/common/js/lib/micrajax.js"></script>
+<%- cachify_js(util.format('/provisioning_api.js')) %>
 <script>
 function getJSON(uri, success, failure) {
   Micrajax.ajax({

--- a/tests/discovery-test.js
+++ b/tests/discovery-test.js
@@ -60,7 +60,7 @@ suite.addBatch({
     "returns a well known": function(e, r) {
       assert.isNull(e);
       var res = JSON.parse(r.body);
-      assert.equal(res.authentication, "http://127.0.0.1:10002/auth#NATIVE");
+      assert.equal(res.authentication, "http://127.0.0.1:10002/auth");
       assert.equal(res.provisioning, "http://127.0.0.1:10002/provision");
       assert.isNotNull(res['public-key']);
     }
@@ -75,7 +75,7 @@ suite.addBatch({
     "returns the secondary well known": function(e, r) {
       assert.isNull(e);
       var res = JSON.parse(r.body);
-      assert.equal(res.authentication, "http://127.0.0.1:10002/auth#NATIVE");
+      assert.equal(res.authentication, "http://127.0.0.1:10002/auth");
       assert.equal(res.provisioning, "http://127.0.0.1:10002/provision");
       assert.isNotNull(res['public-key']);
     }


### PR DESCRIPTION
- Remove useless #NATIVE
- Parse rpInfo from query string parameters
- Fix navigator.mozId breakage from merging Desktop to hg tip
