### PR TITLE
Fix for issue #3270: The xhr_delay error message doesn't specify which W...

### DIFF
--- a/resources/static/common/js/modules/xhr_delay.js
+++ b/resources/static/common/js/modules/xhr_delay.js
@@ -9,10 +9,23 @@ BrowserID.Modules.XHRDelay = (function() {
       delayed,
       sc;
 
-  function delayStart() {
+  function delayStart(event, request) {
     /*jshint validthis:true*/
     delayed = true;
-    this.renderDelay("load", wait.slowXHR);
+
+    var networkInfo; 
+    if (request) {
+      networkInfo = request.network;
+    }
+
+    var info = {
+      id: wait.slowXHR.id,
+      message: wait.slowXHR.message,
+      title: wait.slowXHR.title,
+      network: networkInfo
+    };
+    
+    this.renderDelay("load", info);
   }
 
   function delayStop() {

--- a/resources/static/dialog/views/load.ejs
+++ b/resources/static/dialog/views/load.ejs
@@ -8,4 +8,25 @@
 
   <% if (typeof message !== "undefined") { %>
     <p><%= message %></p>
+
+    <% if(typeof network !== "undefined") { %>
+    <a href="#" class="openMoreInfo">
+      <%= gettext("See more info") %>
+    </a>
+
+    <ul class="moreInfo">
+        <li>
+
+          <strong id="network">Network Info:</strong> <%= network.type %>: <%= network.url %>
+
+          <% if (network.errorThrown) { %>
+            <p>
+              <strong>Error Type:</strong> <%= network.errorThrown %>
+            </p>
+          <% } %>
+        </li>
+
+    </ul>
+    <% } %>
+
   <% } %>

--- a/resources/static/test/cases/common/js/modules/xhr_delay.js
+++ b/resources/static/test/cases/common/js/modules/xhr_delay.js
@@ -37,6 +37,22 @@
     equal(testHelpers.delayVisible(), false, "slowXHR screen no longer visible");
   });
 
+  test("xhr_delay shows the delay screen with see more info link", function() {
+    var request = {
+      network: {
+        type: "GET", 
+        url: "/wsapi/session_context"
+      }
+    };
+    mediator.publish("xhr_delay", request)
+    ok($(".openMoreInfo:visible").length, "see more info link is visible");
+    $(".openMoreInfo").click();
+    ok($(".moreInfo").is(":visible"), "expanded info is visible");
+
+    mediator.publish("xhr_complete");
+    
+  });
+
   test("xhr_complete does not hide delay screen if delay screen not started by xhr_delay", function() {
 
     screens.delay.show("wait", {title: "test delay", message: "testing"});


### PR DESCRIPTION
I have added the `Get more info` link to the load.ejs template. The additional info here only contains network info while the additional info in error pages have an action info object. `renderDelay` is invoked at lower level than `renderError`, the action info is not available. 
