### PR TITLE
Prefer passing display opts to watch, not request

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -149,6 +149,9 @@
       ready: null
     };
 
+    // dialog appearance options (siteLogo, siteName, backgroundColor)
+    var displayOpts = {};
+
     var loggedInUser;
 
     var compatMode = undefined;
@@ -321,6 +324,10 @@
         throw new Error("loggedInUser is not a valid type");
       }
 
+      // Save dialog appearance options
+      if (options.siteName) displayOpts.siteName = options.siteName;
+      if (options.siteLogo) displayOpts.siteLogo = options.siteLogo;
+      if (options.backgroundColor) displayOpts.backgroundColor = options.backgroundColor;
 
       _open_hidden_iframe();
     }
@@ -363,6 +370,15 @@
       if (options.privacyPolicy && !options.termsOfService) {
         warn("privacyPolicy ignored unless termsOfService also defined");
       }
+
+      if (options.siteLogo) warn("Please pass siteLogo to .watch() instead of .request()");
+      if (options.siteName) warn("Please pass siteName to .watch() instead of .request()");
+      if (options.backgroundColor) warn("Please pass backgroundColor to .watch() instead of .request()");
+
+      // Allow request to override display opts passed to watch, for UI testing.
+      options.siteLogo = options.siteLogo || displayOpts.siteLogo;
+      options.siteName = options.siteName || displayOpts.siteName;
+      options.backgroundColor = options.backgroundColor || displayOpts.backgroundColor;
 
       options.rp_api = getRPAPI();
       var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request' || api_called === 'auth');
@@ -534,9 +550,6 @@
         opts.termsOfService = passedOptions.termsOfService || undefined;
         opts.privacyURL = passedOptions.privacyURL || undefined;
         opts.tosURL = passedOptions.tosURL || undefined;
-        opts.siteName = passedOptions.siteName || undefined;
-        opts.siteLogo = passedOptions.siteLogo || undefined;
-        opts.backgroundColor = passedOptions.backgroundColor || undefined;
         opts.experimental_emailHint = passedOptions.experimental_emailHint || undefined;
         // api_called could have been set to getVerifiedEmail already
         api_called = api_called || "get";
@@ -556,7 +569,10 @@
               callback = null;
             }
           },
-          onlogout: function() {}
+          onlogout: function() {},
+          siteName: passedOptions.siteName,
+          siteLogo: passedOptions.siteLogo,
+          backgroundColor: passedOptions.backgroundColor
         });
         opts.oncancel = function() {
           if (callback) {

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -375,10 +375,11 @@
       if (options.siteName) warn("Please pass siteName to .watch() instead of .request()");
       if (options.backgroundColor) warn("Please pass backgroundColor to .watch() instead of .request()");
 
-      // Allow request to override display opts passed to watch, for UI testing.
-      options.siteLogo = options.siteLogo || displayOpts.siteLogo;
-      options.siteName = options.siteName || displayOpts.siteName;
-      options.backgroundColor = options.backgroundColor || displayOpts.backgroundColor;
+      // Options passed to .watch() always win. 
+      // Necessary for backwards compatibility between Goldilocks and Observer
+      options.siteLogo = displayOpts.siteLogo || options.siteLogo;
+      options.siteName = displayOpts.siteName || options.siteName;
+      options.backgroundColor = displayOpts.backgroundColor || options.backgroundColor;
 
       options.rp_api = getRPAPI();
       var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request' || api_called === 'auth');


### PR DESCRIPTION
This patch is backwards compatible.

Console warnings are issued when display options (siteName, siteLogo,
backgroundColor) are passed to .request().

Rationale:

In the future, we hope that browsers will have native support for the BrowserID
protocol. It would be nice if those browsers could display properly themed "sign
into this site" buttons in the native browser UI.

If display options are passed to .request(), they're not known until the user
clicks "sign in" on the site itself. On the other hand, if they're passed to
.watch(), they're known by the browser as soon as the site loads, and can be
used without requiring direct user interaction with the page.

Related to #4134
