### PR TITLE
ISSUE 3838 - desktop dialog text is quite compressed, especially the site name and "sign in to..." FIX

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -417,7 +417,7 @@ h1 {
 
 h2 {
   font-size: 32px;
-  letter-spacing: -1px;
+  letter-spacing: .75px;
   line-height: 100%;
 }
 


### PR DESCRIPTION
Changed the line spacing to CSS from -1px to .75px.
