### PR TITLE
Add a Do Not Track policy

### DIFF
--- a/lib/static/views.js
+++ b/lib/static/views.js
@@ -302,6 +302,13 @@ exports.setup = function(app) {
     res.send(robots);
   });
 
+  var dntPolicy = fs.readFileSync(path.join(__dirname, "..", "..", "resources", "dnt-policy.txt")).toString();
+  app.get("/.well-known/dnt-policy.txt", function(req, res) {
+    cacheAllTheThings(res);
+    res.setHeader('Content-Type', 'text/plain; charset=utf8');
+    res.send(dntPolicy);
+  });
+
   function pickLocale(supported, lang) {
     var templateLocale = 'en',
         locale = i18n.localeFrom(lang);

--- a/resources/dnt-policy.txt
+++ b/resources/dnt-policy.txt
@@ -1,0 +1,15 @@
+PRELIMINARY DNT POLICY
+
+This domain interprets DNT as a request for an opt out of collection and
+retention of visitors' reading habits, which we will respect, subject to
+reasonable exceptions that respect user privacy. 
+
+This is a temporary document.  A full DNT Policy is being drafted at
+https://eff.org/dnt-policy .  When that document is finished, this domain may
+decide to adopt it.
+
+You can agree to this same policy by posting it at
+https://subdomain.example.com/.well-known/dnt-policy.txt, where "subdomain" is
+any domain to which the policy applies.  Commonly it will be posted on third
+party domains.  HTTPS is required.
+


### PR DESCRIPTION
This will prevent Persona from being blocked by privacy-protecting
add-ons such as the EFF's Privacy Badger.

https://www.eff.org/privacybadger#how_to_comply_with_dnt

The temporary policy is copied verbatim from https://www.eff.org/files/dnt-policy-preliminary.txt

https://github.com/EFForg/privacybadgerfirefox/issues/98
