### PR TITLE
fixed issue #4224

### DIFF
--- a/resources/static/dialog/js/modules/authenticate.js
+++ b/resources/static/dialog/js/modules/authenticate.js
@@ -383,6 +383,17 @@ BrowserID.Modules.Authenticate = (function() {
       }
 
       self.bind(EMAIL_SELECTOR, "keyup", emailChange);
+
+      // In case of autofill the continue button was disabled
+      // To make sure that email field is not empty we have to
+      // use setInterval function.
+      // See issue #4224
+      window.setInterval(function(){
+        var emailFieldValue = dom.getInner(EMAIL_SELECTOR);
+        if(emailFieldValue != '') {
+          dom.removeAttr(CONTINUE_BUTTON_SELECTOR, DISABLED_ATTRIBUTE); 
+        }
+      }, 200);
       // Adding the change event causes the email to be checked whenever an
       // element blurs but it has been updated via autofill.  See issue #406
       self.bind(EMAIL_SELECTOR, "change", emailChange);


### PR DESCRIPTION
continue button should be enabled even in case
of autofill the email field.

I do not see any other (and simple) way than use **setInterval()** function. I searched for some libraries which can help us to avoid the issue but I noticed that all of them are using **setInterval()** function internally. 
