### PR TITLE
updates for awsbox changes

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -22,6 +22,7 @@
   "packages": [
     "mysql-server",
     "subversion",
+    "gmp-devel",
     "emacs-nox"
   ]
 }

--- a/.awsbox.json
+++ b/.awsbox.json
@@ -20,6 +20,8 @@
     "postcreate": "node scripts/awsbox_local/post_create.js"
   },
   "packages": [
-    "mysql-server"
+    "mysql-server",
+    "subversion",
+    "emacs-nox"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "start": "node ./scripts/run_locally.js"
   },
   "engines": {
-    "node": ">= 0.10.26"
+    "node": ">= 0.10.25"
   }
 }


### PR DESCRIPTION
1. add missing requirements for subversion, gmp-devel (and emacs) to .awsbox.json to work with new awsbox
2. until we get new awsbox ami images built, this needs to be >= 0.10.25
