### PR TITLE
Adding setup instructions for RHEL and RHEL derivatives

### DIFF
--- a/docs/SETUP_RHEL.md
+++ b/docs/SETUP_RHEL.md
@@ -1,0 +1,7 @@
+Installing Dependencies on RedHat Enterprise Linux and Related Derivatives
+---------------------------------
+[Red Hat Enterprise Linux Derivatives](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux_derivatives)
+
+Run the following to install necessary dependencies:
+
+    sudo yum install gcc-c++ nodejs gmp-devel expat-devel


### PR DESCRIPTION
I went to setup a build environment today and found there weren't instructions regarding dependencies for RHEL and RHEL derivatives. This doc file shows some of the dependencies for building. Since I worked from a Services Ops base system image instead of a stock RHEL machine there may be additional dependencies that aren't represented here but I figured it would be best to get some kind of a guideline up.
