### PR TITLE
Add building status to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
+[![Build Status](https://travis-ci.org/mozilla/persona.svg?branch=future)](https://travis-ci.org/mozilla/persona)
+
 This repository contains the core [Mozilla Persona][] services.
 Persona is a login system based on the [BrowserID protocol][].
 


### PR DESCRIPTION
Currently the README file is not showing any information about the building status, although i may seen not important i think it's good to keep track on what's going on with the repo, so i added the building status for the "future" branch, but could be changed to other branch if needed
