### PR TITLE
Stateless (Goldilocks) API ignores ToS / PP

### DIFF
--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -360,9 +360,7 @@
 
       if (options.rp_api === "stateless") {
         if (options.termsOfService || options.privacyPolicy) {
-          warn("stateless API does not support termsOfService or privacyPolicy, ignoring");
-          delete options.termsOfService;
-          delete options.privacyPolicy;
+          warn("Deprecation notice: termsOfService and privacyPolicy options are deprecated in the stateless (\"Goldilocks\") Persona API, and will eventually be removed. More info: https://github.com/mozilla/persona/issues/4134#issuecomment-44859342");
         }
       }
 

--- a/resources/static/include_js/_include.js
+++ b/resources/static/include_js/_include.js
@@ -356,6 +356,16 @@
       checkRenamed(options, "tosURL", "termsOfService");
       checkRenamed(options, "privacyURL", "privacyPolicy");
 
+      options.rp_api = getRPAPI();
+
+      if (options.rp_api === "stateless") {
+        if (options.termsOfService || options.privacyPolicy) {
+          warn("stateless API does not support termsOfService or privacyPolicy, ignoring");
+          delete options.termsOfService;
+          delete options.privacyPolicy;
+        }
+      }
+
       if (options.termsOfService && !options.privacyPolicy) {
         warn("termsOfService ignored unless privacyPolicy also defined");
       }
@@ -364,7 +374,6 @@
         warn("privacyPolicy ignored unless termsOfService also defined");
       }
 
-      options.rp_api = getRPAPI();
       var couldDoRedirectIfNeeded = (!needsPopupFix || api_called === 'request' || api_called === 'auth');
 
       // reset the api_called in case the site implementor changes which api


### PR DESCRIPTION
Easy to revert if we need to, but let's start by keeping the Goldilocks surface area as absolutely minimal as possible. More discussion in the issue below:

Related to #4134
