### PR TITLE
Prevent email clients from linkifying site domains.

### DIFF
--- a/resources/email_templates/confirm.ejs
+++ b/resources/email_templates/confirm.ejs
@@ -1,4 +1,4 @@
-<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site.replace('.', '\uFEFF.') })%>
 <%= link %>
 
 <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>

--- a/resources/email_templates/confirm.html.ejs
+++ b/resources/email_templates/confirm.html.ejs
@@ -2,7 +2,7 @@
 
   <tr>
     <td align="center">
-      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site.replace('.', '&#xFEFF;.') + '</strong>' })%>
     </td>
   </tr>
 

--- a/resources/email_templates/new.ejs
+++ b/resources/email_templates/new.ejs
@@ -1,4 +1,4 @@
-<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site.replace('.', '\uFEFF.') })%>
 <%= link %>
 
 <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>

--- a/resources/email_templates/new.html.ejs
+++ b/resources/email_templates/new.html.ejs
@@ -3,7 +3,7 @@
 
   <tr>
     <td align="center">
-      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site.replace('.', '&#xFEFF;.') + '</strong>' })%>
     </td>
   </tr>
 

--- a/resources/email_templates/transition.ejs
+++ b/resources/email_templates/transition.ejs
@@ -1,6 +1,6 @@
 <%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
 
-<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site })%>
+<%= format(gettext('Click this link to confirm access to %(site)s:'), { site: site.replace('.', '\uFEFF.') })%>
 <%= link %>
 
 <%= gettext('If you were NOT attempting this sign-in, please ignore this email.') %>

--- a/resources/email_templates/transition.html.ejs
+++ b/resources/email_templates/transition.html.ejs
@@ -5,7 +5,7 @@
       <%= gettext('It looks like your email provider is having trouble with their Persona support.') %>
     </td>
     <td align="center">
-      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site + '</strong>' })%>
+      <%- format(gettext('Click this link to confirm access to %(site)s:'), { site: '<strong>' + site.replace('.', '&#xFEFF;.') + '</strong>' })%>
     </td>
   </tr>
 


### PR DESCRIPTION
As reported in [this mailing list thread](https://groups.google.com/d/msg/mozilla.dev.identity/bbQVtYLXhk8/WFgu14TG1YsJ) (plus my reply, which ~~has yet to be approved by mods~~ I accidentally didn't actually send to the list), mail clients like trying to be clever and linkifying things like URLs.

This _should_ prevent that, although I couldn't test it because I couldn't figure out how to get my local Persona clone to send an email and/or display it to console.
