### PR TITLE
Drop experimental prefix from email hint option

### DIFF
--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -111,13 +111,11 @@ BrowserID.Modules.ValidateRpParams = (function() {
             "experimental_allowUnverified");
       }
 
-      // emailHint allows a site to provide a hint to the persona dialog
+      // email allows a site to provide a hint to the persona dialog
       // of the desired email to verify.  It allows a site who knows an
       // email but must verify it to offer a streamlined user experience
-      if (paramsFromRP.experimental_emailHint) {
-        params.emailHint = validateEmail(
-            paramsFromRP.experimental_emailHint,
-            "experimental_emailHint");
+      if (paramsFromRP.email) {
+        params.emailHint = validateEmail(paramsFromRP.email, "email");
       }
 
       // additional features available only to internal/native consumers

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -353,6 +353,7 @@
       checkDeprecated(options, "requiredEmail");
       checkRenamed(options, "tosURL", "termsOfService");
       checkRenamed(options, "privacyURL", "privacyPolicy");
+      checkRenamed(options, "experimental_emailHint", "email");
 
       if (options.termsOfService && !options.privacyPolicy) {
         warn("termsOfService ignored unless privacyPolicy also defined");
@@ -536,6 +537,7 @@
         opts.siteLogo = passedOptions.siteLogo || undefined;
         opts.backgroundColor = passedOptions.backgroundColor || undefined;
         opts.experimental_emailHint = passedOptions.experimental_emailHint || undefined;
+        opts.email = passedOptions.email || undefined;
         // api_called could have been set to getVerifiedEmail already
         api_called = api_called || "get";
         if (checkDeprecated(passedOptions, "silent")) {

--- a/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
@@ -488,14 +488,13 @@
   });
 
   asyncTest("valid email address for experimental_emailHint - allowed", function() {
-    testExpectValidationSuccess({experimental_emailHint: "testuser@testuser.com"},
+    testExpectValidationSuccess({email: "testuser@testuser.com"},
                          {emailHint: "testuser@testuser.com"});
   });
 
   asyncTest("invalid email address for experimental_emailHint - not allowed", function() {
-    testExpectValidationFailure({
-      experimental_emailHint: "testuser.testuser.com"
-    }, "invalid email for experimental_emailHint: testuser.testuser.com");
+    testExpectValidationFailure({email: "testuser.testuser.com"},
+      "invalid email for email: testuser.testuser.com");
   });
 
   asyncTest("non-object userAssertedClaims - not allowed", function() {


### PR DESCRIPTION
Related to #4134

There are some minor bugs with email hint, but it seem pretty clear that we want to make this happen, and it's 99% there right now.
