### PR TITLE
Enable the "continue" button on mobile if experimental_emailHint is specified.

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -358,7 +358,11 @@ BrowserID.Modules.Authenticate = (function() {
       dom.addClass(BODY_SELECTOR, AUTHENTICATION_CLASS);
       dom.addClass(BODY_SELECTOR, FORM_CLASS);
       dom.setInner(RP_NAME_SELECTOR, rpInfo.getSiteName());
+
       dom.setInner(EMAIL_SELECTOR, lastEmail);
+      if (lastEmail)
+        dom.removeAttr(CONTINUE_BUTTON_SELECTOR, DISABLED_ATTRIBUTE);
+
 
       currentHint = null;
       dom.setInner(CONTENTS_SELECTOR, "");

--- a/resources/static/test/cases/dialog/js/modules/authenticate.js
+++ b/resources/static/test/cases/dialog/js/modules/authenticate.js
@@ -20,6 +20,7 @@
       testElementNotHasClass = testHelpers.testNotHasClass,
       testElementFocused = testHelpers.testElementFocused,
       testElementTextEquals = testHelpers.testElementTextEquals,
+      testElementNotDisabled = testHelpers.testElementNotDisabled,
       register = testHelpers.register,
       provisioning = bid.Mocks.Provisioning,
       AUTH_FORM_SELECTOR = "#authentication_form",
@@ -58,6 +59,8 @@
     setup: function() {
       reset();
       $("input[type=password]").hide();
+      // the "continue" button is disabled when the dialog loads.
+      $(CONTINUE_BUTTON_SELECTOR).attr("disabled", "disabled");
       testHelpers.setup();
       createController();
     },
@@ -206,6 +209,9 @@
       ready: function() {
         equal($(EMAIL_SELECTOR).val(), "testuser@testuser.com", "email prefilled");
         testElementHasClass("body", "start");
+        // mobile's "continue" button is disabled when the dialog loads. If an
+        // email hint is specified, enable the button"
+        testElementNotDisabled(CONTINUE_BUTTON_SELECTOR);
         start();
       }
     });

--- a/resources/static/test/testHelpers/helpers.js
+++ b/resources/static/test/testHelpers/helpers.js
@@ -332,6 +332,14 @@ BrowserID.TestHelpers = (function() {
       ok(!$(selector).length, msg || ("element '" + selector + "' does not exist"));
     },
 
+    testElementDisabled: function(selector, msg) {
+      ok(!!$(selector).attr('disabled'), msg || ("element '" + selector + "' is disabled"));
+    },
+
+    testElementNotDisabled: function(selector, msg) {
+      ok(!$(selector).attr('disabled'), msg || ("element '" + selector + "' is enabled"));
+    },
+
     testRPTosPPShown: function(msg) {
       TestHelpers.testHasClass("body", "rptospp", msg || "RP TOS/PP shown");
     },


### PR DESCRIPTION
This is ready to test on https://hotfix-mobile-continue.personatest.org

fixes #4032
