### PR TITLE
Train 2013.10.09 with logroll

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ train-2013.10.09:
   * Fix a win32 paths-with-spaces bug: #3962
   * Fix an intermittent broken test on linux+ node > 0.10.16: #3912
   * (hotfix 2013.12.02) : [mobile] "next" button not enabled if user not authed and experimental_emailHint specified: issue #4032, #4036
+  * (hotfix 2014.02.06) : add options winston_logging_maxfiles{maxsize,maxfiles} to get some log rotation: https://github.com/mozilla/identity-ops/issues/126
 
 train-2013.09.25:
   * RP Branded verification emails - if a site declares siteLogo and backgroundColor, verification emails will be styled with those instead of Persona branding: #3857

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -294,7 +294,17 @@ var conf = module.exports = convict({
   forcible_issuers: {
     doc: "Hostnames which this Persona instance will issue identies for. Used in b2g only.",
     format: 'array { string }* = [ "fxos.login.persona.org"]',
-  }
+  },
+  winston_logging_maxsize: {
+    doc: "If greater than zero, max size in bytes of the logfile",
+    format: 'integer = 0',
+    env: 'WINSTON_LOGGING_MAXSIZE'
+  },
+  winston_logging_maxfiles: {
+    doc: "Number of previous logfiles to retain",
+    format: 'integer = 10',
+    env: 'WINSTON_LOGGING_MAXFILES'
+  },
 });
 
 // At the time this file is required, we'll determine the "process name" for this proc

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -42,13 +42,20 @@ mkdir_p(log_path);
 
 var filename = path.join(log_path, configuration.get('process_type') + ".log");
 
+var fileOptions = {
+  timestamp: function () { return new Date().toISOString(); },
+  filename: filename,
+  colorize: true,
+  handleExceptions: true
+};
+
+if (configuration.get('winston_logging_maxsize') > 0) {
+  fileOptions.maxsize = configuration.get('winston_logging_maxsize');
+  fileOptions.maxFiles = configuration.get('winston_logging_maxfiles');
+}
+
 exports.logger = new (winston.Logger)({
-  transports: [new (winston.transports.File)({
-    timestamp: function () { return new Date().toISOString(); },
-    filename: filename,
-    colorize: true,
-    handleExceptions: true
-  })]
+  transports: [new (winston.transports.File)(fileOptions)]
 });
 
 exports.enableConsoleLogging = function() {

--- a/scripts/browserid.spec
+++ b/scripts/browserid.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-server
 Version:       0.2013.10.09
-Release:       2%{?dist}_%{svnrev}
+Release:       3%{?dist}_%{svnrev}
 Summary:       BrowserID server
 Packager:      Gene Wood <gene@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
From @jrgm:

"This is a dead-end change to the train-2013.10.09, since the logging code changes significantly after that point in time. This is to address the current lack of log rotation in producition. See mozilla/identity-ops#126 for other comments."

(moved from https://github.com/mozilla/browserid_private/pull/32)
