### PR TITLE
Update decommission notice to make it more final

### DIFF
--- a/resources/static/common/css/style.css
+++ b/resources/static/common/css/style.css
@@ -597,8 +597,8 @@ footer .help {
 
 .notice {
   text-align: center;
-  background: #8A241B;
-  border: 1px solid #710B02;
+  background: #D62626;
+  border: 1px solid #8A241B;
   padding: 5px;
   padding-left: 15px;
   padding-right: 15px;

--- a/resources/views/dialog_layout.ejs
+++ b/resources/views/dialog_layout.ejs
@@ -66,7 +66,7 @@
 
       <footer>
         <div class="notice">
-          <p>The persona.org service is shutting down.  This service will be unavailable after November 30th, 2016.&nbsp;&nbsp;<a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">More Info...</a></p>
+          <p>As of November 30th 2016, the persona.org service is no longer supported.  It will be shut down in December 2016.&nbsp;&nbsp;<a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">More Info...</a></p>
         </div>
       </footer>
 

--- a/resources/views/layout.ejs
+++ b/resources/views/layout.ejs
@@ -43,7 +43,7 @@
 <% } %>
 
     <div class="notice">
-        <p>The persona.org service is shutting down.  This service will be unavailable after November 30th, 2016.&nbsp;&nbsp;<a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">More Info...</a></p>
+          <p>As of November 30th 2016, the persona.org service is no longer supported.  It will be shut down in December 2016.&nbsp;&nbsp;<a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">More Info...</a></p>
     </div>
 
     <div id="wait" class="message_screen"><div class="contents"></div></div>


### PR DESCRIPTION
This changes the shutdown notice to indicate that the service is definitely going away in December, rather than "after November". It also makes it redder so it stands out more:

![screen shot 2016-11-29 at 09 47 58](https://cloud.githubusercontent.com/assets/34695/20689388/489295be-b619-11e6-87fd-0d13e1894554.png)

@shane-tomlinson @relud r?  This will be better than having the site continue to say "after November 30th" once it is in fact after November 30th.