### PR TITLE
fix a couple of js urls to send as content-type application/javascript to work with IE nosniff

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -416,6 +416,7 @@ exports.setup = function(app) {
     var templates = require('../templates');
     var dialogTemplatesPath = path.join(__dirname, '../../resources/static/dialog/views');
     app.get('/common/js/templates.js', function(req, res) {
+      res.setHeader('Content-Type', 'application/javascript');
       res.send(templates.generate(dialogTemplatesPath));
     });
 
@@ -426,6 +427,7 @@ exports.setup = function(app) {
       // mode.
       var siteTemplates = templates.generate(siteTemplatesPath, "site/");
       siteTemplates += templates.generate(sitePartialTemplatesPath, "partial/");
+      res.setHeader('Content-Type', 'application/javascript');
       res.send(siteTemplates);
     });
   }

--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -416,6 +416,9 @@ exports.setup = function(app) {
     var templates = require('../templates');
     var dialogTemplatesPath = path.join(__dirname, '../../resources/static/dialog/views');
     app.get('/common/js/templates.js', function(req, res) {
+      res.setHeader('Cache-Control', 'public, max-age=0');
+      res.setHeader('Access-Control-Allow-Origin', config.get('public_url'));
+      res.setHeader('Vary', 'Accept-Encoding,Accept-Language');
       res.setHeader('Content-Type', 'application/javascript');
       res.send(templates.generate(dialogTemplatesPath));
     });
@@ -427,6 +430,9 @@ exports.setup = function(app) {
       // mode.
       var siteTemplates = templates.generate(siteTemplatesPath, "site/");
       siteTemplates += templates.generate(sitePartialTemplatesPath, "partial/");
+      res.setHeader('Cache-Control', 'public, max-age=0');
+      res.setHeader('Access-Control-Allow-Origin', config.get('public_url'));
+      res.setHeader('Vary', 'Accept-Encoding,Accept-Language');
       res.setHeader('Content-Type', 'application/javascript');
       res.send(siteTemplates);
     });


### PR DESCRIPTION
We started sending 'X-Content-Type-Options: nosniff', but /common/js/templates.js and /test/mocks/site-templates.js were being sent as 'Content-type: text/html; charset=utf-8' and so, not loaded as javascript leading to multiple test failures in the qunit tests.

This changes these to be sent as application/javascript, and while there adds some other missing headers to make these special characters be the same as other single '*.js' files. (Since, in production, these single js files are not sent/referenced, this fix would have no affect in production, but does fix the tests. Or actually, fixes tests, leaving a number of other IE tests broken in current dev branch, which I'll file an issue about in a while).
