### PR TITLE
Change Trovebox -> Octave Online

### DIFF
--- a/resources/views/about.ejs
+++ b/resources/views/about.ejs
@@ -9,12 +9,12 @@
             <article class="blurb">
                 <div class="info first">
                     <h1><%- gettext('Persona replaces multiple passwords') %></h1>
-                    <p><%- format(gettext('Sites such as <a %(webmakerLink)s>%(webmakerName)s</a>, <a %(openphotoLink)s>%(openphotoName)s</a> and <a %(voostLink)s>%(voostName)s</a> use Persona instead of usernames to sign you in.'),
+                    <p><%- format(gettext('Sites such as <a %(webmakerLink)s>%(webmakerName)s</a>, <a %(octaveonlineLink)s>%(octaveonlineName)s</a> and <a %(voostLink)s>%(voostName)s</a> use Persona instead of usernames to sign you in.'),
                                   {
                                     webmakerLink: 'href="https://webmaker.org/" target="_blank"',
                                     webmakerName: 'Mozilla Webmaker',
-                                    openphotoLink: 'href="https://current.trovebox.com/" target="_blank"',
-                                    openphotoName: 'Trovebox',
+                                    octaveonlineLink: 'href="http://octave-online.net/" target="_blank"',
+                                    octaveonlineName: 'Octave Online',
                                     voostLink: 'href="https://www.voo.st/" target="_blank"',
                                     voostName: 'Voost'
                                   })


### PR DESCRIPTION
As of March 31, 2015, Trovebox has [shut down](https://en.wikipedia.org/wiki/Trovebox).  I suggest we change the link to [Octave Online](http://octave-online.net).  I am the author of Octave Online, and we have over 3,000 users who have signed in with Mozilla Persona.
