### PR TITLE
Allow SVG siteLogos to be specified as data: URIs

### DIFF
--- a/resources/static/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/dialog/js/modules/validate_rp_params.js
@@ -252,7 +252,7 @@ BrowserID.Modules.ValidateRpParams = (function() {
     var dataMatches = null; // is this a valid data URI?
     var outputLogoUri;
     // Ideally we'd be loading this from a canonical constants library.
-    var imageMimeTypes = ['png', 'gif', 'jpg', 'jpeg', 'svg'];
+    var imageMimeTypes = ['png', 'gif', 'jpg', 'jpeg', 'svg+xml'];
     // This regex converts valid input of the form:
     //   'data:image/png;base64,iV...'
     // into an array that looks like:

--- a/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
+++ b/resources/static/test/cases/dialog/js/modules/validate_rp_params.js
@@ -245,6 +245,17 @@
     testExpectValidationFailure({siteLogo: URL});
   });
 
+  asyncTest("get with data:image/svg+xml;... siteLogo - allowed", function() {
+    testExpectValidationSuccess({
+        siteLogo: "data:image/svg+xml;base64,FAKEDATA"
+      },
+      {
+        siteLogo: "data:image/svg+xml;base64,FAKEDATA"
+      }
+    );
+  });
+
+
   asyncTest("get with data:image/<whitelist>;... siteLogo - allowed", function() {
     testExpectValidationSuccess({
         siteLogo: "data:image/png;base64,FAKEDATA"
@@ -253,6 +264,11 @@
         siteLogo: "data:image/png;base64,FAKEDATA"
       }
     );
+  });
+
+  asyncTest("get with data:image/svg;... siteLogo - not allowed", function() {
+    var URL = "data:image/svg;base64,FAKEDATA";
+    testExpectValidationFailure({siteLogo: URL});
   });
 
   asyncTest("get with data:<not image>... siteLogo - not allowed", function() {


### PR DESCRIPTION
The only legitimate MIME type for SVGs is "image/svg+xml", but our whitelist
contained "image/svg" instead.

As a result, data-URI encoded SVGs were not allowed as the siteLogo.
