### PR TITLE
Updated FreeBSD setup notes.

### DIFF
--- a/docs/SETUP_FREEBSD.md
+++ b/docs/SETUP_FREEBSD.md
@@ -8,7 +8,16 @@ Run the following to install necessary dependencies:
     make -C math/gmp install clean
     make -C www/npm install clean
     make -C devel/git install clean
+    make -C lang/gcc install clean
 
-or  with pkgng
+or with pkgng:
 
-    pkg add  www/node math/gmp www/npm devel/git
+    pkg install www/node math/gmp www/npm devel/git lang/gcc
+
+GCC will install g++ at /usr/local/bin/g++XX, where XX represents the version.
+Somewhere in the system's PATH, add a symlink named "g++" pointing to the
+installed version.
+
+For example (assuming GCC 4.9)
+
+    ln -s /usr/local/bin/g++49 /usr/local/bin/g++


### PR DESCRIPTION
- FreeBSD 10 does not include GCC in the base system
- 'pkg add' assumes the package is available locally

Solves issue #4186.
