### PR TITLE
Pull vows via https, not git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "connect-fonts-feurasans": "0.0.3"
   },
   "devDependencies": {
-    "vows": "git://github.com/cloudhead/vows#253ca34c",
+    "vows": "https://github.com/cloudhead/vows/tarball/253ca34c",
     "awsbox": "0.6.2",
     "irc": "0.3.6",
     "jshint": "2.1.11",


### PR DESCRIPTION
hardik in IRC had a ton of trouble installing Persona because of this. For some
reason he wasn't able to clone over git://, but https works just fine.

This should also be marginally faster since we don't have to clone an entire
repo.
