### PR TITLE
add options winston_logging_{maxsize,maxfiles} to get some log rotation

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -294,7 +294,17 @@ var conf = module.exports = convict({
   forcible_issuers: {
     doc: "Hostnames which this Persona instance will issue identies for. Used in b2g only.",
     format: 'array { string }* = [ "fxos.login.persona.org"]',
-  }
+  },
+  winston_logging_maxsize: {
+    doc: "If greater than zero, max size in bytes of the logfile",
+    format: 'integer = 0',
+    env: 'WINSTON_LOGGING_MAXSIZE'
+  },
+  winston_logging_maxfiles: {
+    doc: "Number of previous logfiles to retain",
+    format: 'integer = 10',
+    env: 'WINSTON_LOGGING_MAXFILES'
+  },
 });
 
 // At the time this file is required, we'll determine the "process name" for this proc

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -42,13 +42,20 @@ mkdir_p(log_path);
 
 var filename = path.join(log_path, configuration.get('process_type') + ".log");
 
+var fileOptions = {
+  timestamp: function () { return new Date().toISOString(); },
+  filename: filename,
+  colorize: true,
+  handleExceptions: true
+};
+
+if (configuration.get('winston_logging_maxsize') > 0) {
+  fileOptions.maxsize = configuration.get('winston_logging_maxsize');
+  fileOptions.maxFiles = configuration.get('winston_logging_maxfiles');
+}
+
 exports.logger = new (winston.Logger)({
-  transports: [new (winston.transports.File)({
-    timestamp: function () { return new Date().toISOString(); },
-    filename: filename,
-    colorize: true,
-    handleExceptions: true
-  })]
+  transports: [new (winston.transports.File)(fileOptions)]
 });
 
 exports.enableConsoleLogging = function() {


### PR DESCRIPTION
This is a dead-end change to the train-2013.10.09, since the logging code changes significantly after that point in time. This is to address the current lack of log rotation in producition. (However, the current production branch is train-2013.10.09 plus some security fixes, so this PR may not be used, depending on which repo is used to ship this change). See https://github.com/mozilla/identity-ops/issues/126 for other comments.
